### PR TITLE
Fix FuseConv2DWithSqueezeAndBias remapper test

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -907,9 +907,8 @@ TEST_F(RemapperTest, FuseConv2DWithSqueezeAndBias) {
   std::vector<int> strides = {1, 1, 1, 1};
   auto conv = ops::Conv2D(s.WithOpName("conv"), input, filter, strides, "SAME");
 
-  ops::Squeeze::Attrs attrs;
-  attrs = attrs.Axis({2});
-  auto squeeze = ops::Squeeze(s.WithOpName("squeeze"), conv, attrs);
+  auto squeeze = ops::Squeeze(s.WithOpName("squeeze"), conv,
+                              ops::Squeeze::Attrs().Axis({2}));
 
   auto bias_add = ops::BiasAdd(s.WithOpName("bias_add"), squeeze, bias);
   auto fetch = ops::Identity(s.WithOpName("fetch"), bias_add);


### PR DESCRIPTION
The test was using a temporary variable to initialize the Axis array, which was getting destroyed as soon as the function returned.