### PR TITLE
Resurrect core tests

### DIFF
--- a/third_party/dml/ci/build/nightly_build.yml
+++ b/third_party/dml/ci/build/nightly_build.yml
@@ -76,6 +76,6 @@ jobs:
         $Ado.QueuePipeline(
             $TestPipeline.id,
             $null,
-            @{'BuildId' = $env:Build_BuildId; 'EmailTo' = '$(EmailTo)'; 'TestGroups' = '$(TestGroups)'; 'Artifacts' = '$(TestArtifacts)'},
+            @{'BuildId' = $env:Build_BuildId; 'EmailTo' = '$(EmailTo)'; 'TestGroups' = '$(TestGroups)'; 'Artifacts' = '$(TestArtifacts)'; 'WslArtifacts' = '$(WslTestArtifacts)'},
             $env:Build_SourceBranch,
             $env:Build_SourceVersion)

--- a/third_party/dml/ci/test/DispatchTestJobs.ps1
+++ b/third_party/dml/ci/test/DispatchTestJobs.ps1
@@ -144,7 +144,7 @@ foreach ($AgentInfo in $AgentsInfo)
             'RunOnWsl' = $AgentInfo.RunOnWsl;
         }
 
-        Write-Host $Params
+        Write-Host $Params.Artifacts
 
         $Build = $Ado.QueuePipeline(
             $Pipeline.id, 

--- a/third_party/dml/ci/test/DispatchTestJobs.ps1
+++ b/third_party/dml/ci/test/DispatchTestJobs.ps1
@@ -144,6 +144,8 @@ foreach ($AgentInfo in $AgentsInfo)
             'RunOnWsl' = $AgentInfo.RunOnWsl;
         }
 
+        Write-Host $Params
+
         $Build = $Ado.QueuePipeline(
             $Pipeline.id, 
             $AgentInfo.AgentQueueId,

--- a/third_party/dml/ci/test/DispatchTestJobs.ps1
+++ b/third_party/dml/ci/test/DispatchTestJobs.ps1
@@ -83,19 +83,19 @@ foreach ($Agent in $Agents)
 
 foreach ($WslAgent in $WslAgents)
 {
-    $AgentInfo = 
+    $WslAgentInfo = 
     @{
-        'Name' = $Agent.Name;
-        'Status' = $Agent.Status;
-        'Enabled' = $Agent.Enabled;
-        'UserCapabilities' = $Agent.UserCapabilities;
+        'Name' = $WslAgent.Name;
+        'Status' = $WslAgent.Status;
+        'Enabled' = $WslAgent.Enabled;
+        'UserCapabilities' = $WslAgent.UserCapabilities;
         'RunOnWsl' = 1;
         'TestPoolName' = $WslTestPoolName;
         'AgentQueueId' = $WslAgentQueue.id;
         'Artifacts' = $WslArtifacts;
     }
 
-    $AgentsInfo.Add($AgentInfo)
+    $AgentsInfo.Add($WslAgentInfo)
 }
 
 $DispatchedJobs = [System.Collections.ArrayList]::new()

--- a/third_party/dml/ci/test/DispatchTestJobs.ps1
+++ b/third_party/dml/ci/test/DispatchTestJobs.ps1
@@ -144,8 +144,6 @@ foreach ($AgentInfo in $AgentsInfo)
             'RunOnWsl' = $AgentInfo.RunOnWsl;
         }
 
-        Write-Host $Params.Artifacts
-
         $Build = $Ado.QueuePipeline(
             $Pipeline.id, 
             $AgentInfo.AgentQueueId,

--- a/third_party/dml/ci/test/DispatchTestJobs.ps1
+++ b/third_party/dml/ci/test/DispatchTestJobs.ps1
@@ -19,6 +19,9 @@ Param
     # Comma-separated list of build artifacts to test.
     [string]$Artifacts,
 
+    # Comma-separated list of WSL build artifacts to test.
+    [string]$WslArtifacts,
+
     # Comma-separated list of test groups to run on each agent.
     [string]$TestGroups,
 
@@ -27,6 +30,9 @@ Param
 
     # Name of the agent pool to receive dispatched jobs.
     [string]$TestPoolName = 'DirectML',
+
+    # Name of the agent pool to receive dispatched jobs for WSL.
+    [string]$WslTestPoolName = 'DirectML-WSL',
 
     # Path to store test artifacts from dispatched jobs.
     [string]$TestArtifactsPath = 'dispatch_artifacts',
@@ -47,36 +53,78 @@ $Ado = [ADOHelper]::CreateFromPipeline($AccessToken)
 $TriggerPipeline = $Ado.GetBuild($BuildID)
 
 $Pipeline = $Ado.GetBuildDefinition($TestPipelineName)
+
 $AgentPool = $Ado.GetAgentPool($TestPoolName)
 $AgentQueue = $Ado.GetAgentQueue($TestPoolName)
 $Agents = $Ado.GetAgents($AgentPool.id)
-$DispatchedJobs = [System.Collections.ArrayList]::new()
+
+$WslAgentPool = $Ado.GetAgentPool($WslTestPoolName)
+$WslAgentQueue = $Ado.GetAgentQueue($WslTestPoolName)
+$WslAgents = $Ado.GetAgents($WslAgentPool.id)
+
+$AgentsInfo = [System.Collections.ArrayList]::new()
 
 foreach ($Agent in $Agents)
 {
+    $AgentInfo = 
+    @{
+        'Name' = $Agent.Name;
+        'Status' = $Agent.Status;
+        'Enabled' = $Agent.Enabled;
+        'UserCapabilities' = $Agent.UserCapabilities;
+        'RunOnWsl' = 0;
+        'TestPoolName' = $TestPoolName;
+        'AgentQueueId' = $AgentQueue.id;
+        'Artifacts' = $Artifacts;
+    }
+
+    $AgentsInfo.Add($AgentInfo)
+}
+
+foreach ($WslAgent in $WslAgents)
+{
+    $AgentInfo = 
+    @{
+        'Name' = $Agent.Name;
+        'Status' = $Agent.Status;
+        'Enabled' = $Agent.Enabled;
+        'UserCapabilities' = $Agent.UserCapabilities;
+        'RunOnWsl' = 1;
+        'TestPoolName' = $WslTestPoolName;
+        'AgentQueueId' = $WslAgentQueue.id;
+        'Artifacts' = $WslArtifacts;
+    }
+
+    $AgentsInfo.Add($AgentInfo)
+}
+
+$DispatchedJobs = [System.Collections.ArrayList]::new()
+
+foreach ($AgentInfo in $AgentsInfo)
+{
     $JobInfo = 
     @{
-        'AgentName' = $Agent.Name; 
-        'AgentStatus' = $Agent.Status; 
-        'AgentEnabled' = $Agent.Enabled; 
+        'AgentName' = $AgentInfo.Name; 
+        'AgentStatus' = $AgentInfo.Status; 
+        'AgentEnabled' = $AgentInfo.Enabled; 
         'IsSlowRing' = $false;
     }
 
-    if (!$Agent.Enabled)
+    if (!$AgentInfo.Enabled)
     {
         Write-Host "Agent $($JobInfo.AgentName) is disabled. Skipping."
     }
-    elseif ($Agent.Status -ne 'online')
+    elseif ($AgentInfo.Status -ne 'online')
     {
         Write-Host "Agent $($JobInfo.AgentName) is offline. Skipping."
     }
-    elseif ($SkipSlowRingAgents -and $Agent.UserCapabilities.'AP.SlowRing')
+    elseif ($SkipSlowRingAgents -and $AgentInfo.UserCapabilities.'AP.SlowRing')
     {
-        Write-Host "Agent $($Agent.Name) is in the slow ring. Skipping."
+        Write-Host "Agent $($AgentInfo.Name) is in the slow ring. Skipping."
         $JobInfo.AgentEnabled = $false
         $JobInfo.IsSlowRing = $true
     }
-    elseif ($Agent.UserCapabilities.'AP.TargetXbox')
+    elseif ($AgentInfo.UserCapabilities.'AP.TargetXbox')
     {
         # TensorFlow does not run on Xbox. Skip any agents that have the AP.TargetXbox capability
         # set, which indicates a proxy agent that deploys tests to an Xbox device.
@@ -86,18 +134,19 @@ foreach ($Agent in $Agents)
     {
         $Params = 
         @{
-            'Artifacts' = $Artifacts;
+            'Artifacts' = $AgentInfo.Artifacts;
             'TestGroups' = $TestGroups;
             'Pipeline' = $TriggerPipeline.Definition.Name;
             'PipelineBuildID' = $BuildID;
-            'AgentName' = $Agent.Name;
-            'AgentPool' = $TestPoolName;
+            'AgentName' = $AgentInfo.Name;
+            'AgentPool' = $AgentInfo.TestPoolName;
             'TimeoutMinutes' = ($TimeoutMinutes - 5);
+            'RunOnWsl' = $AgentInfo.RunOnWsl;
         }
 
         $Build = $Ado.QueuePipeline(
             $Pipeline.id, 
-            $AgentQueue.id,
+            $AgentInfo.AgentQueueId,
             $Params, 
             $env:Build_SourceBranch, 
             $env:Build_SourceVersion)

--- a/third_party/dml/ci/test/nightly_test.yml
+++ b/third_party/dml/ci/test/nightly_test.yml
@@ -6,9 +6,11 @@
 # The following variables are set in the pipeline web UI:
 # - (required) ControlPool : name of the ADO agent pool that runs the dispatch/report job in this pipeline.
 # - (required) TestPool : name of the ADO agent pool to test. All active agents in this pool will be tested.
+# - (required) WslTestPool : name of the ADO agent pool to test for WSL. All active agents in this pool will be tested.
 # - (required) BuildID : ID of the build to test.
 # - (required) TestGroups : comma-separated list of test groups to test. e.g. 'python,core'
 # - (required) Artifacts : comma-separated list of build artifacts to test. e.g. 'x64-win-release-cp36'
+# - (required) WslArtifacts : comma-separated list of WSL build artifacts to test. e.g. 'x64-linux-release-cp36'
 # - (required) AccessToken : personal access token to use REST API for dispatching tests.
 # - (optional) EmailTo : email address to receive generated HTML report. If empty, no email is sent.
 

--- a/third_party/dml/ci/test/templates/test_artifact_steps.yml
+++ b/third_party/dml/ci/test/templates/test_artifact_steps.yml
@@ -13,7 +13,7 @@ parameters:
 steps:
 - task: DownloadBuildArtifacts@0
   displayName: Download ${{parameters.Artifact}}
-  condition: contains(variables.Artifacts, ${{parameters.Artifact}})
+  condition: contains(variables.Artifacts, '${{parameters.Artifact}}')
   inputs:
     buildType: specific
     project: WindowsAI

--- a/third_party/dml/ci/test/templates/test_artifact_steps.yml
+++ b/third_party/dml/ci/test/templates/test_artifact_steps.yml
@@ -13,7 +13,7 @@ parameters:
 steps:
 - task: DownloadBuildArtifacts@0
   displayName: Download ${{parameters.Artifact}}
-  condition: contains(variables.Artifacts, '${{parameters.Artifact}}')
+  condition: contains(variables.Artifacts, ${{parameters.Artifact}})
   inputs:
     buildType: specific
     project: WindowsAI

--- a/third_party/dml/ci/test/templates/test_artifact_steps.yml
+++ b/third_party/dml/ci/test/templates/test_artifact_steps.yml
@@ -13,7 +13,7 @@ parameters:
 steps:
 - task: DownloadBuildArtifacts@0
   displayName: Download ${{parameters.Artifact}}
-  condition: contains(variables.Artifacts, '${{parameters.Artifact}}')
+  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   inputs:
     buildType: specific
     project: WindowsAI
@@ -26,7 +26,7 @@ steps:
 
 - task: PowerShell@2
   displayName: Test ${{parameters.Artifact}}
-  condition: contains(variables.Artifacts, '${{parameters.Artifact}}')
+  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   inputs:
     targetType: filePath
     filePath: $(System.ArtifactsDirectory)/${{parameters.Artifact}}/TestAgent.ps1
@@ -39,11 +39,11 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: Upload ${{parameters.Artifact}} Test Results
-  condition: contains(variables.Artifacts, '${{parameters.Artifact}}')
+  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   inputs:
     pathToPublish: $(System.ArtifactsDirectory)/test
     artifactName: $(AgentName)
 
 - powershell: Remove-Item -Path "$(System.ArtifactsDirectory)/test/${{parameters.Artifact}}" -Recurse -Force
-  condition: contains(variables.Artifacts, '${{parameters.Artifact}}')
+  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   displayName: Cleanup Artifacts

--- a/third_party/dml/ci/test/templates/test_artifact_steps.yml
+++ b/third_party/dml/ci/test/templates/test_artifact_steps.yml
@@ -13,7 +13,6 @@ parameters:
 steps:
 - task: DownloadBuildArtifacts@0
   displayName: Download ${{parameters.Artifact}}
-  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   inputs:
     buildType: specific
     project: WindowsAI
@@ -26,7 +25,6 @@ steps:
 
 - task: PowerShell@2
   displayName: Test ${{parameters.Artifact}}
-  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   inputs:
     targetType: filePath
     filePath: $(System.ArtifactsDirectory)/${{parameters.Artifact}}/TestAgent.ps1
@@ -39,11 +37,9 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: Upload ${{parameters.Artifact}} Test Results
-  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   inputs:
     pathToPublish: $(System.ArtifactsDirectory)/test
     artifactName: $(AgentName)
 
 - powershell: Remove-Item -Path "$(System.ArtifactsDirectory)/test/${{parameters.Artifact}}" -Recurse -Force
-  condition: contains(variables.Artifacts, '$[parameters.Artifact]')
   displayName: Cleanup Artifacts

--- a/third_party/dml/ci/test/templates/test_artifact_steps.yml
+++ b/third_party/dml/ci/test/templates/test_artifact_steps.yml
@@ -8,6 +8,7 @@ parameters:
   PipelineBuildID: ''  # ID of the specific build from the named build pipeline to test (e.g. '15958541')
   Artifact: ''         # Name of the build artifact to test (e.g. 'x64-release')
   TestGroups: ''       # Comma-separated list of test groups to run
+  RunOnWsl: 0          # Whether we should run the tests on WSL or not
 
 steps:
 - task: DownloadBuildArtifacts@0
@@ -33,7 +34,7 @@ steps:
       -TestGroups ${{parameters.TestGroups}}
       -BuildArtifactsPath $(System.ArtifactsDirectory)/${{parameters.Artifact}}
       -TestArtifactsPath $(System.ArtifactsDirectory)/test/${{parameters.Artifact}}
-      -TensorFlowWheelPath $(System.ArtifactsDirectory)/${{parameters.Artifact}}/tensorflow_directml-*-win_amd64.whl
+      -RunOnWsl ${{parameters.RunOnWsl}}
     errorActionPreference: continue
 
 - task: PublishBuildArtifacts@1

--- a/third_party/dml/ci/test/templates/test_build_steps.yml
+++ b/third_party/dml/ci/test/templates/test_build_steps.yml
@@ -16,10 +16,12 @@ steps:
     filePath: third_party/dml/ci/test/DispatchTestJobs.ps1
     arguments: >
       -Artifacts "$(Artifacts)"
+      -WslArtifacts "$(WslArtifacts)"
       -BuildID $(BuildID) 
       -TestGroups "$(TestGroups)"
       -TestArtifactsPath ${{parameters.TestArtifactsPath}}
       -TestPoolName $(TestPool)
+      -WslTestPoolName $(WslTestPool)
       -TimeoutMinutes ${{parameters.TimeoutInMinutes}}
       -AccessToken $(AccessToken)
       -SkipSlowRingAgents ${{parameters.SkipSlowRingAgents}}

--- a/third_party/dml/ci/test/test_agent.yml
+++ b/third_party/dml/ci/test/test_agent.yml
@@ -53,7 +53,7 @@ jobs:
 
   - template: templates/test_artifact_steps.yml
     parameters:
-      Artifact: $(Artifacts)
+      Artifact: '$(Artifacts)'
       TestGroups: $(TestGroups)
       Pipeline: $(Pipeline)
       PipelineBuildID: $(PipelineBuildID)

--- a/third_party/dml/ci/test/test_agent.yml
+++ b/third_party/dml/ci/test/test_agent.yml
@@ -53,7 +53,7 @@ jobs:
 
   - template: templates/test_artifact_steps.yml
     parameters:
-      Artifact: '$(Artifacts)'
+      Artifact: 'lalala'
       TestGroups: $(TestGroups)
       Pipeline: $(Pipeline)
       PipelineBuildID: $(PipelineBuildID)

--- a/third_party/dml/ci/test/test_agent.yml
+++ b/third_party/dml/ci/test/test_agent.yml
@@ -53,7 +53,7 @@ jobs:
 
   - template: templates/test_artifact_steps.yml
     parameters:
-      Artifact: 'lalala'
+      Artifact: $(TestGroups)
       TestGroups: $(TestGroups)
       Pipeline: $(Pipeline)
       PipelineBuildID: $(PipelineBuildID)

--- a/third_party/dml/ci/test/test_agent.yml
+++ b/third_party/dml/ci/test/test_agent.yml
@@ -11,6 +11,7 @@
 # - (required) PipelineBuildID : ID of the build pipeline that produced artifacts to test
 # - (required) TestGroups : comma-separated list of test groups to test. e.g. 'python,core'
 # - (required) TimeoutMinutes : number of minutes allowed to test before the job is canceled
+# - (required) RunOnWsl : whether this agent should run the WSL tests or not
 
 name: 'test.$(AgentName)-$(PipelineBuildID)$(Rev:.r)'
 
@@ -52,7 +53,8 @@ jobs:
 
   - template: templates/test_artifact_steps.yml
     parameters:
-      Artifact: 'x64-win-release-cp36'
+      Artifact: $(Artifacts)
       TestGroups: $(TestGroups)
       Pipeline: $(Pipeline)
       PipelineBuildID: $(PipelineBuildID)
+      RunOnWsl: $(RunOnWsl)

--- a/third_party/dml/ci/test/test_agent.yml
+++ b/third_party/dml/ci/test/test_agent.yml
@@ -53,7 +53,7 @@ jobs:
 
   - template: templates/test_artifact_steps.yml
     parameters:
-      Artifact: $(TestGroups)
+      Artifact: $(Artifacts)
       TestGroups: $(TestGroups)
       Pipeline: $(Pipeline)
       PipelineBuildID: $(PipelineBuildID)


### PR DESCRIPTION
- Resurrect the core tests by extracting the right DirectML DLL from the python package, renaming it to DirectML.dll and setting `TF_DIRECTML_PATH` to its location
- Onboard the remapper tests to make sure that the new fusions that we added in our branch don't break anything