### PR TITLE
Unblock tests by setting ALLOW_GROWTH env var

### DIFF
--- a/third_party/dml/ci/test/tests/tfdml_test_runner.py
+++ b/third_party/dml/ci/test/tests/tfdml_test_runner.py
@@ -79,6 +79,8 @@ def _run_test(
   else:
     raise Exception("Unsupported test framework.")
 
+  env_copy["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"
+
   try:
     with tempfile.TemporaryFile(mode="w+", encoding="iso-8859-1") as stdout, \
          tempfile.TemporaryFile(mode="w+", encoding="iso-8859-1") as stderr:


### PR DESCRIPTION
As tests run in parallel, we need to set this environment variable to prevent multiple test processes from each trying to consume all available GPU memory.