### PR TITLE
Handle device hung removal

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -364,7 +364,7 @@ void DmlCommandRecorder::CloseAndExecute() {
 
   HRESULT device_removed_reason = dml_device_->GetDeviceRemovedReason();
 
-  if (device_removed_reason == S_OK) {
+  if (SUCCEEDED(device_removed_reason)) {
     device_removed_reason = d3d_device_->GetDeviceRemovedReason();
   }
 
@@ -374,8 +374,8 @@ void DmlCommandRecorder::CloseAndExecute() {
         "Device was removed because of the following reason: ",
         dml_util::StringifyDeviceRemovedReason(device_removed_reason),
         ". This can happen when the GPU times out or when there's a problem in "
-        "the driver. You won't be able to use DML devices until you restart "
-        "the process.");
+        "the driver. You won't be able to keep using DML devices in the "
+        "current process.");
     return;
   }
 

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -74,6 +74,8 @@ class DmlExecutionContextImpl {
   // on the GPU.
   StatusOr<DmlGpuEvent> Flush();
 
+  Status GetCommandRecorderStatus() const;
+
   // Returns an event which will become signaled when everything submitted to
   // the execution context thus far has completed execution on the GPU,
   // including work that has yet to be flushed to the queue.
@@ -154,6 +156,10 @@ class DmlExecutionContext {
   StatusOr<DmlGpuEvent> Flush() {
     std::unique_lock<std::mutex> lock(mutex_);
     return impl_->Flush();
+  }
+
+  Status GetCommandRecorderStatus() const {
+    return impl_->GetCommandRecorderStatus();
   }
 
   DmlGpuEvent GetCurrentCompletionEvent() {

--- a/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
@@ -72,7 +72,10 @@ StatusOr<DmlGpuEvent> DmlReadbackHeap::ReadbackFromGpu(
 
   // Note that we don't need to keep a ref on the readback_heap, because the
   // pooled allocator guarantees it'll live until we give the signal
-  auto done_callback = [dst, readback_heap, offset_in_chunk, done_event] {
+  auto done_callback = [this, dst, readback_heap, offset_in_chunk, done_event] {
+    // The device could have been removed before the callback is called
+    if (!execution_context_->GetCommandRecorderStatus().ok()) return;
+
     void* readback_heap_data = nullptr;
     DML_CHECK_SUCCEEDED(readback_heap->Map(0, nullptr, &readback_heap_data));
     readback_heap_data =

--- a/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
@@ -33,6 +33,7 @@ StatusOr<DmlGpuEvent> DmlUploadHeap::BeginUploadToGpu(
     ID3D12Resource* dst, uint64_t dst_offset, D3D12_RESOURCE_STATES dst_state,
     absl::Span<const uint8_t> src) {
   std::unique_lock<std::mutex> lock(mutex_);
+  TF_RETURN_IF_ERROR(execution_context_->GetCommandRecorderStatus());
 
   assert(!src.empty());
   assert(dst->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER);

--- a/tensorflow/core/common_runtime/dml/dml_util.h
+++ b/tensorflow/core/common_runtime/dml/dml_util.h
@@ -94,6 +94,26 @@ inline bool HrIsOutOfMemory(HRESULT hr) {
   // when building winerror.h, so we check both potential values here
   return hr == 0x80000002 || hr == 0x8007000e;
 }
+
+inline absl::string_view StringifyDeviceRemovedReason(HRESULT reason) {
+  switch (reason) {
+    case DXGI_ERROR_DEVICE_HUNG:
+      return "DXGI_ERROR_DEVICE_HUNG";
+    case DXGI_ERROR_DEVICE_REMOVED:
+      return "DXGI_ERROR_DEVICE_REMOVED";
+    case DXGI_ERROR_DEVICE_RESET:
+      return "DXGI_ERROR_DEVICE_RESET";
+    case DXGI_ERROR_DRIVER_INTERNAL_ERROR:
+      return "DXGI_ERROR_DRIVER_INTERNAL_ERROR";
+    case DXGI_ERROR_INVALID_CALL:
+      return "DXGI_ERROR_INVALID_CALL";
+    case S_OK:
+      return "S_OK";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 }  // namespace dml_util
 
 }  // namespace tensorflow

--- a/tensorflow/core/grappler/clusters/utils.cc
+++ b/tensorflow/core/grappler/clusters/utils.cc
@@ -159,6 +159,13 @@ DeviceProperties GetLocalDMLInfo(int device_id) {
 
 #if TENSORFLOW_USE_DIRECTML
   auto adapters = EnumerateAdapters();
+
+  // When the D3D12 or DML device is removed after initially enumerating the
+  // devices, the adapters list will be empty
+  if (adapters.empty()) {
+    return device;
+  }
+
   CHECK(device_id >= 0 && device_id < adapters.size());
 
   const auto& adapter = adapters[device_id];


### PR DESCRIPTION
Device hung errors should allow the user to fallback instead of crashing the process.