### PR TITLE
Re-enable some disabled DML tests

### DIFF
--- a/tensorflow/python/distribute/ctl_correctness_test.py
+++ b/tensorflow/python/distribute/ctl_correctness_test.py
@@ -217,8 +217,6 @@ class TestDistributionStrategyDnnCorrectness(test.TestCase,
     np.random.seed(_RANDOM_SEED)
     random_seed.set_random_seed(_RANDOM_SEED)
 
-  # TFDML #25610789
-  @test_util.skip_dml
   @combinations.generate(
       combinations.combine(
           distribution=strategy_combinations.strategies_minus_tpu,

--- a/tensorflow/python/keras/backend_test.py
+++ b/tensorflow/python/keras/backend_test.py
@@ -359,8 +359,6 @@ class BackendLinearAlgebraTest(test.TestCase):
 
     # TODO(fchollet): insufficiently tested.
 
-  # TFDML #25611038
-  @test_util.skip_dml
   def test_reduction_ops(self):
     ops_to_test = [
         (keras.backend.max, np.max),
@@ -550,8 +548,6 @@ class BackendShapeOpsTest(test.TestCase):
                                   width_factor,
                                   data_format='unknown')
 
-  # TFDML #25611056
-  @test_util.skip_dml
   def test_resize_volumes(self):
     height_factor = 2
     width_factor = 2
@@ -704,8 +700,6 @@ class BackendShapeOpsTest(test.TestCase):
 @test_util.run_all_in_graph_and_eager_modes
 class BackendNNOpsTest(test.TestCase, parameterized.TestCase):
 
-  # TFDML #25611042
-  @test_util.skip_dml
   def test_bias_add(self):
     keras_op = keras.backend.bias_add
     np_op = np.add
@@ -1140,8 +1134,6 @@ class BackendNNOpsTest(test.TestCase, parameterized.TestCase):
     with self.assertRaises(ValueError):
       y = keras.backend.conv3d(x, k, (2, 2))
 
-  # TFDML #25622473
-  @test_util.skip_dml
   def test_rnn(self):
     # implement a simple RNN
     num_samples = 4
@@ -1425,8 +1417,6 @@ class BackendNNOpsTest(test.TestCase, parameterized.TestCase):
 
       self.assertAllClose(keras.backend.eval(outputs), expected_outputs)
 
-  # TFDML #25655493
-  @test_util.skip_dml
   def test_rnn_state_num_dim_larger_than_2_masking(self):
     num_samples = 3
     num_timesteps = 4

--- a/tensorflow/python/keras/layers/convolutional_recurrent_test.py
+++ b/tensorflow/python/keras/layers/convolutional_recurrent_test.py
@@ -31,8 +31,6 @@ from tensorflow.python.platform import test
 @keras_parameterized.run_all_keras_modes
 class ConvLSTMTest(keras_parameterized.TestCase):
 
-  # TFDML #25610831
-  @test_util.skip_dml
   @parameterized.named_parameters(
       *test_util.generate_combinations_with_testcase_name(
           data_format=['channels_first', 'channels_last'],

--- a/tensorflow/python/keras/layers/recurrent_test.py
+++ b/tensorflow/python/keras/layers/recurrent_test.py
@@ -734,8 +734,6 @@ class RNNTest(keras_parameterized.TestCase):
       y_np_2 = model.predict(x_np)
       self.assertAllClose(y_np, y_np_2, atol=1e-4)
 
-  # TFDML #25610913
-  @test_util.skip_dml
   @parameterized.named_parameters(
       *test_util.generate_combinations_with_testcase_name(
           layer=[rnn_v1.SimpleRNN, rnn_v1.GRU, rnn_v1.LSTM,

--- a/tensorflow/python/kernel_tests/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/init_ops_test.py
@@ -554,8 +554,6 @@ class LinSpaceTest(test.TestCase):
         self.assertEqual([num], tf_ans.get_shape())
         return self.evaluate(tf_ans)
 
-  # TFDML #25655124
-  @test_util.skip_dml
   def testPositive(self):
     for self.force_gpu in self._gpu_modes():
       self.assertArrayNear(self._LinSpace(1., 5., 1), np.array([1.]), 1e-5)
@@ -577,8 +575,6 @@ class LinSpaceTest(test.TestCase):
           self._LinSpace(-1., -5., 4),
           np.array([-1., -7. / 3., -11. / 3., -5.]), 1e-5)
 
-  # TFDML #25655164
-  @test_util.skip_dml
   def testNegativeToPositive(self):
     for self.force_gpu in self._gpu_modes():
       self.assertArrayNear(self._LinSpace(-1., 5., 1), np.array([-1.]), 1e-5)
@@ -596,8 +592,6 @@ class LinSpaceTest(test.TestCase):
       self.assertArrayNear(self._LinSpace(5., 5., 3), np.array([5.] * 3), 1e-5)
       self.assertArrayNear(self._LinSpace(5., 5., 4), np.array([5.] * 4), 1e-5)
 
-  # TFDML #25655116/
-  @test_util.skip_dml
   def testEndpointsAreExact(self):
     for self.force_gpu in self._gpu_modes():
       # Test some cases that produce last values not equal to "stop" when
@@ -735,8 +729,6 @@ class ConvolutionDeltaOrthogonalInitializerTest(test.TestCase):
         t2 = init2(shape).eval()
       self.assertAllClose(t1, t2 / 3.14)
 
-  # TFDML #25655720
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testShapesValues(self):
     gain = 3.14
@@ -1094,8 +1086,6 @@ class ConvolutionOrthogonal3dInitializerTest(test.TestCase):
       # Compute the sum of the absolute values of 'count' determinants
       self.assertAllClose(abs_value, count, rtol=tol, atol=tol)
 
-  # TFDML #25655724
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testShapesValues(self):
     def circular_pad(input_, width, kernel_size):


### PR DESCRIPTION
I ran a private test run after re-enabling a handful of tests, and no additional failures showed up.