### PR TITLE
Enclose package names in double quotes when installing them during CI

### DIFF
--- a/third_party/dml/ci/test/conda_helpers.py
+++ b/third_party/dml/ci/test/conda_helpers.py
@@ -55,9 +55,9 @@ class CondaEnv:
 
   def install_package(self, package_name):
     subprocess.run(
-        f"{self.hook_command}"
-        f" && conda activate {self.env_name}"
-        f" && pip install {package_name}",
+        f'{self.hook_command}'
+        f' && conda activate {self.env_name}'
+        f' && pip install "{package_name}"',
         shell=True,
         check=True)
 


### PR DESCRIPTION
Some package names may contain characters reserved for the shell (e.g. <).