### PR TITLE
Improve OOM error handling

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_command_queue.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_queue.cc
@@ -39,13 +39,6 @@ void DmlCommandQueue::ExecuteCommandLists(
   DML_CHECK_SUCCEEDED(queue_->Signal(fence_.Get(), last_fence_value_));
 }
 
-void DmlCommandQueue::Wait(ID3D12Fence* fence, uint64_t value) {
-  DML_CHECK_SUCCEEDED(queue_->Wait(fence, value));
-
-  ++last_fence_value_;
-  DML_CHECK_SUCCEEDED(queue_->Signal(fence_.Get(), last_fence_value_));
-}
-
 DmlGpuEvent DmlCommandQueue::GetCurrentCompletionEvent() {
   return DmlGpuEvent{last_fence_value_, fence_};
 }

--- a/tensorflow/core/common_runtime/dml/dml_command_queue.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_queue.cc
@@ -26,10 +26,6 @@ DmlCommandQueue::DmlCommandQueue(ID3D12CommandQueue* existing_queue)
       device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence_)));
 }
 
-void DmlCommandQueue::ExecuteCommandList(ID3D12CommandList* command_list) {
-  ExecuteCommandLists(absl::Span<ID3D12CommandList*>(&command_list, 1));
-}
-
 void DmlCommandQueue::ExecuteCommandLists(
     absl::Span<ID3D12CommandList*> command_lists) {
   queue_->ExecuteCommandLists(static_cast<uint32_t>(command_lists.size()),

--- a/tensorflow/core/common_runtime/dml/dml_command_queue.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_queue.h
@@ -36,10 +36,6 @@ class DmlCommandQueue {
   void ExecuteCommandList(ID3D12CommandList* command_list);
   void ExecuteCommandLists(absl::Span<ID3D12CommandList*> command_lists);
 
-  // Queues a wait to block the GPU until the specified fence is signaled to a
-  // given value.
-  void Wait(ID3D12Fence* fence, uint64_t value);
-
   // Returns an event that will become signaled when everything submitted to the
   // queue thus far has completed execution on the GPU.
   DmlGpuEvent GetCurrentCompletionEvent();

--- a/tensorflow/core/common_runtime/dml/dml_command_queue.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_queue.h
@@ -33,7 +33,6 @@ class DmlCommandQueue {
   Microsoft::WRL::ComPtr<ID3D12Fence> GetFence() const { return fence_; }
   uint64_t GetLastFenceValue() const { return last_fence_value_; }
 
-  void ExecuteCommandList(ID3D12CommandList* command_list);
   void ExecuteCommandLists(absl::Span<ID3D12CommandList*> command_lists);
 
   // Returns an event that will become signaled when everything submitted to the

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -304,23 +304,10 @@ Status DmlCommandRecorder::ExecuteCommandList(
   return Status::OK();
 }
 
-StatusOr<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>>
-DmlCommandRecorder::GetCommandList() {
-  // Assume operations are added by the caller after this returns
-  TF_RETURN_IF_ERROR(OnCommandRecorded());
-  return current_command_list_;
-}
-
 Status DmlCommandRecorder::ResourceBarrier(
     absl::Span<const D3D12_RESOURCE_BARRIER> barriers) {
   current_command_list_->ResourceBarrier(static_cast<uint32_t>(barriers.size()),
                                          barriers.data());
-  return OnCommandRecorded();
-}
-
-Status DmlCommandRecorder::AddUAVBarrier() {
-  auto barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
-  current_command_list_->ResourceBarrier(1, &barrier);
   return OnCommandRecorded();
 }
 
@@ -351,6 +338,8 @@ Status DmlCommandRecorder::CloseAndExecute() {
   if (dml_util::HrIsOutOfMemory(hr)) {
     return errors::ResourceExhausted("OOM when closing the command list");
   }
+
+  printf("HRESULT: %X\n", hr);
 
   DML_CHECK_SUCCEEDED(hr);
 

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -339,8 +339,6 @@ Status DmlCommandRecorder::CloseAndExecute() {
     return errors::ResourceExhausted("OOM when closing the command list");
   }
 
-  printf("HRESULT: %X\n", hr);
-
   DML_CHECK_SUCCEEDED(hr);
 
   if (operations_recorded_in_current_command_list_ != 0) {

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -278,6 +278,8 @@ void DmlCommandRecorder::ExecuteCommandList(
     return;
   }
 
+  DML_CHECK_SUCCEEDED(hr);
+
   if (operations_recorded_in_current_command_list_ != 0) {
     pending_command_lists_.push_back(current_command_list_.Get());
     pending_command_lists_cacheable_.push_back(true);

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.h
@@ -33,35 +33,38 @@ class DmlCommandRecorder {
                      std::shared_ptr<DmlCommandQueue> command_queue,
                      DmlAllocator* allocator);
 
-  Status InitializeOperator(IDMLCompiledOperator* op,
+  void InitializeOperator(IDMLCompiledOperator* op,
                             const DML_BINDING_DESC& persistent_resource_binding,
                             const DML_BINDING_DESC& input_array_binding);
 
-  Status ExecuteOperator(IDMLCompiledOperator* op,
-                         const DML_BINDING_DESC& persistent_resource_binding,
-                         absl::Span<const DML_BINDING_DESC> input_bindings,
-                         absl::Span<const DML_BINDING_DESC> output_bindings);
+  void ExecuteOperator(IDMLCompiledOperator* op,
+                       const DML_BINDING_DESC& persistent_resource_binding,
+                       absl::Span<const DML_BINDING_DESC> input_bindings,
+                       absl::Span<const DML_BINDING_DESC> output_bindings);
 
-  Status CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
-                          ID3D12Resource* src_buffer, uint64_t src_offset,
-                          uint64_t byte_count);
+  void CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
+                        ID3D12Resource* src_buffer, uint64_t src_offset,
+                        uint64_t byte_count);
 
-  Status FillBufferWithPattern(
+  void FillBufferWithPattern(
       ID3D12Resource* dst, uint64_t dst_offset, uint64_t dst_size_in_bytes,
       absl::Span<const uint8_t>
           value /* Data type agnostic value, treated as raw bits */);
 
-  Status ExecuteCommandList(ID3D12GraphicsCommandList* command_list,
-                            _Outptr_ ID3D12Fence** fence,
-                            _Out_ uint64_t* completion_value);
+  void ExecuteCommandList(ID3D12GraphicsCommandList* command_list,
+                          _Outptr_ ID3D12Fence** fence,
+                          _Out_ uint64_t* completion_value);
 
-  Status ResourceBarrier(absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
+  void ResourceBarrier(absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
 
-  Status CloseAndExecute();
+  void CloseAndExecute();
 
   // If false, there are no pending commands to be submitted which indicates
   // that CloseAndExecute() would be a no-op.
   bool HasUnflushedWork() const;
+
+  Status GetStatus() const { return status_; }
+  void ResetStatus() { status_ = Status::OK(); }
 
  private:
   std::shared_ptr<DmlCommandQueue> queue_;
@@ -96,13 +99,18 @@ class DmlCommandRecorder {
   std::deque<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>>
       cached_command_lists_;
 
+  // Status of the first error encountered when closing the command list.
+  // Operations that flush the command list or readback from the GPU should make
+  // sure that this status doesn't contain an error before doing so.
+  Status status_ = Status::OK();
+
   void SetDescriptorHeap(ID3D12DescriptorHeap* descriptor_heap);
   void Open();
 
   // Increments operations_recorded_in_current_command_list_. If the size of the
   // current command list exceeds a certain value (based on heuristic), the
   // command list is flushed.
-  Status OnCommandRecorded();
+  void OnCommandRecorded();
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.h
@@ -55,10 +55,7 @@ class DmlCommandRecorder {
                             _Outptr_ ID3D12Fence** fence,
                             _Out_ uint64_t* completion_value);
 
-  StatusOr<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>> GetCommandList();
-
   Status ResourceBarrier(absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
-  Status AddUAVBarrier();
 
   Status CloseAndExecute();
 

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.h
@@ -52,10 +52,6 @@ class DmlCommandRecorder {
       absl::Span<const uint8_t>
           value /* Data type agnostic value, treated as raw bits */);
 
-  void ExecuteCommandList(ID3D12GraphicsCommandList* command_list,
-                          _Outptr_ ID3D12Fence** fence,
-                          _Out_ uint64_t* completion_value);
-
   void ResourceBarrier(absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
 
   void CloseAndExecute();
@@ -87,14 +83,6 @@ class DmlCommandRecorder {
   // have been recorded yet.
   Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> current_command_list_;
   uint32_t operations_recorded_in_current_command_list_ = 0;
-
-  // Command lists which have been batched up for execution.  The values in
-  // pending_command_lists_cacheable_ indicate whether they can be moved into
-  // this class's cache after execution, versus if they belong to the caller and
-  // were passed to ExecuteCommandList.
-  std::vector<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>>
-      pending_command_lists_;
-  std::vector<bool> pending_command_lists_cacheable_;
 
   // A pool of cached command lists which may be re-used.
   std::deque<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>>

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "dml_command_queue.h"
 #include "dml_common.h"
 #include "dml_descriptor_pool.h"
+#include "dml_status.h"
 #include "tensorflow/core/lib/core/errors.h"
 
 namespace tensorflow {
@@ -41,25 +42,25 @@ class DmlCommandRecorder {
                          absl::Span<const DML_BINDING_DESC> input_bindings,
                          absl::Span<const DML_BINDING_DESC> output_bindings);
 
-  void CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
-                        ID3D12Resource* src_buffer, uint64_t src_offset,
-                        uint64_t byte_count);
+  Status CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
+                          ID3D12Resource* src_buffer, uint64_t src_offset,
+                          uint64_t byte_count);
 
-  void FillBufferWithPattern(
+  Status FillBufferWithPattern(
       ID3D12Resource* dst, uint64_t dst_offset, uint64_t dst_size_in_bytes,
       absl::Span<const uint8_t>
           value /* Data type agnostic value, treated as raw bits */);
 
-  void ExecuteCommandList(ID3D12GraphicsCommandList* command_list,
-                          _Outptr_ ID3D12Fence** fence,
-                          _Out_ uint64_t* completion_value);
+  Status ExecuteCommandList(ID3D12GraphicsCommandList* command_list,
+                            _Outptr_ ID3D12Fence** fence,
+                            _Out_ uint64_t* completion_value);
 
-  Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> GetCommandList();
+  StatusOr<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>> GetCommandList();
 
-  void ResourceBarrier(absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
-  void AddUAVBarrier();
+  Status ResourceBarrier(absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
+  Status AddUAVBarrier();
 
-  void CloseAndExecute();
+  Status CloseAndExecute();
 
   // If false, there are no pending commands to be submitted which indicates
   // that CloseAndExecute() would be a no-op.
@@ -104,7 +105,7 @@ class DmlCommandRecorder {
   // Increments operations_recorded_in_current_command_list_. If the size of the
   // current command list exceeds a certain value (based on heuristic), the
   // command list is flushed.
-  void OnCommandRecorded();
+  Status OnCommandRecorded();
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_device.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device.cc
@@ -55,7 +55,10 @@ Status DmlDevice::Sync() {
   VLOG(2) << "DirectML device: performing GPU sync.";
 
   auto start_time = std::chrono::high_resolution_clock::now();
-  state_->execution_context->Flush().WaitForSignal();
+
+  auto status_or_event = state_->execution_context->Flush();
+  TF_RETURN_IF_ERROR(status_or_event.status());
+  status_or_event.ConsumeValueOrDie().WaitForSignal();
   auto end_time = std::chrono::high_resolution_clock::now();
 
   std::chrono::duration<double> wait_seconds = end_time - start_time;

--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -134,6 +134,7 @@ void DMLDeviceContext::CopyDeviceTensorToCPU(const Tensor* device_tensor,
 
   if (!status_or_event.ok()) {
     done(status_or_event.status());
+    return;
   }
 
   // Keep a ref on the source tensor to keep it alive until we're done with it

--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -83,16 +83,16 @@ void DMLDeviceContext::CopyTensorInSameDevice(const Tensor* input_tensor,
       D3D12_RESOURCE_STATE_UNORDERED_ACCESS;  // GPU resources are always kept
                                               // in UAV state
 
-  auto status_or_event = execution_context_->CopyBufferRegion(
-      dst_data, dst_offset, dst_state, src_data, src_offset, src_state,
-      total_bytes);
+  (void)execution_context_->CopyBufferRegion(dst_data, dst_offset, dst_state,
+                                             src_data, src_offset, src_state,
+                                             total_bytes);
 
   // Immediately signal completion even though we haven't actually kicked off
   // the GPU, or waited for it to complete. This is because from the framework's
   // point of view, there's no way for it to observe this state (except when
   // copying a tensor back to CPU, at which point we correctly flush and queue a
   // callback)
-  done(status_or_event.status());
+  done(Status::OK());
 }
 
 void DMLDeviceContext::CopyDeviceTensorToCPU(const Tensor* device_tensor,

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -56,7 +56,7 @@ StatusOr<DmlGpuEvent> DmlExecutionContextImpl::CopyBufferRegion(
   }
 
   if (!barriers.empty()) {
-    dml_recorder_.ResourceBarrier(barriers);
+    TF_RETURN_IF_ERROR(dml_recorder_.ResourceBarrier(barriers));
   }
 
   TF_RETURN_IF_ERROR(dml_recorder_.CopyBufferRegion(
@@ -68,7 +68,7 @@ StatusOr<DmlGpuEvent> DmlExecutionContextImpl::CopyBufferRegion(
       std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
     }
 
-    dml_recorder_.ResourceBarrier(barriers);
+    TF_RETURN_IF_ERROR(dml_recorder_.ResourceBarrier(barriers));
   }
 
   return GetCurrentCompletionEvent();
@@ -121,20 +121,12 @@ StatusOr<DmlGpuEvent> DmlExecutionContextImpl::ExecuteOperator(
   return GetCurrentCompletionEvent();
 }
 
-DmlGpuEvent DmlExecutionContextImpl::AddUAVBarrier() {
-  assert(!closed_);
-  SetCommandRecorder(&dml_recorder_);
-
-  dml_recorder_.AddUAVBarrier();
-  return GetCurrentCompletionEvent();
-}
-
-DmlGpuEvent DmlExecutionContextImpl::ResourceBarrier(
+StatusOr<DmlGpuEvent> DmlExecutionContextImpl::ResourceBarrier(
     absl::Span<const D3D12_RESOURCE_BARRIER> barriers) {
   assert(!closed_);
   SetCommandRecorder(&dml_recorder_);
 
-  dml_recorder_.ResourceBarrier(barriers);
+  TF_RETURN_IF_ERROR(dml_recorder_.ResourceBarrier(barriers));
   return GetCurrentCompletionEvent();
 }
 

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -59,16 +59,6 @@ DmlGpuEvent DmlExecutionContextImpl::FillBufferWithPattern(
   return GetCurrentCompletionEvent();
 }
 
-DmlGpuEvent DmlExecutionContextImpl::ExecuteCommandList(
-    ID3D12GraphicsCommandList* command_list, _Outptr_ ID3D12Fence** fence,
-    _Out_ uint64_t* completion_value) {
-  assert(!closed_);
-
-  SetCommandRecorder(&dml_recorder_);
-  dml_recorder_.ExecuteCommandList(command_list, fence, completion_value);
-  return GetCurrentCompletionEvent();
-}
-
 DmlGpuEvent DmlExecutionContextImpl::InitializeOperator(
     IDMLCompiledOperator* op,
     const DML_BINDING_DESC& persistent_resource_binding,

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -130,13 +130,6 @@ StatusOr<DmlGpuEvent> DmlExecutionContextImpl::ResourceBarrier(
   return GetCurrentCompletionEvent();
 }
 
-Status DmlExecutionContextImpl::Wait(ID3D12Fence* fence, uint64_t value) {
-  assert(!closed_);
-  TF_RETURN_IF_ERROR(Flush().status());
-  queue_->Wait(fence, value);
-  return Status::OK();
-}
-
 Status DmlExecutionContextImpl::SetCommandRecorder(
     DmlCommandRecorder* new_recorder) {
   assert(!closed_);

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -66,10 +66,6 @@ class DmlExecutionContextImpl {
       absl::Span<const DML_BINDING_DESC> input_bindings,
       absl::Span<const DML_BINDING_DESC> output_bindings);
 
-  DmlGpuEvent ExecuteCommandList(ID3D12GraphicsCommandList* command_list,
-                                 _Outptr_ ID3D12Fence** fence,
-                                 _Out_ uint64_t* completion_value);
-
   DmlGpuEvent ResourceBarrier(
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
 
@@ -147,13 +143,6 @@ class DmlExecutionContext {
     std::unique_lock<std::mutex> lock(mutex_);
     return impl_->ExecuteOperator(op, persistent_resource_binding,
                                   input_bindings, output_bindings);
-  }
-
-  DmlGpuEvent ExecuteCommandList(ID3D12GraphicsCommandList* command_list,
-                                 _Outptr_ ID3D12Fence** fence,
-                                 _Out_ uint64_t* completion_value) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    return impl_->ExecuteCommandList(command_list, fence, completion_value);
   }
 
   DmlGpuEvent ResourceBarrier(

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -75,9 +75,6 @@ class DmlExecutionContextImpl {
   StatusOr<DmlGpuEvent> ResourceBarrier(
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
 
-  // See ID3D12CommandQueue::Wait
-  Status Wait(ID3D12Fence* fence, uint64_t value);
-
   // Forces all queued work to begin executing on the GPU. This method returns
   // immediately and does not wait for the submitted work to complete execution
   // on the GPU.
@@ -168,11 +165,6 @@ class DmlExecutionContext {
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers) {
     std::unique_lock<std::mutex> lock(mutex_);
     return impl_->ResourceBarrier(barriers);
-  }
-
-  void Wait(ID3D12Fence* fence, uint64_t value) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    impl_->Wait(fence, value);
   }
 
   StatusOr<DmlGpuEvent> Flush() {

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -72,8 +72,7 @@ class DmlExecutionContextImpl {
                                  _Outptr_ ID3D12Fence** fence,
                                  _Out_ uint64_t* completion_value);
 
-  DmlGpuEvent AddUAVBarrier();
-  DmlGpuEvent ResourceBarrier(
+  StatusOr<DmlGpuEvent> ResourceBarrier(
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
 
   // See ID3D12CommandQueue::Wait
@@ -165,12 +164,7 @@ class DmlExecutionContext {
     return impl_->ExecuteCommandList(command_list, fence, completion_value);
   }
 
-  DmlGpuEvent AddUAVBarrier() {
-    std::unique_lock<std::mutex> lock(mutex_);
-    return impl_->AddUAVBarrier();
-  }
-
-  DmlGpuEvent ResourceBarrier(
+  StatusOr<DmlGpuEvent> ResourceBarrier(
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers) {
     std::unique_lock<std::mutex> lock(mutex_);
     return impl_->ResourceBarrier(barriers);

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -44,25 +44,23 @@ class DmlExecutionContextImpl {
   // for execution. Transition barriers are automatically inserted to transition
   // the source and destination resources to COPY_SOURCE and COPY_DEST if
   // necessary.
-  StatusOr<DmlGpuEvent> CopyBufferRegion(ID3D12Resource* dst_buffer,
-                                         uint64_t dst_offset,
-                                         D3D12_RESOURCE_STATES dst_state,
-                                         ID3D12Resource* src_buffer,
-                                         uint64_t src_offset,
-                                         D3D12_RESOURCE_STATES src_state,
-                                         uint64_t byte_count);
+  DmlGpuEvent CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
+                               D3D12_RESOURCE_STATES dst_state,
+                               ID3D12Resource* src_buffer, uint64_t src_offset,
+                               D3D12_RESOURCE_STATES src_state,
+                               uint64_t byte_count);
 
-  StatusOr<DmlGpuEvent> FillBufferWithPattern(
+  DmlGpuEvent FillBufferWithPattern(
       ID3D12Resource* dst, uint64_t dst_offset, uint64_t dst_size_in_bytes,
       absl::Span<const uint8_t>
           value /* Data type agnostic value, treated as raw bits */);
 
-  StatusOr<DmlGpuEvent> InitializeOperator(
+  DmlGpuEvent InitializeOperator(
       IDMLCompiledOperator* op,
       const DML_BINDING_DESC& persistent_resource_binding,
       const DML_BINDING_DESC& input_array_binding);
 
-  StatusOr<DmlGpuEvent> ExecuteOperator(
+  DmlGpuEvent ExecuteOperator(
       IDMLCompiledOperator* op,
       const DML_BINDING_DESC& persistent_resource_binding,
       absl::Span<const DML_BINDING_DESC> input_bindings,
@@ -72,7 +70,7 @@ class DmlExecutionContextImpl {
                                  _Outptr_ ID3D12Fence** fence,
                                  _Out_ uint64_t* completion_value);
 
-  StatusOr<DmlGpuEvent> ResourceBarrier(
+  DmlGpuEvent ResourceBarrier(
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
 
   // Forces all queued work to begin executing on the GPU. This method returns
@@ -90,7 +88,7 @@ class DmlExecutionContextImpl {
  private:
   Microsoft::WRL::ComPtr<ID3D12Device> d3d_device_;
 
-  Status SetCommandRecorder(DmlCommandRecorder* new_recorder);
+  void SetCommandRecorder(DmlCommandRecorder* new_recorder);
 
   std::shared_ptr<DmlCommandQueue> queue_;
 
@@ -113,29 +111,26 @@ class DmlExecutionContext {
     impl_->Close();
   }
 
-  StatusOr<DmlGpuEvent> CopyBufferRegion(ID3D12Resource* dst_buffer,
-                                         uint64_t dst_offset,
-                                         D3D12_RESOURCE_STATES dst_state,
-                                         ID3D12Resource* src_buffer,
-                                         uint64_t src_offset,
-                                         D3D12_RESOURCE_STATES src_state,
-                                         uint64_t byte_count) {
+  DmlGpuEvent CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
+                               D3D12_RESOURCE_STATES dst_state,
+                               ID3D12Resource* src_buffer, uint64_t src_offset,
+                               D3D12_RESOURCE_STATES src_state,
+                               uint64_t byte_count) {
     std::unique_lock<std::mutex> lock(mutex_);
     return impl_->CopyBufferRegion(dst_buffer, dst_offset, dst_state,
                                    src_buffer, src_offset, src_state,
                                    byte_count);
   }
 
-  StatusOr<DmlGpuEvent> FillBufferWithPattern(ID3D12Resource* dst,
-                                              uint64_t dst_offset,
-                                              uint64_t dst_size_in_bytes,
-                                              absl::Span<const uint8_t> value) {
+  DmlGpuEvent FillBufferWithPattern(ID3D12Resource* dst, uint64_t dst_offset,
+                                    uint64_t dst_size_in_bytes,
+                                    absl::Span<const uint8_t> value) {
     std::unique_lock<std::mutex> lock(mutex_);
     return impl_->FillBufferWithPattern(dst, dst_offset, dst_size_in_bytes,
                                         value);
   }
 
-  StatusOr<DmlGpuEvent> InitializeOperator(
+  DmlGpuEvent InitializeOperator(
       IDMLCompiledOperator* op,
       const DML_BINDING_DESC& persistent_resource_binding,
       const DML_BINDING_DESC& input_array_binding) {
@@ -144,7 +139,7 @@ class DmlExecutionContext {
                                      input_array_binding);
   }
 
-  StatusOr<DmlGpuEvent> ExecuteOperator(
+  DmlGpuEvent ExecuteOperator(
       IDMLCompiledOperator* op,
       const DML_BINDING_DESC& persistent_resource_binding,
       absl::Span<const DML_BINDING_DESC> input_bindings,
@@ -161,7 +156,7 @@ class DmlExecutionContext {
     return impl_->ExecuteCommandList(command_list, fence, completion_value);
   }
 
-  StatusOr<DmlGpuEvent> ResourceBarrier(
+  DmlGpuEvent ResourceBarrier(
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers) {
     std::unique_lock<std::mutex> lock(mutex_);
     return impl_->ResourceBarrier(barriers);

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
@@ -225,11 +225,9 @@ DmlGpuEvent DmlKernelContext::GetCurrentCompletionEvent() const {
   return device_->GetExecutionContext()->GetCurrentCompletionEvent();
 }
 
-DmlGpuEvent DmlKernelContext::CopyBufferToBuffer(ID3D12Resource* dst,
-                                                 uint64_t dst_offset,
-                                                 ID3D12Resource* src,
-                                                 uint64_t src_offset,
-                                                 uint64 size_in_bytes) const {
+StatusOr<DmlGpuEvent> DmlKernelContext::CopyBufferToBuffer(
+    ID3D12Resource* dst, uint64_t dst_offset, ID3D12Resource* src,
+    uint64_t src_offset, uint64 size_in_bytes) const {
   return device_->GetExecutionContext()->CopyBufferRegion(
       dst, dst_offset, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, src, src_offset,
       D3D12_RESOURCE_STATE_UNORDERED_ACCESS, size_in_bytes);
@@ -242,14 +240,15 @@ StatusOr<DmlGpuEvent> DmlKernelContext::CopyHostToBuffer(
       dst, dst_offset, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, src);
 }
 
-DmlGpuEvent DmlKernelContext::ZeroBuffer(ID3D12Resource* dst, uint64_t offset,
-                                         uint64_t size_in_bytes) const {
+StatusOr<DmlGpuEvent> DmlKernelContext::ZeroBuffer(
+    ID3D12Resource* dst, uint64_t offset, uint64_t size_in_bytes) const {
   uint8_t pattern[] = {0};
   return device_->GetExecutionContext()->FillBufferWithPattern(
       dst, offset, size_in_bytes, pattern);
 }
 
-DmlGpuEvent DmlKernelContext::ZeroBuffer(const D3D12BufferRegion& dst) const {
+StatusOr<DmlGpuEvent> DmlKernelContext::ZeroBuffer(
+    const D3D12BufferRegion& dst) const {
   return ZeroBuffer(dst.Resource(), dst.Offset(), dst.SizeInBytes());
 }
 
@@ -260,7 +259,7 @@ DmlGpuEvent DmlKernelContext::InsertUavBarrier() const {
       absl::Span<D3D12_RESOURCE_BARRIER>(&barrier, 1));
 }
 
-DmlGpuEvent DmlKernelContext::FillBufferWithPattern(
+StatusOr<DmlGpuEvent> DmlKernelContext::FillBufferWithPattern(
     ID3D12Resource* dst, uint64_t offset, uint64_t size_in_bytes,
     absl::Span<const uint8_t> pattern) const {
   return device_->GetExecutionContext()->FillBufferWithPattern(

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
@@ -252,7 +252,7 @@ StatusOr<DmlGpuEvent> DmlKernelContext::ZeroBuffer(
   return ZeroBuffer(dst.Resource(), dst.Offset(), dst.SizeInBytes());
 }
 
-DmlGpuEvent DmlKernelContext::InsertUavBarrier() const {
+StatusOr<DmlGpuEvent> DmlKernelContext::InsertUavBarrier() const {
   D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
 
   return device_->GetExecutionContext()->ResourceBarrier(

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.h
@@ -53,7 +53,7 @@ class DmlKernelConstruction {
   // Initializes a given DML operator on the GPU. Note that this merely queues
   // the initialization; the returned event will enter the signaled state when
   // it completes.
-  Status InitializeOperator(
+  void InitializeOperator(
       IDMLCompiledOperator* op,
       _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding,
       absl::Span<const DML_BUFFER_BINDING> input_bindings);
@@ -138,18 +138,16 @@ class DmlKernelContext {
 
   // Executes a DML operator. Note that this merely queues the execution; the
   // returned event will enter the signaled state when it completes.
-  StatusOr<DmlGpuEvent> ExecuteOperator(
+  DmlGpuEvent ExecuteOperator(
       IDMLCompiledOperator* op,
       _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding,
       absl::Span<const absl::optional<DML_BUFFER_BINDING>> input_bindings,
       absl::Span<const absl::optional<DML_BUFFER_BINDING>> output_bindings);
 
   // Copies src to dst (dst needs to be at at least as big as src)
-  StatusOr<DmlGpuEvent> CopyBufferToBuffer(ID3D12Resource* dst,
-                                           uint64_t dst_offset,
-                                           ID3D12Resource* src,
-                                           uint64_t src_offset,
-                                           uint64 size_in_bytes) const;
+  DmlGpuEvent CopyBufferToBuffer(ID3D12Resource* dst, uint64_t dst_offset,
+                                 ID3D12Resource* src, uint64_t src_offset,
+                                 uint64 size_in_bytes) const;
 
   // Copies src (host memory) to dst (dst needs to be at least as big as src).
   StatusOr<DmlGpuEvent> CopyHostToBuffer(ID3D12Resource* dst,
@@ -157,15 +155,13 @@ class DmlKernelContext {
                                          absl::Span<const uint8_t> src) const;
 
   // Sets a region of the destination buffer to zero.
-  StatusOr<DmlGpuEvent> ZeroBuffer(ID3D12Resource* dst, uint64_t offset,
-                                   uint64_t size_in_bytes) const;
-  StatusOr<DmlGpuEvent> ZeroBuffer(const D3D12BufferRegion& dst) const;
+  DmlGpuEvent ZeroBuffer(ID3D12Resource* dst, uint64_t offset,
+                         uint64_t size_in_bytes) const;
+  DmlGpuEvent ZeroBuffer(const D3D12BufferRegion& dst) const;
 
   template <typename T>
-  StatusOr<DmlGpuEvent> FillBufferWithValue(ID3D12Resource* dst,
-                                            uint64_t offset,
-                                            uint64_t size_in_bytes,
-                                            T value) const {
+  DmlGpuEvent FillBufferWithValue(ID3D12Resource* dst, uint64_t offset,
+                                  uint64_t size_in_bytes, T value) const {
     static_assert(
         sizeof(value) <= 16,
         "FillBufferWithValue doesn't accept values bigger than 16 bytes.");
@@ -181,13 +177,12 @@ class DmlKernelContext {
   }
 
   template <typename T>
-  StatusOr<DmlGpuEvent> FillBufferWithValue(const D3D12BufferRegion& dst,
-                                            T value) const {
+  DmlGpuEvent FillBufferWithValue(const D3D12BufferRegion& dst, T value) const {
     return FillBufferWithValue(dst.Resource(), dst.Offset(), dst.SizeInBytes(),
                                value);
   }
 
-  StatusOr<DmlGpuEvent> InsertUavBarrier() const;
+  DmlGpuEvent InsertUavBarrier() const;
 
   DmlGpuEvent GetCurrentCompletionEvent() const;
 
@@ -201,9 +196,9 @@ class DmlKernelContext {
   uint32_t GetOutputCount() const { return op_ctx_->num_outputs(); }
 
  private:
-  StatusOr<DmlGpuEvent> FillBufferWithPattern(
-      ID3D12Resource* dst, uint64_t offset, uint64_t size_in_bytes,
-      absl::Span<const uint8_t> pattern) const;
+  DmlGpuEvent FillBufferWithPattern(ID3D12Resource* dst, uint64_t offset,
+                                    uint64_t size_in_bytes,
+                                    absl::Span<const uint8_t> pattern) const;
 
   const DmlDevice* device_;
   OpKernelContext* op_ctx_;

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.h
@@ -187,7 +187,7 @@ class DmlKernelContext {
                                value);
   }
 
-  DmlGpuEvent InsertUavBarrier() const;
+  StatusOr<DmlGpuEvent> InsertUavBarrier() const;
 
   DmlGpuEvent GetCurrentCompletionEvent() const;
 

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.h
@@ -145,9 +145,11 @@ class DmlKernelContext {
       absl::Span<const absl::optional<DML_BUFFER_BINDING>> output_bindings);
 
   // Copies src to dst (dst needs to be at at least as big as src)
-  DmlGpuEvent CopyBufferToBuffer(ID3D12Resource* dst, uint64_t dst_offset,
-                                 ID3D12Resource* src, uint64_t src_offset,
-                                 uint64 size_in_bytes) const;
+  StatusOr<DmlGpuEvent> CopyBufferToBuffer(ID3D12Resource* dst,
+                                           uint64_t dst_offset,
+                                           ID3D12Resource* src,
+                                           uint64_t src_offset,
+                                           uint64 size_in_bytes) const;
 
   // Copies src (host memory) to dst (dst needs to be at least as big as src).
   StatusOr<DmlGpuEvent> CopyHostToBuffer(ID3D12Resource* dst,
@@ -155,13 +157,15 @@ class DmlKernelContext {
                                          absl::Span<const uint8_t> src) const;
 
   // Sets a region of the destination buffer to zero.
-  DmlGpuEvent ZeroBuffer(ID3D12Resource* dst, uint64_t offset,
-                         uint64_t size_in_bytes) const;
-  DmlGpuEvent ZeroBuffer(const D3D12BufferRegion& dst) const;
+  StatusOr<DmlGpuEvent> ZeroBuffer(ID3D12Resource* dst, uint64_t offset,
+                                   uint64_t size_in_bytes) const;
+  StatusOr<DmlGpuEvent> ZeroBuffer(const D3D12BufferRegion& dst) const;
 
   template <typename T>
-  DmlGpuEvent FillBufferWithValue(ID3D12Resource* dst, uint64_t offset,
-                                  uint64_t size_in_bytes, T value) const {
+  StatusOr<DmlGpuEvent> FillBufferWithValue(ID3D12Resource* dst,
+                                            uint64_t offset,
+                                            uint64_t size_in_bytes,
+                                            T value) const {
     static_assert(
         sizeof(value) <= 16,
         "FillBufferWithValue doesn't accept values bigger than 16 bytes.");
@@ -177,7 +181,8 @@ class DmlKernelContext {
   }
 
   template <typename T>
-  DmlGpuEvent FillBufferWithValue(const D3D12BufferRegion& dst, T value) const {
+  StatusOr<DmlGpuEvent> FillBufferWithValue(const D3D12BufferRegion& dst,
+                                            T value) const {
     return FillBufferWithValue(dst.Resource(), dst.Offset(), dst.SizeInBytes(),
                                value);
   }
@@ -196,9 +201,9 @@ class DmlKernelContext {
   uint32_t GetOutputCount() const { return op_ctx_->num_outputs(); }
 
  private:
-  DmlGpuEvent FillBufferWithPattern(ID3D12Resource* dst, uint64_t offset,
-                                    uint64_t size_in_bytes,
-                                    absl::Span<const uint8_t> pattern) const;
+  StatusOr<DmlGpuEvent> FillBufferWithPattern(
+      ID3D12Resource* dst, uint64_t offset, uint64_t size_in_bytes,
+      absl::Span<const uint8_t> pattern) const;
 
   const DmlDevice* device_;
   OpKernelContext* op_ctx_;

--- a/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
@@ -61,11 +61,9 @@ StatusOr<DmlGpuEvent> DmlReadbackHeap::ReadbackFromGpu(
   // Copy from the source resource into the readback heap. `gpu_done_event` is
   // the event that will be signaled when the copy to the readback heap
   // completes on the GPU.
-  auto status_or_event = execution_context_->CopyBufferRegion(
+  DmlGpuEvent gpu_done_event = execution_context_->CopyBufferRegion(
       readback_heap, offset_in_chunk, D3D12_RESOURCE_STATE_COPY_DEST, src,
       src_offset, src_state, dst.size());
-
-  TF_RETURN_IF_ERROR(status_or_event.status());
 
   // Get the event which will become signaled once the readback into `dst` has
   // fully completed on the CPU.
@@ -93,7 +91,7 @@ StatusOr<DmlGpuEvent> DmlReadbackHeap::ReadbackFromGpu(
   // Enqueue the done_callback to fire once the copy from src -> readback_heap
   // completes on the GPU. The callback will then perform the copy
   // readback_heap -> dst.
-  event_queue_->Enqueue(status_or_event.ConsumeValueOrDie(), done_callback);
+  event_queue_->Enqueue(gpu_done_event, done_callback);
   return done_event;
 }
 

--- a/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
@@ -61,9 +61,11 @@ StatusOr<DmlGpuEvent> DmlReadbackHeap::ReadbackFromGpu(
   // Copy from the source resource into the readback heap. `gpu_done_event` is
   // the event that will be signaled when the copy to the readback heap
   // completes on the GPU.
-  DmlGpuEvent gpu_done_event = execution_context_->CopyBufferRegion(
+  auto status_or_event = execution_context_->CopyBufferRegion(
       readback_heap, offset_in_chunk, D3D12_RESOURCE_STATE_COPY_DEST, src,
       src_offset, src_state, dst.size());
+
+  TF_RETURN_IF_ERROR(status_or_event.status());
 
   // Get the event which will become signaled once the readback into `dst` has
   // fully completed on the CPU.
@@ -91,7 +93,7 @@ StatusOr<DmlGpuEvent> DmlReadbackHeap::ReadbackFromGpu(
   // Enqueue the done_callback to fire once the copy from src -> readback_heap
   // completes on the GPU. The callback will then perform the copy
   // readback_heap -> dst.
-  event_queue_->Enqueue(gpu_done_event, done_callback);
+  event_queue_->Enqueue(status_or_event.ConsumeValueOrDie(), done_callback);
   return done_event;
 }
 

--- a/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
@@ -58,18 +58,15 @@ StatusOr<DmlGpuEvent> DmlUploadHeap::BeginUploadToGpu(
   chunk->resource->Unmap(0, nullptr);
 
   // Copy from the upload heap into the destination resource
-  auto status_or_event = execution_context_->CopyBufferRegion(
+  DmlGpuEvent done_event = execution_context_->CopyBufferRegion(
       dst, dst_offset, dst_state, chunk->resource.Get(), offset_in_chunk,
       D3D12_RESOURCE_STATE_GENERIC_READ, src.size());
 
-  TF_RETURN_IF_ERROR(status_or_event.status());
-
   // Add an allocation entry to the chunk
   chunk->allocations.push_back(Allocation{static_cast<uint64_t>(src.size()),
-                                          offset_in_chunk,
-                                          status_or_event.ValueOrDie()});
+                                          offset_in_chunk, done_event});
 
-  return status_or_event;
+  return done_event;
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -218,7 +218,8 @@ void CopyTensorInSameDevice(OpKernelContext* op_ctx, Tensor* dst,
                             const Tensor& src) {
   auto* device = static_cast<Device*>(op_ctx->device());
   op_ctx->op_device_context()->CopyTensorInSameDevice(
-      &src, device, dst, [](const Status& s) { TF_CHECK_OK(s); });
+      &src, device, dst,
+      [op_ctx](const Status& s) { OP_REQUIRES_OK(op_ctx, s); });
 }
 
 D3D12BufferRegion CreateBufferForTensor(const DmlDevice* device,

--- a/tensorflow/core/kernels/dml_addn_op.cc
+++ b/tensorflow/core/kernels/dml_addn_op.cc
@@ -80,7 +80,7 @@ class DmlAddNKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -88,7 +88,8 @@ class DmlAddNKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_addn_op.cc
+++ b/tensorflow/core/kernels/dml_addn_op.cc
@@ -88,8 +88,7 @@ class DmlAddNKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_assign_ops.cc
+++ b/tensorflow/core/kernels/dml_assign_ops.cc
@@ -32,7 +32,8 @@ class DmlAssignOp : public AssignOp {
     Device* device = static_cast<Device*>(context->device());
 
     device_context->CopyTensorInSameDevice(
-        &rhs, device, lhs, [](const Status& s) { TF_CHECK_OK(s); });
+        &rhs, device, lhs,
+        [context](const Status& s) { OP_REQUIRES_OK(context, s); });
   }
 };
 

--- a/tensorflow/core/kernels/dml_broadcast_to_op.cc
+++ b/tensorflow/core/kernels/dml_broadcast_to_op.cc
@@ -114,7 +114,7 @@ class DmlBroadcastToKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -122,7 +122,8 @@ class DmlBroadcastToKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_broadcast_to_op.cc
+++ b/tensorflow/core/kernels/dml_broadcast_to_op.cc
@@ -122,8 +122,7 @@ class DmlBroadcastToKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cast_op.cc
+++ b/tensorflow/core/kernels/dml_cast_op.cc
@@ -70,10 +70,11 @@ class DmlCastKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const {
     if (zero_outputs_) {
       Tensor* output = ctx->GetOutputTensor(0);
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cast_op.cc
+++ b/tensorflow/core/kernels/dml_cast_op.cc
@@ -71,8 +71,7 @@ class DmlCastKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const {
     if (zero_outputs_) {
       Tensor* output = ctx->GetOutputTensor(0);
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_check_numerics_op.cc
+++ b/tensorflow/core/kernels/dml_check_numerics_op.cc
@@ -149,12 +149,9 @@ class DmlCheckNumericsKernel : public DmlKernel {
       D3D12BufferRegion output_buffer =
           dml_util::CreateBufferForTensor(device, *output_tensor);
 
-      auto status_or_event = ctx->CopyBufferToBuffer(
-          output_buffer.Resource(), output_buffer.Offset(),
-          input_buffer.Resource(), input_buffer.Offset(),
-          output_tensor->TotalBytes());
-
-      TF_RETURN_IF_ERROR(status_or_event.status());
+      ctx->CopyBufferToBuffer(output_buffer.Resource(), output_buffer.Offset(),
+                              input_buffer.Resource(), input_buffer.Offset(),
+                              output_tensor->TotalBytes());
     }
 
     return ctx->GetCurrentCompletionEvent();

--- a/tensorflow/core/kernels/dml_concat_op.cc
+++ b/tensorflow/core/kernels/dml_concat_op.cc
@@ -240,7 +240,7 @@ class DmlConcatKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -248,7 +248,8 @@ class DmlConcatKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_concat_op.cc
+++ b/tensorflow/core/kernels/dml_concat_op.cc
@@ -247,8 +247,7 @@ class DmlConcatKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -154,7 +154,7 @@ class DmlBinaryKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -162,7 +162,8 @@ class DmlBinaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -200,7 +201,7 @@ class DmlCompositeBinaryKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -208,7 +209,8 @@ class DmlCompositeBinaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -239,7 +241,7 @@ class DmlUnaryKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -247,7 +249,8 @@ class DmlUnaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -339,7 +342,7 @@ class DmlCompositeUnaryKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -347,7 +350,8 @@ class DmlCompositeUnaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -383,7 +387,7 @@ class DmlUnaryScaleBiasKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -391,7 +395,8 @@ class DmlUnaryScaleBiasKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -715,7 +720,7 @@ REGISTER_DML_COMPOSITE_BINARY_FLOAT_KERNEL(SigmoidGrad, y* x*(1 - x),
                                            kNchwDimensionCount)
 REGISTER_DML_COMPOSITE_BINARY_FLOAT_KERNEL(TanhGrad, y*(1 - x * x),
                                            kNchwDimensionCount)
-REGISTER_DML_COMPOSITE_BINARY_FLOAT_KERNEL(ReciprocalGrad, - y * x * x,
+REGISTER_DML_COMPOSITE_BINARY_FLOAT_KERNEL(ReciprocalGrad, -y* x* x,
                                            kNchwDimensionCount)
 #undef REGISTER_DML_FLOAT_OP_KERNEL
 #undef REGISTER_OP_KERNEL
@@ -760,7 +765,7 @@ class DmlClipByValueKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -768,7 +773,8 @@ class DmlClipByValueKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -820,7 +826,7 @@ class DmlBinaryWithZeroKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -828,7 +834,8 @@ class DmlBinaryWithZeroKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -928,7 +935,7 @@ class DmlSquaredDifferenceKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -936,7 +943,8 @@ class DmlSquaredDifferenceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -159,8 +159,7 @@ class DmlBinaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -206,8 +205,7 @@ class DmlCompositeBinaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -246,8 +244,7 @@ class DmlUnaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -342,8 +339,7 @@ class DmlCompositeUnaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -387,8 +383,7 @@ class DmlUnaryScaleBiasKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -765,8 +760,7 @@ class DmlClipByValueKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -826,8 +820,7 @@ class DmlBinaryWithZeroKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -935,8 +928,7 @@ class DmlSquaredDifferenceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_data_format_dim_map.cc
+++ b/tensorflow/core/kernels/dml_data_format_dim_map.cc
@@ -133,8 +133,7 @@ class DmlDataFormaDimMapKernel : public DmlKernel {
     // Since we gather uint8 values with strides of 4 or 8, we always need to
     // zero the buffer
     Tensor* output = ctx->GetOutputTensor(0);
-    TF_RETURN_IF_ERROR(
-        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+    ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     return DmlKernel::Compute(ctx);
   }
 };

--- a/tensorflow/core/kernels/dml_data_format_dim_map.cc
+++ b/tensorflow/core/kernels/dml_data_format_dim_map.cc
@@ -129,11 +129,12 @@ class DmlDataFormaDimMapKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Since we gather uint8 values with strides of 4 or 8, we always need to
     // zero the buffer
     Tensor* output = ctx->GetOutputTensor(0);
-    ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+    TF_RETURN_IF_ERROR(
+        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     return DmlKernel::Compute(ctx);
   }
 };

--- a/tensorflow/core/kernels/dml_data_format_vec_permute.cc
+++ b/tensorflow/core/kernels/dml_data_format_vec_permute.cc
@@ -96,7 +96,7 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
             D3D12_RESOURCE_STATE_COPY_DEST),
     };
 
-    execution_context->ResourceBarrier(barriers);
+    OP_REQUIRES_OK(ctx, execution_context->ResourceBarrier(barriers).status());
 
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
@@ -153,7 +153,7 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
       std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
     }
 
-    execution_context->ResourceBarrier(barriers);
+    OP_REQUIRES_OK(ctx, execution_context->ResourceBarrier(barriers).status());
   }
 
  private:

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -56,10 +56,12 @@ class DmlDeepCopyKernel : public OpKernel {
     constexpr uint64_t dst_offset = 0;
     constexpr uint64_t src_offset = 0;
 
-    execution_context->CopyBufferRegion(
+    auto status_or_event = execution_context->CopyBufferRegion(
         output_buffer.Resource(), dst_offset, D3D12_RESOURCE_STATE_COPY_DEST,
         input_buffer.Resource(), src_offset, D3D12_RESOURCE_STATE_COPY_SOURCE,
         input.TotalBytes());
+
+    OP_REQUIRES_OK(ctx, status_or_event.status());
 
     for (auto& barrier : barriers) {
       std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -51,23 +51,21 @@ class DmlDeepCopyKernel : public OpKernel {
             D3D12_RESOURCE_STATE_COPY_DEST),
     };
 
-    OP_REQUIRES_OK(ctx, execution_context->ResourceBarrier(barriers).status());
+    execution_context->ResourceBarrier(barriers);
 
     constexpr uint64_t dst_offset = 0;
     constexpr uint64_t src_offset = 0;
 
-    auto status_or_event = execution_context->CopyBufferRegion(
+    execution_context->CopyBufferRegion(
         output_buffer.Resource(), dst_offset, D3D12_RESOURCE_STATE_COPY_DEST,
         input_buffer.Resource(), src_offset, D3D12_RESOURCE_STATE_COPY_SOURCE,
         input.TotalBytes());
-
-    OP_REQUIRES_OK(ctx, status_or_event.status());
 
     for (auto& barrier : barriers) {
       std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
     }
 
-    OP_REQUIRES_OK(ctx, execution_context->ResourceBarrier(barriers).status());
+    execution_context->ResourceBarrier(barriers);
   }
 };
 

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -51,7 +51,7 @@ class DmlDeepCopyKernel : public OpKernel {
             D3D12_RESOURCE_STATE_COPY_DEST),
     };
 
-    execution_context->ResourceBarrier(barriers);
+    OP_REQUIRES_OK(ctx, execution_context->ResourceBarrier(barriers).status());
 
     constexpr uint64_t dst_offset = 0;
     constexpr uint64_t src_offset = 0;
@@ -67,7 +67,7 @@ class DmlDeepCopyKernel : public OpKernel {
       std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
     }
 
-    execution_context->ResourceBarrier(barriers);
+    OP_REQUIRES_OK(ctx, execution_context->ResourceBarrier(barriers).status());
   }
 };
 

--- a/tensorflow/core/kernels/dml_diag_op.cc
+++ b/tensorflow/core/kernels/dml_diag_op.cc
@@ -109,10 +109,11 @@ class DmlDiagKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Zero the buffer since we use strides to skip over elements
     Tensor* output = ctx->GetOutputTensor(0);
-    ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+    TF_RETURN_IF_ERROR(
+        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
 
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_diag_op.cc
+++ b/tensorflow/core/kernels/dml_diag_op.cc
@@ -112,8 +112,7 @@ class DmlDiagKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Zero the buffer since we use strides to skip over elements
     Tensor* output = ctx->GetOutputTensor(0);
-    TF_RETURN_IF_ERROR(
-        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+    ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
 
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_diag_part_op.cc
+++ b/tensorflow/core/kernels/dml_diag_part_op.cc
@@ -116,7 +116,7 @@ class DmlDiagPartKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -124,7 +124,8 @@ class DmlDiagPartKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_diag_part_op.cc
+++ b/tensorflow/core/kernels/dml_diag_part_op.cc
@@ -124,8 +124,7 @@ class DmlDiagPartKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
@@ -122,7 +122,8 @@ class DmlDynamicStitchKernel : public OpKernel {
         output_buffer.Resource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
         D3D12_RESOURCE_STATE_COPY_DEST));
 
-    device->GetExecutionContext()->ResourceBarrier(barriers);
+    OP_REQUIRES_OK(
+        ctx, device->GetExecutionContext()->ResourceBarrier(barriers).status());
 
     DCHECK(indices_inputs.size() == data_inputs.size());
     for (int tensor_idx = 0; tensor_idx < indices_inputs.size(); ++tensor_idx) {
@@ -152,7 +153,8 @@ class DmlDynamicStitchKernel : public OpKernel {
       std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
     }
 
-    device->GetExecutionContext()->ResourceBarrier(barriers);
+    OP_REQUIRES_OK(
+        ctx, device->GetExecutionContext()->ResourceBarrier(barriers).status());
   }
 };
 

--- a/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
@@ -131,8 +131,7 @@ class DmlDynamicStitchKernel : public OpKernel {
         output_buffer.Resource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
         D3D12_RESOURCE_STATE_COPY_DEST));
 
-    OP_REQUIRES_OK(
-        ctx, device->GetExecutionContext()->ResourceBarrier(barriers).status());
+    device->GetExecutionContext()->ResourceBarrier(barriers);
 
     DCHECK(indices_inputs.size() == data_inputs.size());
     for (int tensor_idx = 0; tensor_idx < indices_inputs.size(); ++tensor_idx) {
@@ -154,12 +153,10 @@ class DmlDynamicStitchKernel : public OpKernel {
         const uint64_t dst_offset =
             output_buffer.Offset() + byte_stride * output_idx;
 
-        auto status_or_event = device->GetExecutionContext()->CopyBufferRegion(
+        device->GetExecutionContext()->CopyBufferRegion(
             output_buffer.Resource(), dst_offset,
             D3D12_RESOURCE_STATE_COPY_DEST, input_buffer.Resource(), src_offset,
             D3D12_RESOURCE_STATE_COPY_SOURCE, byte_stride);
-
-        OP_REQUIRES_OK(ctx, status_or_event.status());
       }
     }
 
@@ -167,8 +164,7 @@ class DmlDynamicStitchKernel : public OpKernel {
       std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
     }
 
-    OP_REQUIRES_OK(
-        ctx, device->GetExecutionContext()->ResourceBarrier(barriers).status());
+    device->GetExecutionContext()->ResourceBarrier(barriers);
   }
 };
 

--- a/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
@@ -139,10 +139,12 @@ class DmlDynamicStitchKernel : public OpKernel {
         const uint64_t dst_offset =
             output_buffer.Offset() + byte_stride * output_idx;
 
-        device->GetExecutionContext()->CopyBufferRegion(
+        auto status_or_event = device->GetExecutionContext()->CopyBufferRegion(
             output_buffer.Resource(), dst_offset,
             D3D12_RESOURCE_STATE_COPY_DEST, input_buffer.Resource(), src_offset,
             D3D12_RESOURCE_STATE_COPY_SOURCE, byte_stride);
+
+        OP_REQUIRES_OK(ctx, status_or_event.status());
       }
     }
 

--- a/tensorflow/core/kernels/dml_fill_op.cc
+++ b/tensorflow/core/kernels/dml_fill_op.cc
@@ -89,7 +89,7 @@ class DmlFillKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -97,7 +97,8 @@ class DmlFillKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_fill_op.cc
+++ b/tensorflow/core/kernels/dml_fill_op.cc
@@ -97,8 +97,7 @@ class DmlFillKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_gather_nd_op.cc
+++ b/tensorflow/core/kernels/dml_gather_nd_op.cc
@@ -240,7 +240,7 @@ class DmlGatherNdKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -248,7 +248,8 @@ class DmlGatherNdKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_gather_nd_op.cc
+++ b/tensorflow/core/kernels/dml_gather_nd_op.cc
@@ -255,8 +255,7 @@ class DmlGatherNdKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_gather_op.cc
+++ b/tensorflow/core/kernels/dml_gather_op.cc
@@ -324,20 +324,19 @@ class DmlGatherKernel : public DmlKernel {
     D3D12BufferRegion output_buffers[] = {ctx->CreateBufferForTensor(*output)};
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(ctx->ZeroBuffer(output_buffers[0]).status());
+      ctx->ZeroBuffer(output_buffers[0]);
     }
 
     // Create bindings
     auto input_bindings = dml_util::GetBufferBindings(input_buffers);
     auto output_bindings = dml_util::GetBufferBindings(output_buffers);
 
-    StatusOr<DmlGpuEvent> status_or_event =
+    DmlGpuEvent gpu_event =
         ctx->ExecuteOperator(GetCompiledOp(), GetPersistentResourceBinding(),
                              input_bindings, output_bindings);
 
     init_helper->Unlock();
-    TF_RETURN_IF_ERROR(status_or_event.status());
-    return status_or_event.ConsumeValueOrDie();
+    return gpu_event;
   }
 };
 

--- a/tensorflow/core/kernels/dml_gru_ops.cc
+++ b/tensorflow/core/kernels/dml_gru_ops.cc
@@ -226,9 +226,11 @@ class DmlGruBlockCellOp : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)))
+              .status());
     }
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_gru_ops.cc
+++ b/tensorflow/core/kernels/dml_gru_ops.cc
@@ -228,9 +228,7 @@ class DmlGruBlockCellOp : public DmlKernel {
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)))
-              .status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
     }
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -91,12 +91,9 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
               dml_util::CreateBufferForTensor(dml_device, *output_tensor);
 
           const uint8_t fill_pattern[] = {0};
-          auto status_or_event =
-              dml_device->GetExecutionContext()->FillBufferWithPattern(
-                  buffer.Resource(), buffer.Offset(), buffer.SizeInBytes(),
-                  fill_pattern);
-
-          OP_REQUIRES_OK(ctx, status_or_event.status());
+          dml_device->GetExecutionContext()->FillBufferWithPattern(
+              buffer.Resource(), buffer.Offset(), buffer.SizeInBytes(),
+              fill_pattern);
         }
       }
       return;

--- a/tensorflow/core/kernels/dml_kernel_wrapper.h
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.h
@@ -62,8 +62,8 @@ class DmlKernelWrapperBase : public OpKernel {
       DmlKernelConstruction* ctx,
       const InitializationHelper* initialized_helper) const = 0;
 
-  virtual DmlGpuEvent ComputeKernel(DmlKernel* kernel,
-                                    DmlKernelContext* context) const = 0;
+  virtual StatusOr<DmlGpuEvent> ComputeKernel(
+      DmlKernel* kernel, DmlKernelContext* context) const = 0;
 
  protected:
   // Creates a key which uniquely identifies the kernel instance we need. The
@@ -143,8 +143,8 @@ class DmlKernelWrapper : public DmlKernelWrapperBase {
     return std::make_shared<const typename TKernel::InitHelper>(ctx, attr_);
   }
 
-  DmlGpuEvent ComputeKernel(DmlKernel* kernel,
-                            DmlKernelContext* context) const override {
+  StatusOr<DmlGpuEvent> ComputeKernel(
+      DmlKernel* kernel, DmlKernelContext* context) const override {
     return kernel->Compute(context);
   }
 

--- a/tensorflow/core/kernels/dml_lstm_ops.cc
+++ b/tensorflow/core/kernels/dml_lstm_ops.cc
@@ -1128,12 +1128,13 @@ class DmlBlockLstmOp : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     if (skip_) {
       uint32_t num_out = ctx->GetOutputCount();
       for (uint32_t i = 0; i < num_out; ++i) {
         Tensor* output = ctx->GetOutputTensor(i);
-        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+        TF_RETURN_IF_ERROR(
+            ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
       }
       return ctx->GetCurrentCompletionEvent();
     }
@@ -1687,9 +1688,11 @@ class DmlBlockLstmGradOp : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)))
+              .status());
     }
     if (skip_) {
       return ctx->GetCurrentCompletionEvent();

--- a/tensorflow/core/kernels/dml_lstm_ops.cc
+++ b/tensorflow/core/kernels/dml_lstm_ops.cc
@@ -1133,8 +1133,7 @@ class DmlBlockLstmOp : public DmlKernel {
       uint32_t num_out = ctx->GetOutputCount();
       for (uint32_t i = 0; i < num_out; ++i) {
         Tensor* output = ctx->GetOutputTensor(i);
-        TF_RETURN_IF_ERROR(
-            ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
       }
       return ctx->GetCurrentCompletionEvent();
     }
@@ -1690,9 +1689,7 @@ class DmlBlockLstmGradOp : public DmlKernel {
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)))
-              .status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
     }
     if (skip_) {
       return ctx->GetCurrentCompletionEvent();

--- a/tensorflow/core/kernels/dml_matrix_diag_ops.cc
+++ b/tensorflow/core/kernels/dml_matrix_diag_ops.cc
@@ -316,11 +316,8 @@ class DmlMatrixDiagKernel : public DmlKernel {
       // Fill the buffer with the padding value since we use strides to skip
       // over elements
       Tensor* output = ctx->GetOutputTensor(0);
-      auto status_or_event =
-          ctx->FillBufferWithValue(ctx->CreateBufferForTensor(*output),
-                                   static_cast<float>(padding_value_));
-
-      TF_RETURN_IF_ERROR(status_or_event.status());
+      ctx->FillBufferWithValue(ctx->CreateBufferForTensor(*output),
+                               static_cast<float>(padding_value_));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_ops_common.cc
+++ b/tensorflow/core/kernels/dml_ops_common.cc
@@ -213,7 +213,7 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   OP_REQUIRES_OK(ctx->GetOpKernelContext(), status);
 }
 
-DmlGpuEvent DmlKernel::Compute(DmlKernelContext* ctx) const {
+StatusOr<DmlGpuEvent> DmlKernel::Compute(DmlKernelContext* ctx) const {
   auto input_buffers = CreateInputBuffers(ctx);
   auto output_buffers = CreateOutputBuffers(ctx);
 
@@ -221,16 +221,9 @@ DmlGpuEvent DmlKernel::Compute(DmlKernelContext* ctx) const {
   auto input_bindings = dml_util::GetBufferBindings(input_buffers);
   auto output_bindings = dml_util::GetBufferBindings(output_buffers);
 
-  StatusOr<DmlGpuEvent> status_or_event =
-      ctx->ExecuteOperator(compiled_op_.Get(), GetPersistentResourceBinding(),
-                           input_bindings, output_bindings);
-
-  if (!status_or_event.ok()) {
-    ctx->GetOpKernelContext()->SetStatus(status_or_event.status());
-    return ctx->GetCurrentCompletionEvent();
-  }
-
-  return status_or_event.ConsumeValueOrDie();
+  return ctx->ExecuteOperator(compiled_op_.Get(),
+                              GetPersistentResourceBinding(), input_bindings,
+                              output_bindings);
 }
 
 absl::InlinedVector<D3D12BufferRegion, 8> DmlKernel::CreateInputBuffers(

--- a/tensorflow/core/kernels/dml_ops_common.cc
+++ b/tensorflow/core/kernels/dml_ops_common.cc
@@ -233,10 +233,8 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   // We don't supply any input bindings, because we never set OWNED_BY_DML
   absl::Span<const DML_BUFFER_BINDING> input_init_bindings = {};
 
-  Status status = ctx->InitializeOperator(
-      compiled_op_.Get(), GetPersistentResourceBinding(), input_init_bindings);
-
-  OP_REQUIRES_OK(ctx->GetOpKernelContext(), status);
+  ctx->InitializeOperator(compiled_op_.Get(), GetPersistentResourceBinding(),
+                          input_init_bindings);
 }
 
 StatusOr<DmlGpuEvent> DmlKernel::Compute(DmlKernelContext* ctx) const {

--- a/tensorflow/core/kernels/dml_ops_common.h
+++ b/tensorflow/core/kernels/dml_ops_common.h
@@ -92,7 +92,7 @@ class DmlKernel {
   // Computes this kernel. By default, this simply submits the compiled DML
   // operator for execution. A DmlGpuEvent is returned which becomes signaled
   // when the kernel completes execution on the GPU. This method is thread-safe.
-  virtual DmlGpuEvent Compute(DmlKernelContext* ctx) const;
+  virtual StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const;
 
   absl::Span<const absl::optional<uint32_t>> GetOutputRefsForwarding() const {
     return output_refs_forwarding_;

--- a/tensorflow/core/kernels/dml_pack_op.cc
+++ b/tensorflow/core/kernels/dml_pack_op.cc
@@ -153,7 +153,7 @@ class DmlPackKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -161,7 +161,8 @@ class DmlPackKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_pack_op.cc
+++ b/tensorflow/core/kernels/dml_pack_op.cc
@@ -160,8 +160,7 @@ class DmlPackKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_random_ops.cc
+++ b/tensorflow/core/kernels/dml_random_ops.cc
@@ -198,18 +198,11 @@ class DmlStatelessRandomUniformKernel : public DmlKernel {
     auto byte_span =
         absl::MakeSpan(byte_ptr, input_state_.size() * sizeof(input_state_[0]));
 
-    StatusOr<DmlGpuEvent> status_or_event = ctx->CopyHostToBuffer(
-        input_state_buffer.Resource(), input_state_buffer.Offset(), byte_span);
+    ctx->CopyHostToBuffer(input_state_buffer.Resource(),
+                          input_state_buffer.Offset(), byte_span);
 
-    TF_RETURN_IF_ERROR(status_or_event.status());
-
-    status_or_event =
-        ctx->ExecuteOperator(GetCompiledOp(), GetPersistentResourceBinding(),
-                             input_bindings, output_bindings);
-
-    TF_RETURN_IF_ERROR(status_or_event.status());
-
-    return status_or_event;
+    return ctx->ExecuteOperator(GetCompiledOp(), GetPersistentResourceBinding(),
+                                input_bindings, output_bindings);
   }
 };
 
@@ -357,18 +350,11 @@ class DmlRandomUniformKernel : public DmlKernel {
     auto byte_span =
         absl::MakeSpan(byte_ptr, state_buf.size() * sizeof(state_buf[0]));
 
-    StatusOr<DmlGpuEvent> status_or_event = ctx->CopyHostToBuffer(
-        state_buffer_->Resource(), state_buffer_->Offset(), byte_span);
+    ctx->CopyHostToBuffer(state_buffer_->Resource(), state_buffer_->Offset(),
+                          byte_span);
 
-    TF_RETURN_IF_ERROR(status_or_event.status());
-
-    status_or_event =
-        ctx->ExecuteOperator(GetCompiledOp(), GetPersistentResourceBinding(),
-                             input_bindings, output_bindings);
-
-    TF_RETURN_IF_ERROR(status_or_event.status());
-
-    return status_or_event;
+    return ctx->ExecuteOperator(GetCompiledOp(), GetPersistentResourceBinding(),
+                                input_bindings, output_bindings);
   }
 };
 

--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -371,10 +371,11 @@ class DmlReduceKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     if (zero_outputs_) {
       Tensor* output = ctx->GetOutputTensor(0);
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -373,8 +373,7 @@ class DmlReduceKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     if (zero_outputs_) {
       Tensor* output = ctx->GetOutputTensor(0);
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_resource_variable_ops.cc
+++ b/tensorflow/core/kernels/dml_resource_variable_ops.cc
@@ -23,30 +23,6 @@ limitations under the License.
 
 namespace tensorflow {
 
-static void GetVariable(OpKernelContext* op_ctx,
-                        core::RefCountPtr<Var>& variable) {
-  OP_REQUIRES_OK(op_ctx,
-                 LookupResource(op_ctx, HandleFromInput(op_ctx, 0), &variable));
-}
-
-static void PrepareVariableUpdate(OpKernelContext* op_ctx,
-                                  core::RefCountPtr<Var>& variable) {
-  Tensor* var_tensor = variable->tensor();
-  const TensorShape& var_shape = variable->tensor()->shape();
-  const TensorShape& value_shape = op_ctx->input(1).shape();
-
-  OP_REQUIRES(op_ctx, var_shape.IsSameSize(value_shape),
-              errors::InvalidArgument(
-                  "Cannot update variable with shape ", var_shape.DebugString(),
-                  " using a Tensor with shape ", value_shape.DebugString(),
-                  ", shapes must be equal."));
-
-  OP_REQUIRES_OK(op_ctx,
-                 PrepareToUpdateVariable(op_ctx, var_tensor,
-                                         variable->copy_on_read_mode.load(),
-                                         &dml_util::CopyTensorInSameDevice));
-}
-
 template <DML_OPERATOR_TYPE op_type, typename DML_OPERATOR_SPECIFIC_DESC>
 class DmlUpdateVariableOp : public DmlKernel {
  public:
@@ -85,24 +61,31 @@ class DmlUpdateVariableOp : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     auto* op_ctx = ctx->GetOpKernelContext();
 
     core::RefCountPtr<Var> variable;
-    GetVariable(op_ctx, variable);
-    if (!op_ctx->status().ok()) {
-      return ctx->GetCurrentCompletionEvent();
-    }
+    TF_RETURN_IF_ERROR(
+        LookupResource(op_ctx, HandleFromInput(op_ctx, 0), &variable));
 
     mutex_lock ml(*variable->mu());
 
-    PrepareVariableUpdate(op_ctx, variable);
-    if (!op_ctx->status().ok()) {
-      return ctx->GetCurrentCompletionEvent();
+    Tensor* var_tensor = variable->tensor();
+    const TensorShape& var_shape = variable->tensor()->shape();
+    const Tensor& value = ctx->GetInputTensor(1);
+    const TensorShape& value_shape = value.shape();
+
+    if (!var_shape.IsSameSize(value_shape)) {
+      return errors::InvalidArgument(
+          "Cannot update variable with shape ", var_shape.DebugString(),
+          " using a Tensor with shape ", value_shape.DebugString(),
+          ", shapes must be equal.");
     }
 
-    const Tensor& value = ctx->GetInputTensor(1);
-    Tensor* var_tensor = variable->tensor();
+    TF_RETURN_IF_ERROR(PrepareToUpdateVariable(
+        op_ctx, var_tensor, variable->copy_on_read_mode.load(),
+        &dml_util::CopyTensorInSameDevice));
+
     D3D12BufferRegion var_resource = ctx->CreateBufferForTensor(*var_tensor);
     D3D12BufferRegion value_resource = ctx->CreateBufferForTensor(value);
 
@@ -117,16 +100,8 @@ class DmlUpdateVariableOp : public DmlKernel {
         input_bindings[0],
     };
 
-    StatusOr<DmlGpuEvent> status_or_event =
-        ctx->ExecuteOperator(GetCompiledOp(), GetPersistentResourceBinding(),
-                             input_bindings, output_bindings);
-
-    if (!status_or_event.ok()) {
-      ctx->GetOpKernelContext()->SetStatus(status_or_event.status());
-      return ctx->GetCurrentCompletionEvent();
-    }
-
-    return status_or_event.ConsumeValueOrDie();
+    return ctx->ExecuteOperator(GetCompiledOp(), GetPersistentResourceBinding(),
+                                input_bindings, output_bindings);
   }
 
  private:

--- a/tensorflow/core/kernels/dml_reverse_op.cc
+++ b/tensorflow/core/kernels/dml_reverse_op.cc
@@ -159,7 +159,7 @@ class DmlReverseKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee
     // that our output tensor's memory is zero'd, we need to do so manually
@@ -167,7 +167,8 @@ class DmlReverseKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_reverse_op.cc
+++ b/tensorflow/core/kernels/dml_reverse_op.cc
@@ -167,8 +167,7 @@ class DmlReverseKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_reverse_sequence_op.cc
+++ b/tensorflow/core/kernels/dml_reverse_sequence_op.cc
@@ -174,7 +174,7 @@ class DmlReverseSequenceKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -182,7 +182,8 @@ class DmlReverseSequenceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_reverse_sequence_op.cc
+++ b/tensorflow/core/kernels/dml_reverse_sequence_op.cc
@@ -182,8 +182,7 @@ class DmlReverseSequenceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_scan_ops.cc
+++ b/tensorflow/core/kernels/dml_scan_ops.cc
@@ -136,8 +136,7 @@ class DmlCumsumKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_scan_ops.cc
+++ b/tensorflow/core/kernels/dml_scan_ops.cc
@@ -128,7 +128,7 @@ class DmlCumsumKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -136,7 +136,8 @@ class DmlCumsumKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_select_op.cc
+++ b/tensorflow/core/kernels/dml_select_op.cc
@@ -235,8 +235,7 @@ class DmlTernaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_select_op.cc
+++ b/tensorflow/core/kernels/dml_select_op.cc
@@ -227,7 +227,7 @@ class DmlTernaryKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -235,7 +235,8 @@ class DmlTernaryKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_slice_op.cc
+++ b/tensorflow/core/kernels/dml_slice_op.cc
@@ -148,7 +148,7 @@ class DmlSliceKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -156,7 +156,8 @@ class DmlSliceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_slice_op.cc
+++ b/tensorflow/core/kernels/dml_slice_op.cc
@@ -156,8 +156,7 @@ class DmlSliceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_snapshot_op.cc
+++ b/tensorflow/core/kernels/dml_snapshot_op.cc
@@ -33,7 +33,8 @@ class DmlSnapshotOp : public OpKernel {
       Device* device = static_cast<Device*>(context->device());
 
       device_context->CopyTensorInSameDevice(
-          &input, device, output, [](const Status& s) { TF_CHECK_OK(s); });
+          &input, device, output,
+          [context](const Status& s) { OP_REQUIRES_OK(context, s); });
     }
   }
 };

--- a/tensorflow/core/kernels/dml_space_depth_ops.cc
+++ b/tensorflow/core/kernels/dml_space_depth_ops.cc
@@ -191,8 +191,7 @@ class DmlSpaceDepthKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_space_depth_ops.cc
+++ b/tensorflow/core/kernels/dml_space_depth_ops.cc
@@ -183,7 +183,7 @@ class DmlSpaceDepthKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -191,7 +191,8 @@ class DmlSpaceDepthKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_split_op.cc
+++ b/tensorflow/core/kernels/dml_split_op.cc
@@ -234,7 +234,7 @@ class DmlSplitKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -243,7 +243,8 @@ class DmlSplitKernel : public DmlKernel {
       for (uint32_t i = 0; i < ctx->GetOutputCount(); ++i) {
         if (ctx->GetOutputTensor(i)->NumElements() != 0) {
           Tensor* output = ctx->GetOutputTensor(i);
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+          TF_RETURN_IF_ERROR(
+              ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
         }
       }
     }

--- a/tensorflow/core/kernels/dml_split_op.cc
+++ b/tensorflow/core/kernels/dml_split_op.cc
@@ -243,8 +243,7 @@ class DmlSplitKernel : public DmlKernel {
       for (uint32_t i = 0; i < ctx->GetOutputCount(); ++i) {
         if (ctx->GetOutputTensor(i)->NumElements() != 0) {
           Tensor* output = ctx->GetOutputTensor(i);
-          TF_RETURN_IF_ERROR(
-              ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
         }
       }
     }

--- a/tensorflow/core/kernels/dml_strided_slice_op.cc
+++ b/tensorflow/core/kernels/dml_strided_slice_op.cc
@@ -33,10 +33,9 @@ struct SimplifiedSlice {
 };
 
 template <typename T>
-void ShiftDim(T& vec, int shift_amount, uint32_t dim_count)
-{
-    std::rotate(vec.begin(), vec.begin() + shift_amount, vec.end());
-    vec.resize(dim_count);
+void ShiftDim(T& vec, int shift_amount, uint32_t dim_count) {
+  std::rotate(vec.begin(), vec.begin() + shift_amount, vec.end());
+  vec.resize(dim_count);
 }
 
 // This helper may simplify an N-dimensional slice to a lower rank slice by
@@ -378,7 +377,7 @@ class DmlStridedSliceKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -386,7 +385,8 @@ class DmlStridedSliceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);
@@ -487,7 +487,7 @@ class DmlStridedSliceGradKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -495,7 +495,8 @@ class DmlStridedSliceGradKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_strided_slice_op.cc
+++ b/tensorflow/core/kernels/dml_strided_slice_op.cc
@@ -385,8 +385,7 @@ class DmlStridedSliceKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -495,8 +494,7 @@ class DmlStridedSliceGradKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_tensor_array.cc
+++ b/tensorflow/core/kernels/dml_tensor_array.cc
@@ -57,7 +57,7 @@ Status DmlAddToTensor(OpKernelContext* ctx, Tensor* sum, const Tensor* current,
   TensorValue out = op_ctx.release_output(0);
   ctx->device()->CopyTensorInSameDevice(
       out.tensor, sum, ctx->op_device_context(),
-      [](const Status& s) { TF_CHECK_OK(s); });
+      [ctx](const Status& s) { OP_REQUIRES_OK(ctx, s); });
 
   return op_ctx.status();
 }
@@ -67,16 +67,17 @@ Status DmlTensorSetZero(OpKernelContext* ctx, Tensor* value) {
   D3D12BufferRegion dst = dml_util::CreateBufferForTensor(device, *value);
 
   uint8_t pattern[] = {0};
-  (void)device->GetExecutionContext()->FillBufferWithPattern(
+  auto status_or_event = device->GetExecutionContext()->FillBufferWithPattern(
       dst.Resource(), dst.Offset(), dst.SizeInBytes(), pattern);
 
-  return Status::OK();
+  return status_or_event.status();
 }
 
 void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
                       absl::Span<PersistentTensor> values) {
   auto* device = static_cast<DmlDevice*>(ctx->device());
-  D3D12BufferRegion dst = dml_util::CreateBufferForTensor(device, *output_tensor);
+  D3D12BufferRegion dst =
+      dml_util::CreateBufferForTensor(device, *output_tensor);
   uint64_t dst_offset = dst.Offset();
 
   for (PersistentTensor& value : values) {
@@ -87,13 +88,17 @@ void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
     assert(input_tensor.NumElements() <= output_tensor->NumElements());
 
     uint64_t bytes_to_copy = input_tensor.TotalBytes();
-    D3D12BufferRegion src = dml_util::CreateBufferForTensor(device, input_tensor);
+    D3D12BufferRegion src =
+        dml_util::CreateBufferForTensor(device, input_tensor);
 
     // GPU resources are always kept in UAV state
     const auto barrier_state = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-    (void)device->GetExecutionContext()->CopyBufferRegion(
+
+    auto status_or_event = device->GetExecutionContext()->CopyBufferRegion(
         dst.Resource(), dst_offset, barrier_state, src.Resource(), src.Offset(),
         barrier_state, bytes_to_copy);
+
+    OP_REQUIRES_OK(ctx, status_or_event.status());
 
     dst_offset += bytes_to_copy;
     CHECK(dst_offset <= dst.Resource()->GetDesc().Width);
@@ -114,14 +119,18 @@ void DmlSplitTensor(OpKernelContext* ctx, Tensor* output_tensor,
   uint64_t src_offset = start_element * element_byte_size;
 
   auto* device = static_cast<DmlDevice*>(ctx->device());
-  D3D12BufferRegion dst = dml_util::CreateBufferForTensor(device, *output_tensor);
+  D3D12BufferRegion dst =
+      dml_util::CreateBufferForTensor(device, *output_tensor);
   D3D12BufferRegion src = dml_util::CreateBufferForTensor(device, input_tensor);
 
   // GPU resources are always kept in UAV state
   const auto barrier_state = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-  (void)device->GetExecutionContext()->CopyBufferRegion(
+
+  auto status_or_event = device->GetExecutionContext()->CopyBufferRegion(
       dst.Resource(), dst.Offset(), barrier_state, src.Resource(),
       src.Offset() + src_offset, barrier_state, bytes_to_copy);
+
+  OP_REQUIRES_OK(ctx, status_or_event.status());
 }
 
 }  // namespace tensor_array

--- a/tensorflow/core/kernels/dml_tensor_array.h
+++ b/tensorflow/core/kernels/dml_tensor_array.h
@@ -38,7 +38,7 @@ struct DMLDeviceTag {};
 Status DmlAddToTensor(OpKernelContext* ctx, Tensor* sum, const Tensor* current,
                       const Tensor* add);
 
-Status DmlTensorSetZero(OpKernelContext* ctx, Tensor* value);
+void DmlTensorSetZero(OpKernelContext* ctx, Tensor* value);
 
 void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
                       absl::Span<PersistentTensor> values);
@@ -60,7 +60,8 @@ void DmlSplitTensor(OpKernelContext* ctx, Tensor* output_tensor,
   template <>                                                                 \
   inline Status TensorSetZero<DMLDeviceTag, T>(OpKernelContext * ctx,         \
                                                Tensor * value) {              \
-    return DmlTensorSetZero(ctx, value);                                      \
+    DmlTensorSetZero(ctx, value);                                             \
+    return Status::OK();                                                      \
   }                                                                           \
   template <>                                                                 \
   inline void ConcatTensors<DMLDeviceTag, T>(                                 \

--- a/tensorflow/core/kernels/dml_tile_op.cc
+++ b/tensorflow/core/kernels/dml_tile_op.cc
@@ -239,7 +239,7 @@ class DmlTileKernel : public DmlKernel {
     }
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -247,7 +247,8 @@ class DmlTileKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_tile_op.cc
+++ b/tensorflow/core/kernels/dml_tile_op.cc
@@ -246,8 +246,7 @@ class DmlTileKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_transpose_op.cc
+++ b/tensorflow/core/kernels/dml_transpose_op.cc
@@ -238,7 +238,7 @@ class DmlTransposeKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -246,7 +246,8 @@ class DmlTransposeKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      TF_RETURN_IF_ERROR(
+          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_transpose_op.cc
+++ b/tensorflow/core/kernels/dml_transpose_op.cc
@@ -246,8 +246,7 @@ class DmlTransposeKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     if (Is64BitIntegerType(output->dtype())) {
-      TF_RETURN_IF_ERROR(
-          ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_unpack_op.cc
+++ b/tensorflow/core/kernels/dml_unpack_op.cc
@@ -143,7 +143,7 @@ class DmlUnpackKernel : public DmlKernel {
     Initialize(ctx, std::move(tensors), op_desc);
   }
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
+  StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Currently, 64-bit integers in DML are emulated using 32-bit integers
     // using striding to emulate a larger type. Because we can't guarantee that
     // our output tensor's memory is zero'd, we need to do so manually prior to
@@ -152,7 +152,8 @@ class DmlUnpackKernel : public DmlKernel {
       Tensor* output = ctx->GetOutputTensor(i);
 
       if (Is64BitIntegerType(output->dtype())) {
-        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+        TF_RETURN_IF_ERROR(
+            ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
       }
     }
 

--- a/tensorflow/core/kernels/dml_unpack_op.cc
+++ b/tensorflow/core/kernels/dml_unpack_op.cc
@@ -152,8 +152,7 @@ class DmlUnpackKernel : public DmlKernel {
       Tensor* output = ctx->GetOutputTensor(i);
 
       if (Is64BitIntegerType(output->dtype())) {
-        TF_RETURN_IF_ERROR(
-            ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output)).status());
+        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
       }
     }
 

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -22,23 +22,34 @@ limitations under the License.
 
 namespace tensorflow {
 
-class DmlZerosLikeKernel : public DmlKernel {
+class DmlZerosLikeKernel : public OpKernel {
  public:
-  using InitHelper = NoOpInitializationHelper;
+  explicit DmlZerosLikeKernel(OpKernelConstruction* ctx) : OpKernel(ctx) {}
 
-  explicit DmlZerosLikeKernel(DmlKernelConstruction* ctx,
-                              const InitHelper* init_helper) {}
+  void Compute(OpKernelContext* ctx) override {
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(0, ctx->input(0).shape(), &output_tensor));
 
-  DmlGpuEvent Compute(DmlKernelContext* ctx) const override {
-    Tensor* output = ctx->GetOutputTensor(0);
-    return ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+    DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
+
+    D3D12BufferRegion output_buffer =
+        dml_util::CreateBufferForTensor(device, *output_tensor);
+
+    uint8_t pattern[] = {0};
+
+    auto status_or_event = device->GetExecutionContext()->FillBufferWithPattern(
+        output_buffer.Resource(), output_buffer.Offset(),
+        output_buffer.SizeInBytes(), pattern);
+
+    OP_REQUIRES_OK(ctx, status_or_event.status());
   }
 };
 
 #define REGISTER_DML_KERNEL(TYPE)                                     \
   REGISTER_KERNEL_BUILDER(                                            \
       Name("ZerosLike").Device(DEVICE_DML).TypeConstraint<TYPE>("T"), \
-      DmlKernelWrapper<DmlZerosLikeKernel, GetOutputShapeAsInputShapeHelper>);
+      DmlZerosLikeKernel);
 
 // TODO(b/25387198): A special kernel exists for int32 (see constant_op.cc).
 TF_CALL_DML_ALL_TYPES_EXCEPT_INT32(REGISTER_DML_KERNEL)

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -38,11 +38,9 @@ class DmlZerosLikeKernel : public OpKernel {
 
     uint8_t pattern[] = {0};
 
-    auto status_or_event = device->GetExecutionContext()->FillBufferWithPattern(
+    device->GetExecutionContext()->FillBufferWithPattern(
         output_buffer.Resource(), output_buffer.Offset(),
         output_buffer.SizeInBytes(), pattern);
-
-    OP_REQUIRES_OK(ctx, status_or_event.status());
   }
 };
 


### PR DESCRIPTION
OOM errors can happen anytime when closing a command list because we batch commands together and close the command list when the number of commands reaches a threshold. OOM errors should never crash the process, but should instead bubble up and eventually throw a ResourceExhausted exception at the python level. This change adds a Status to the return type of functions that can cause an OOM error and removes a bunch of dead code.