### PR TITLE
Fix default window sizes for StridedSlice

### DIFF
--- a/tensorflow/core/kernels/dml_strided_slice_op.cc
+++ b/tensorflow/core/kernels/dml_strided_slice_op.cc
@@ -61,7 +61,7 @@ static absl::optional<SimplifiedSlice> SimplifySlice(
   desc.input_strides.resize(max_output_size, 1);
   desc.output_sizes.resize(max_output_size, 1);
   desc.window_offset.resize(max_output_size, 0);
-  desc.window_sizes.resize(max_output_size, 0);
+  desc.window_sizes.resize(max_output_size, 1);
   desc.window_strides.resize(max_output_size, 1);
 
   int current_dim = max_output_size - 1;


### PR DESCRIPTION
When the input size and output size of a dimension are equal, the kernel logic tries to collapse window dimensions together in order to allow more dimensions to be supported. But when it does so, it doesn't overwrite the default values which are set to 0. This problem was previously hidden by the fact that DML didn't validate the range of the window sizes, and it just happened that the kernel worked when `WindowSize[i] == 0`.