### PR TITLE
Pin h5py version to <3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TensorFlow-DirectML <!-- omit in toc -->
 
-|           |                                                                                                                                                                        |
+| :warning: | Warnings                                                                                                                                                               |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | :warning: | **NumPy 1.19.4 is broken on Windows. Please make sure that your environment has a different version of NumPy before using TensorFlow-DirectML.**                       |
 | :warning: | **h5py 3.0.0 and 3.1.0 broke compatibility with TensorFlow. Please make sure that your environment has a different version of h5py before using TensorFlow-DirectML.** |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # TensorFlow-DirectML <!-- omit in toc -->
 
-| :warning: | **NumPy 1.19.4 is broken on Windows. Please make sure that your environment has a different version of NumPy before using TensorFlow-DirectML.** |
-|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+|           |                                                                                                                                                                        |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :warning: | **NumPy 1.19.4 is broken on Windows. Please make sure that your environment has a different version of NumPy before using TensorFlow-DirectML.**                       |
+| :warning: | **h5py 3.0.0 and 3.1.0 broke compatibility with TensorFlow. Please make sure that your environment has a different version of h5py before using TensorFlow-DirectML.** |
 
 
 | PyPI Release                                                                                                      | Build (directml branch)                                                                                                                                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TensorFlow-DirectML <!-- omit in toc -->
 
-| :warning: | Warnings                                                                                                                                                               |
+|           | Warnings                                                                                                                                                               |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | :warning: | **NumPy 1.19.4 is broken on Windows. Please make sure that your environment has a different version of NumPy before using TensorFlow-DirectML.**                       |
 | :warning: | **h5py 3.0.0 and 3.1.0 broke compatibility with TensorFlow. Please make sure that your environment has a different version of h5py before using TensorFlow-DirectML.** |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # TensorFlow-DirectML <!-- omit in toc -->
 
-|           |                                                                                                                                                                        |
-|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | :warning: | **NumPy 1.19.4 is broken on Windows. Please make sure that your environment has a different version of NumPy before using TensorFlow-DirectML.**                       |
 | :warning: | **h5py 3.0.0 and 3.1.0 broke compatibility with TensorFlow. Please make sure that your environment has a different version of h5py before using TensorFlow-DirectML.** |
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TensorFlow-DirectML <!-- omit in toc -->
 
+|           |                                                                                                                                                                        |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | :warning: | **NumPy 1.19.4 is broken on Windows. Please make sure that your environment has a different version of NumPy before using TensorFlow-DirectML.**                       |
 | :warning: | **h5py 3.0.0 and 3.1.0 broke compatibility with TensorFlow. Please make sure that your environment has a different version of h5py before using TensorFlow-DirectML.** |
 

--- a/third_party/dml/ci/test/run_tests_data.json
+++ b/third_party/dml/ci/test/run_tests_data.json
@@ -11,6 +11,7 @@
       ],
       "pipDeps": [
         "numpy==1.19.3",
+        "h5py<3.0.0",
         "scipy",
         "portpicker"
       ],


### PR DESCRIPTION
The 2 latest h5py versions break TensorFlow, so we pin it to <3.0.0.