### PR TITLE
Use NCHW for FusedBatchNormGrad

### DIFF
--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
@@ -776,6 +776,10 @@ Status FusedBatchNormGradTransposer::TransposeNode(
 
   if (!IsTraining(*node)) {
     string task, device;
+
+    // Unlike the CUDA kernel, DML's FusedBatchNormGrad should always be faster
+    // with NCHW, so we transform the layout here instead of doing it
+    // in the kernel itself.
     bool is_on_dml = DeviceNameUtils::SplitDeviceName(node->node()->device(),
                                                       &task, &device) &&
                      absl::StartsWith(device, DEVICE_DML);


### PR DESCRIPTION
Jeff noticed that operators used inside FusedBatchNormGrad (e.g. Reduce) didn't have a NCHW layout inside DML. This is because grappler explicitly uses NHWC by default for FusedBatchNormGrad when is_training == false. This is because the GPU kernel does layout transformations on a case-by-case basis since cuDNN has some NHWC fast paths. For DML on the other hand, NCHW should always be faster than NHWC at the moment.