### PR TITLE
Fix TestAgent.ps1 for WSL machines

### DIFF
--- a/third_party/dml/ci/test/TestAgent.ps1
+++ b/third_party/dml/ci/test/TestAgent.ps1
@@ -23,77 +23,66 @@ if (!(Test-Path $TestArtifactsPath))
 
 if ($RunOnWsl)
 {
+    Write-Host "Copying the test artifacts to the WSL filesystem. This may take a while..."
     $TestArtifact = Split-Path -Path $BuildArtifactsPath -Leaf
     $BuildArtifactPathWinAsWsl = wsl wslpath -a ($BuildArtifactsPath -replace '\\','/')
     $WslArtifactFolder = "/tmp/$TestArtifact"
-    wsl rm -rf $WslArtifactFolder
-    wsl mkdir -p /tmp
-    wsl cp -r $BuildArtifactPathWinAsWsl $WslArtifactFolder
+    # wsl rm -rf $WslArtifactFolder
+    # wsl mkdir -p /tmp
+    # wsl cp -r $BuildArtifactPathWinAsWsl $WslArtifactFolder
 
     $WslArtifactFolderAsWin = wsl wslpath -w $WslArtifactFolder
 }
 
-try
+foreach ($TestGroup in $TestGroups)
 {
-    Push-Location "$BuildArtifactsPath"
+    $Results = @{'Time'=@{}}
 
-    foreach ($TestGroup in $TestGroups)
+    Write-Host "Testing $TestGroup..."
+    $Results.Time.Start = (Get-Date).ToString()
+
+    if ($RunOnWsl)
     {
-        $Results = @{'Time'=@{}}
+        $LoadLibraryPath = wsl echo $WslArtifactFolder`:`$LD_LIBRARY_PATH
+        $WslTensorFlowWheelPath = wsl ls $WslArtifactFolder/tensorflow_directml-*linux_x86_64.whl
+        Invoke-Expression "wsl export LD_LIBRARY_PATH='$LoadLibraryPath' '&&' python3 $WslArtifactFolder/run_tests.py --test_group $TestGroup --tensorflow_wheel $WslTensorFlowWheelPath > $BuildArtifactsPath/test_${TestGroup}_log.txt"
 
-        Write-Host "Testing $TestGroup..."
-        $Results.Time.Start = (Get-Date).ToString()
-
-        if ($RunOnWsl)
-        {
-            Push-Location $WslArtifactFolderAsWin
-
-            $LoadLibraryPath = wsl echo $WslArtifactFolder`:`$LD_LIBRARY_PATH
-            $WslTensorFlowWheelPath = Get-ChildItem tensorflow_directml-*linux_x86_64.whl | Select-Object -First 1 -ExpandProperty Name
-            Invoke-Expression "wsl export LD_LIBRARY_PATH='$LoadLibraryPath' '&&' python3 run_tests.py --test_group $TestGroup --tensorflow_wheel $WslTensorFlowWheelPath > test_${TestGroup}_log.txt"
-            wsl find . -name '*_test_result.xml' -exec cp '{}' $BuildArtifactPathWinAsWsl --parents \`;
-            wsl find . -name '*_test_result.xml' -exec rm '{}' \`;
-            wsl mv ./test_${TestGroup}_log.txt $BuildArtifactPathWinAsWsl
-
-            Pop-Location
-        }
-        else
-        {
-            # Resolve path with wildcards
-            $TensorFlowWheelPath = (Resolve-Path "$BuildArtifactsPath/tensorflow_directml-*-win_amd64.whl").Path
-            py run_tests.py --test_group $TestGroup --tensorflow_wheel $TensorFlowWheelPath | Out-File -FilePath "test_${TestGroup}_log.txt"
-        }
-
-        $Results.Time.End = (Get-Date).ToString()
-        $TestResultFragments = (Get-ChildItem . -Filter '*_test_result.xml' -Recurse).FullName
-
-        if ($TestResultFragments.Count -gt 0)
-        {
-            # We convert the AbslTest log to the same JSON format as the TAEF tests to avoid duplicating postprocessing steps.
-            # After this step, there should be no differences between the 2 pipelines.
-            Write-Host "Parsing $TestGroup results..."
-            $TestResults = & "$PSScriptRoot\ParseAbslTestLogs.ps1" $TestResultFragments
-            $TestResultFragments | Remove-Item
-
-            $Results.Summary = $TestResults
-            $Results | ConvertTo-Json -Depth 8 -Compress | Out-File "test_${TestGroup}_summary.json" -Encoding utf8
-            if ($TestResults.Errors)
-            {
-                $TestResults.Errors | Out-File "test_${TestGroup}_errors.txt"
-            }
-
-            Write-Host "Copying $TestGroup artifacts..."
-            robocopy . $TestArtifactsPath "test_${TestGroup}_*" /R:3 /W:10
-        }
-        else
-        {
-            throw 'No test artifacts were produced'
-        }
-
-        Write-Host ""
+        # Because of the runfiles folder, test result paths in WSL can get very long, so we give them a unique name and put them all at the root of the artifacts folder in the Windows filesystem
+        wsl i=0`; for f in `$`(find $WslArtifactFolder -name *_test_result.xml`)`; do i=`$`(`(i+1`)`)`; mv `$f $BuildArtifactPathWinAsWsl/`$`{i`}_test_result.xml`; done`;
+        $TestResultFragments = (Get-ChildItem $BuildArtifactsPath -Filter '*_test_result.xml').FullName
     }
-}
-finally
-{
-    Pop-Location
+    else
+    {
+        # Resolve path with wildcards
+        $TensorFlowWheelPath = (Resolve-Path "$BuildArtifactsPath/tensorflow_directml-*-win_amd64.whl").Path
+        py $BuildArtifactsPath/run_tests.py --test_group $TestGroup --tensorflow_wheel $TensorFlowWheelPath | Out-File -FilePath "$BuildArtifactsPath/test_${TestGroup}_log.txt"
+        $TestResultFragments = (Get-ChildItem $BuildArtifactsPath -Filter '*_test_result.xml' -Recurse).FullName
+    }
+
+    $Results.Time.End = (Get-Date).ToString()
+
+    if ($TestResultFragments.Count -gt 0)
+    {
+        # We convert the AbslTest log to the same JSON format as the TAEF tests to avoid duplicating postprocessing steps.
+        # After this step, there should be no differences between the 2 pipelines.
+        Write-Host "Parsing $TestGroup results..."
+        $TestResults = & "$PSScriptRoot\ParseAbslTestLogs.ps1" $TestResultFragments
+        $TestResultFragments | Remove-Item
+
+        $Results.Summary = $TestResults
+        $Results | ConvertTo-Json -Depth 8 -Compress | Out-File "$BuildArtifactsPath/test_${TestGroup}_summary.json" -Encoding utf8
+        if ($TestResults.Errors)
+        {
+            $TestResults.Errors | Out-File "$BuildArtifactsPath/test_${TestGroup}_errors.txt"
+        }
+
+        Write-Host "Copying $TestGroup artifacts..."
+        robocopy $BuildArtifactsPath $TestArtifactsPath "test_${TestGroup}_*" /R:3 /W:10
+    }
+    else
+    {
+        throw 'No test artifacts were produced'
+    }
+
+    Write-Host ""
 }


### PR DESCRIPTION
We cannot rely on Push-Location for WSL paths since it sometimes seems to fail randomly, especially when WSL isn't actively used on the machine. Instead, just use the absolute path to the build artifacts when running each command.

Also, because of the runfiles folder, the test results xml paths are sometimes to big for Windows. Therefore, we now give them a unique name and move them all in the same directory, which is the root of the build artifacts folder on the Windows filesystem.