### PR TITLE
Add the DISABLE_GPU_TIMEOUT flag to the command queue

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_device_state.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_state.cc
@@ -70,7 +70,7 @@ namespace tensorflow {
   D3D12_COMMAND_QUEUE_DESC command_queue_desc = {};
   command_queue_desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
   command_queue_desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
-  command_queue_desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+  command_queue_desc.Flags = D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT;
   command_queue_desc.NodeMask = 0;
 
   ComPtr<ID3D12CommandQueue> command_queue;


### PR DESCRIPTION
Sets the `D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT` flag on the D3D12 command queue. This resolves an issue where running AIBenchmark would cause a TDR on AMD 5700XT devices due to timeout.