### PR TITLE
Resurrect core tests

### DIFF
--- a/build.py
+++ b/build.py
@@ -125,7 +125,6 @@ def build_tests(args):
                 "-no_dml",
                 "-no_oss",
                 "-benchmark-test",
-                "-manual",
                 "dml",
             ],
         )

--- a/build.py
+++ b/build.py
@@ -156,6 +156,14 @@ def build_tests(args):
       cl.append("--copt /FS")
       cl.append("--linkopt /DEBUG:FASTLINK")
 
+    # This is necessary because of name clashes when bazel tries to copy 2 DLLs
+    # with the same name but different paths into the binary folder. This
+    # doesn't affect the python package, but it's required to reliably build the
+    # core tests.
+    # https://github.com/bazelbuild/bazel/issues/11515
+    if sys.platform == "win32":
+      cl.append("--dynamic_mode=off")
+
     # For now, since we only want to run the core tests tagged as "dml", we need
     # to run the command multiple times. Even though bazel allows multiple
     # targets to be built from the same command, they will have the same

--- a/build.py
+++ b/build.py
@@ -125,6 +125,7 @@ def build_tests(args):
                 "-no_dml",
                 "-no_oss",
                 "-benchmark-test",
+                "-manual",
                 "dml",
             ],
         )

--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -817,6 +817,9 @@ tf_cuda_cc_test(
         "//tensorflow/core/grappler/inputs:trivial_test_graph_input_yielder",
         "//tensorflow/core/grappler/utils:grappler_test",
     ],
+    tags = [
+        "dml",
+    ],
 )
 
 tf_cc_test_mkl(

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -58,7 +58,7 @@ class RemapperTest : public GrapplerTest {
 
     auto pad = ops::Pad(s.WithOpName("pad"), input, paddings);
 
-    constexpr auto explicit_paddings = {0, 0, 7, 10, 8, 2, 0, 0};
+    constexpr int explicit_paddings[] = {0, 0, 7, 10, 8, 2, 0, 0};
     ops::Conv2D::Attrs attrs;
 
     if (padding_type == "EXPLICIT") {

--- a/third_party/dml/ci/build/bazel_helpers.py
+++ b/third_party/dml/ci/build/bazel_helpers.py
@@ -230,7 +230,14 @@ class BazelEnv:
 
     # Convert the bazel path to relative filesystem paths
     tests_info = []
-    test_data_bazel_paths = set()
+    bazel_paths = set()
+
+    for rule in xml_root.iter("rule"):
+      # Save the executable path in the set so we can quickly check if
+      # executables with the _gpu suffix have an equivalent executable without
+      # the _gpu suffix
+      bazel_path = rule.get("name")
+      bazel_paths.add(bazel_path)
 
     bin_path = self._get_bin_path(py_version)
 
@@ -242,7 +249,7 @@ class BazelEnv:
       # without "_gpu", except that they have benchmarking enabled. Since we
       # don't need these benchmarking executables for our test loop, keeping
       # them doesn't give us anything.
-      if bazel_path.endswith("_gpu"):
+      if bazel_path.endswith("_gpu") and bazel_path[:-4] in bazel_paths:
         continue
 
       if os.name == "nt":

--- a/third_party/dml/ci/build/gather_test_binaries.py
+++ b/third_party/dml/ci/build/gather_test_binaries.py
@@ -108,6 +108,7 @@ def main():
               "-no_dml",
               "-no_oss",
               "-benchmark-test",
+              "-manual",
               "dml",
           ]
       ),

--- a/third_party/dml/ci/build/gather_test_binaries.py
+++ b/third_party/dml/ci/build/gather_test_binaries.py
@@ -108,7 +108,6 @@ def main():
               "-no_dml",
               "-no_oss",
               "-benchmark-test",
-              "-manual",
               "dml",
           ]
       ),

--- a/third_party/dml/ci/test/conda_helpers.py
+++ b/third_party/dml/ci/test/conda_helpers.py
@@ -61,11 +61,18 @@ class CondaEnv:
         shell=True,
         check=True)
 
-  def run(self, args):
+  def run(self, args, variables=None):
     args_string = " ".join(args)
+
+    env = None
+
+    if variables is not None:
+      env = {**os.environ, **variables}
+
     subprocess.run(
         f"{self.hook_command}"
         f" && conda activate {self.env_name}"
         f" && python {args_string}",
         shell=True,
-        check=True)
+        check=True,
+        env=env)

--- a/third_party/dml/ci/test/run_tests.py
+++ b/third_party/dml/ci/test/run_tests.py
@@ -81,11 +81,15 @@ def main():
 
           # Rename the DLL to DirectML.dll since TF_DIRECTML_PATH only works
           # with that name
-          dll_folder = f"{temp_dir}/_solib_directml"
-          old_dll_path = glob.glob(f"{dll_folder}/DirectML*.dll")[0]
-          new_dll_path = f"{dll_folder}/DirectML.dll"
-          os.rename(old_dll_path, new_dll_path)
-          conda_env.run(command_line, {"TF_DIRECTML_PATH": dll_folder})
+          lib_folder = f"{temp_dir}/_solib_directml"
+
+          old_glob = "DirectML*.dll" if os.name == "nt" else "libdirectml.so.*"
+          new_name = "DirectML.dll" if os.name == "nt" else "libdirectml.so"
+
+          old_lib_path = glob.glob(f"{lib_folder}/{old_glob}")[0]
+          new_lib_path = f"{lib_folder}/{new_name}"
+          os.rename(old_lib_path, new_lib_path)
+          conda_env.run(command_line, {"TF_DIRECTML_PATH": lib_folder})
       else:
         conda_env.run(command_line)
 


### PR DESCRIPTION
- Resurrect the core tests by extracting the right DirectML DLL from the python package, renaming it to DirectML.dll and setting `TF_DIRECTML_PATH` to its location
- Onboard the remapper tests to make sure that the new fusions that we added in our branch don't break anything