### PR TITLE
Add aliasing barriers after writes to GPU memory

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -215,9 +215,6 @@ void DmlCommandRecorder::CopyBufferRegion(
     std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
   }
 
-  D3D12_HEAP_PROPERTIES dst_heap_props;
-  DML_CHECK_SUCCEEDED(dst_buffer->GetHeapProperties(&dst_heap_props, nullptr));
-
   // Since this copy may write to GPU memory, we also need to perform an
   // aliasing barrier
   barriers.push_back(CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr));

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -104,7 +104,6 @@ Status DmlCommandRecorder::InitializeOperator(
   SetDescriptorHeap(descriptor_range.heap);
   recorder_->RecordDispatch(current_command_list_.Get(), initializer_.Get(),
                             binding_table.Get());
-  OnCommandRecorded();
 
   // Barrier if there's an output (i.e. persistent resource), or if any temps
   // are used.
@@ -115,6 +114,8 @@ Status DmlCommandRecorder::InitializeOperator(
         CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr)};
     current_command_list_->ResourceBarrier(ABSL_ARRAYSIZE(barriers), barriers);
   }
+
+  OnCommandRecorded();
 
   return Status::OK();
 }
@@ -175,7 +176,6 @@ Status DmlCommandRecorder::ExecuteOperator(
   SetDescriptorHeap(descriptor_range.heap);
   recorder_->RecordDispatch(current_command_list_.Get(), op,
                             binding_table.Get());
-  OnCommandRecorded();
 
   // Barrier all outputs.
   D3D12_RESOURCE_BARRIER barriers[] = {
@@ -183,16 +183,47 @@ Status DmlCommandRecorder::ExecuteOperator(
       CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr)};
   current_command_list_->ResourceBarrier(ABSL_ARRAYSIZE(barriers), barriers);
 
+  OnCommandRecorded();
+
   return Status::OK();
 }
 
-void DmlCommandRecorder::CopyBufferRegion(ID3D12Resource* dst_buffer,
-                                          uint64_t dst_offset,
-                                          ID3D12Resource* src_buffer,
-                                          uint64_t src_offset,
-                                          uint64_t byte_count) {
+void DmlCommandRecorder::CopyBufferRegion(
+    ID3D12Resource* dst_buffer, uint64_t dst_offset,
+    D3D12_RESOURCE_STATES dst_state, ID3D12Resource* src_buffer,
+    uint64_t src_offset, D3D12_RESOURCE_STATES src_state, uint64_t byte_count) {
+  absl::InlinedVector<D3D12_RESOURCE_BARRIER, 3> barriers;
+
+  if (!(dst_state & D3D12_RESOURCE_STATE_COPY_DEST)) {
+    barriers.push_back(CD3DX12_RESOURCE_BARRIER::Transition(
+        dst_buffer, dst_state, D3D12_RESOURCE_STATE_COPY_DEST));
+  }
+  if (!(src_state & D3D12_RESOURCE_STATE_COPY_SOURCE)) {
+    barriers.push_back(CD3DX12_RESOURCE_BARRIER::Transition(
+        src_buffer, src_state, D3D12_RESOURCE_STATE_COPY_SOURCE));
+  }
+
+  if (!barriers.empty()) {
+    current_command_list_->ResourceBarrier(barriers.size(), barriers.data());
+  }
+
   current_command_list_->CopyBufferRegion(dst_buffer, dst_offset, src_buffer,
                                           src_offset, byte_count);
+
+  // Reset barrier state
+  for (auto& barrier : barriers) {
+    std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
+  }
+
+  D3D12_HEAP_PROPERTIES dst_heap_props;
+  DML_CHECK_SUCCEEDED(dst_buffer->GetHeapProperties(&dst_heap_props, nullptr));
+
+  // Since this copy may write to GPU memory, we also need to perform an
+  // aliasing barrier
+  barriers.push_back(CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr));
+
+  current_command_list_->ResourceBarrier(barriers.size(), barriers.data());
+
   OnCommandRecorded();
 }
 
@@ -257,13 +288,14 @@ void DmlCommandRecorder::FillBufferWithPattern(
   current_command_list_->ClearUnorderedAccessViewUint(
       descriptor_range_gpu.gpu_handle, descriptor_range_cpu.cpu_handle, dst,
       fillPattern.integers, 0, nullptr);
-  OnCommandRecorded();
 
   // Barrier all outputs.
   D3D12_RESOURCE_BARRIER barriers[] = {
       CD3DX12_RESOURCE_BARRIER::UAV(nullptr),
       CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr)};
   current_command_list_->ResourceBarrier(ABSL_ARRAYSIZE(barriers), barriers);
+
+  OnCommandRecorded();
 }
 
 void DmlCommandRecorder::ExecuteCommandList(

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -110,8 +110,10 @@ Status DmlCommandRecorder::InitializeOperator(
   // are used.
   if ((persistent_resource_binding.Type != DML_BINDING_TYPE_NONE) ||
       (temporary_resource_size > 0)) {
-    auto barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
-    current_command_list_->ResourceBarrier(1, &barrier);
+    D3D12_RESOURCE_BARRIER barriers[] = {
+        CD3DX12_RESOURCE_BARRIER::UAV(nullptr),
+        CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr)};
+    current_command_list_->ResourceBarrier(ABSL_ARRAYSIZE(barriers), barriers);
   }
 
   return Status::OK();
@@ -176,8 +178,10 @@ Status DmlCommandRecorder::ExecuteOperator(
   OnCommandRecorded();
 
   // Barrier all outputs.
-  auto barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
-  current_command_list_->ResourceBarrier(1, &barrier);
+  D3D12_RESOURCE_BARRIER barriers[] = {
+      CD3DX12_RESOURCE_BARRIER::UAV(nullptr),
+      CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr)};
+  current_command_list_->ResourceBarrier(ABSL_ARRAYSIZE(barriers), barriers);
 
   return Status::OK();
 }
@@ -256,8 +260,10 @@ void DmlCommandRecorder::FillBufferWithPattern(
   OnCommandRecorded();
 
   // Barrier all outputs.
-  auto barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
-  current_command_list_->ResourceBarrier(1, &barrier);
+  D3D12_RESOURCE_BARRIER barriers[] = {
+      CD3DX12_RESOURCE_BARRIER::UAV(nullptr),
+      CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr)};
+  current_command_list_->ResourceBarrier(ABSL_ARRAYSIZE(barriers), barriers);
 }
 
 void DmlCommandRecorder::ExecuteCommandList(

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.h
@@ -42,8 +42,9 @@ class DmlCommandRecorder {
                          absl::Span<const DML_BINDING_DESC> output_bindings);
 
   void CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
+                        D3D12_RESOURCE_STATES dst_state,
                         ID3D12Resource* src_buffer, uint64_t src_offset,
-                        uint64_t byte_count);
+                        D3D12_RESOURCE_STATES src_state, uint64_t byte_count);
 
   void FillBufferWithPattern(
       ID3D12Resource* dst, uint64_t dst_offset, uint64_t dst_size_in_bytes,

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -43,35 +43,8 @@ DmlGpuEvent DmlExecutionContextImpl::CopyBufferRegion(
   assert(!closed_);
 
   SetCommandRecorder(&dml_recorder_);
-
-  absl::InlinedVector<D3D12_RESOURCE_BARRIER, 3> barriers;
-
-  if (!(dst_state & D3D12_RESOURCE_STATE_COPY_DEST)) {
-    barriers.push_back(CD3DX12_RESOURCE_BARRIER::Transition(
-        dst_buffer, dst_state, D3D12_RESOURCE_STATE_COPY_DEST));
-  }
-  if (!(src_state & D3D12_RESOURCE_STATE_COPY_SOURCE)) {
-    barriers.push_back(CD3DX12_RESOURCE_BARRIER::Transition(
-        src_buffer, src_state, D3D12_RESOURCE_STATE_COPY_SOURCE));
-  }
-
-  if (!barriers.empty()) {
-    dml_recorder_.ResourceBarrier(barriers);
-  }
-
-  dml_recorder_.CopyBufferRegion(dst_buffer, dst_offset, src_buffer, src_offset,
-                                 byte_count);
-
-  // Reset barrier state
-  for (auto& barrier : barriers) {
-    std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
-  }
-
-  // Since we modified GPU memory, perform an aliasing barrier
-  barriers.push_back(CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr));
-
-  dml_recorder_.ResourceBarrier(barriers);
-
+  dml_recorder_.CopyBufferRegion(dst_buffer, dst_offset, dst_state, src_buffer,
+                                 src_offset, src_state, byte_count);
   return GetCurrentCompletionEvent();
 }
 
@@ -79,6 +52,7 @@ DmlGpuEvent DmlExecutionContextImpl::FillBufferWithPattern(
     ID3D12Resource* dst, uint64_t dst_offset, uint64_t dst_size_in_bytes,
     absl::Span<const uint8_t>
         value /* Data type agnostic value, treated as raw bits */) {
+  assert(!closed_);
   SetCommandRecorder(&dml_recorder_);
   dml_recorder_.FillBufferWithPattern(dst, dst_offset, dst_size_in_bytes,
                                       value);


### PR DESCRIPTION
Because we now write to memory through placed resources, we should be using aliasing barriers as the resources alias the same heap memory. We haven't actually observed any failures yet due to missing aliasing barriers, but strictly speaking by the D3D12 spec they are required between reads and writes of the same physical memory if those accesses occur through different resources.

The rule for where we need to place aliasing barriers is very similar to UAV barriers, except that it also applies to copies (not just dispatches and clears).

This change also moves a couple of calls to `OnCommandRecorded`. OnCommandRecorded can flush, so it doesn't really make sense to perform barriers immediately *after* a flush.