### PR TITLE
Add Bitcast kernel registration

### DIFF
--- a/tensorflow/c/kernels/bitcast_op.cc
+++ b/tensorflow/c/kernels/bitcast_op.cc
@@ -158,6 +158,17 @@ void RegisterBitcastOpKernel() {
   }
 #endif
 
+#if TENSORFLOW_USE_DIRECTML
+  {
+    auto* builder = TF_NewKernelBuilder("Bitcast", tensorflow::DEVICE_DML,
+                                        &BitcastOp_Create, &BitcastOp_Compute,
+                                        &BitcastOp_Delete);
+    TF_RegisterKernelBuilder("BitcastOp", builder, status);
+    CHECK_EQ(TF_OK, TF_GetCode(status))
+        << "Error while registering DML bitcast kernel";
+  }
+#endif
+
   TF_DeleteStatus(status);
 }
 

--- a/tensorflow/python/kernel_tests/bitcast_op_test.py
+++ b/tensorflow/python/kernel_tests/bitcast_op_test.py
@@ -55,9 +55,6 @@ class BitcastTest(test.TestCase):
     shape = [3, 4]
     self._testBitcast(x, x.dtype, shape)
 
-  # TODO: Enable when DML supports int64
-  # TFDML #24755571
-  @test_util.skip_dml
   def testSameSize(self):
     x = np.random.rand(3, 4)
     shape = [3, 4]
@@ -88,9 +85,6 @@ class BitcastTest(test.TestCase):
     datatype = dtypes.quint16
     self._testBitcast(x, datatype, shape)
 
-  # TODO: Enable when DML supports uint64
-  # TFDML #24755571
-  @test_util.skip_dml
   def testUnsignedType(self):
     shape = [3, 4]
     x = np.zeros(shape, np.int64)


### PR DESCRIPTION
Bitcast is a low-level C kernel that simply reinterprets the tensor's data to a different type and shape.