### PR TITLE
Update BUILD.md to remove reference to unused branch

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -10,7 +10,7 @@ The `directml` branch is considered the main branch for development in this repo
 
 ## Developer Mode
 
-Changes in this repository may reference in-development or preview versions of DirectML that are subject to change. This allows testing new APIs before they are committed to the DirectML API (once an API appears in DirectML.h it is immutable). A preview build of DirectML requires *developer mode* to be enabled or it will fail to load; this restriction is intended to avoid a long-term dependency on the preview library. **Packages on PyPI will only be released when the repository can depend on a stable version of DirectML.**
+This repository may periodically reference in-development versions of DirectML for testing new features. For example, experimental APIs are added to `DirectMLPreview.h`, which may have breaking changes; once an API appears in `DirectML.h` it is immutable. A preview build of DirectML requires *developer mode* to be enabled or it will fail to load. This restriction is intended to avoid a long-term dependency on the preview library. **Packages on PyPI will only be released when the repository depends on a stable version of DirectML.**
 
 You can determine if the current state of the repository references an in-development version of DirectML by inspecting `tensorflow/workspace.bzl`. If the version attribute ends with `-dev*`, then developer mode will be required. For example, the following snippet shows a dependency on DirectML 1.5.0-dev1, which requires developer mode.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,17 +2,29 @@
 
 This document contains instructions for producing private builds of tensorflow-directml.
 
-## DirectML and DirectML-Dev Branches
+## DirectML Branch
 
 This project is a fork of the official [tensorflow](https://github.com/tensorflow/tensorflow) repository that targets TensorFlow v1.15. This fork will not merge upstream, since TensorFlow does not accept new features for previous releases, so the `master` branch is based off v1.15.0 from the upstream repository. DirectML changes do not appear in the `master` branch.
 
-The `directml` branch is considered the main branch for development in this repository, and it should be the most stable branch to test. Packages of [tensorflow-directml on PyPI](https://pypi.org/project/tensorflow-directml/) are produced from the `directml` branch. This branch contains changes related to DirectML as well as security fixes in the upstream branch (e.g. changes in 1.15.1, 1.15.2, 1.15.3., etc.).
-
-The latest changes occur in the `directml-dev` branch. This branch is intended for rapid development, so builds of the `directml-dev` branch may reference unstable DirectML APIs that are subject to change over time; preview DirectML APIs are included in a special preview redistributable of DirectML that requires *developer mode*. 
+The `directml` branch is considered the main branch for development in this repository. This branch contains changes related to DirectML as well as security fixes in the upstream repository (e.g. changes in 1.15.1, 1.15.2, 1.15.3., etc.). Since this project is still in early development, the `directml` branch may be unstable and reference a "preview" version of DirectML that is subject to change. We recommend testing pre-built packages of [tensorflow-directml on PyPI](https://pypi.org/project/tensorflow-directml/); these builds are produced from the `directml` branch, but **only** when a stable version of DirectML is referenced. Alternatively, we recommend building against release tags associated with PyPI releases.
 
 ## Developer Mode
 
-**The python packages produced from the `directml-dev` branch will not run unless you enable developer mode, since they are not intended to be shipped or distributed for mainstream use**. To enable developer mode:
+Changes in this repository may reference in-development or preview versions of DirectML that are subject to change. This allows testing new APIs before they are committed to the DirectML API (once an API appears in DirectML.h it is immutable). A preview build of DirectML requires *developer mode* to be enabled or it will fail to load; this restriction is intended to avoid a long-term dependency on the preview library. **Packages on PyPI will only be released when the repository can depend on a stable version of DirectML.**
+
+You can determine if the current state of the repository references an in-development version of DirectML by inspecting `tensorflow/workspace.bzl`. If the version attribute ends with `-dev*`, then developer mode will be required. For example, the following snippet shows a dependency on DirectML 1.5.0-dev1, which requires developer mode.
+
+```
+dml_repository(
+    name = "dml_redist",
+    package = "DirectML",
+    version = "1.5.0-dev1",
+    source = "https://pkgs.dev.azure.com/ms/DirectML/_packaging/tensorflow-directml/nuget/v3/index.json",
+    build_file = "//third_party/dml/redist:BUILD.bazel",
+)
+```
+
+Developer mode is, as the name indicates, only intended to be used for development! It should not be used for any other purpose. To enable developer mode:
 
 - **Windows**
   - [Toggle "Developer Mode" to "On"](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development) in the "For developers" tab of the "Update & Security" section of the Settings app.


### PR DESCRIPTION
Our build doc still references the original two-branch strategy (directml, directml-dev) for DirectML integration with TensorFlow. This change updates the notes to reflect reality, which is that all development occurs in the directml branch and preview APIs may or may not be in use.