### PR TITLE
Switch to DirectML 1.4.0

### DIFF
--- a/tensorflow/core/kernels/dml_space_to_batch_op.cc
+++ b/tensorflow/core/kernels/dml_space_to_batch_op.cc
@@ -431,8 +431,9 @@ class DmlSpaceToBatchKernel : public DmlKernel {
       DmlKernelWrapper<DmlSpaceToBatchKernel<SpaceToBatchInitHelper>,   \
                        SpaceToBatchShapeHelper>);
 
-TF_CALL_float(REGISTER_DML_KERNEL);
-TF_CALL_half(REGISTER_DML_KERNEL);
+// TODO: re-register these kernels when we can depend on DML 1.15.
+// TF_CALL_float(REGISTER_DML_KERNEL);
+// TF_CALL_half(REGISTER_DML_KERNEL);
 #undef REGISTER_DML_KERNEL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/dml_space_to_batch_op.cc
+++ b/tensorflow/core/kernels/dml_space_to_batch_op.cc
@@ -431,7 +431,7 @@ class DmlSpaceToBatchKernel : public DmlKernel {
       DmlKernelWrapper<DmlSpaceToBatchKernel<SpaceToBatchInitHelper>,   \
                        SpaceToBatchShapeHelper>);
 
-// TODO: re-register these kernels when we can depend on DML 1.15.
+// TODO: #30565402 - re-register these kernels when we can depend on DML 1.15.
 // TF_CALL_float(REGISTER_DML_KERNEL);
 // TF_CALL_half(REGISTER_DML_KERNEL);
 #undef REGISTER_DML_KERNEL

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <stdlib.h>
 
+#include "DirectMLConfig.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "tensorflow/stream_executor/lib/env.h"
@@ -25,7 +26,6 @@ limitations under the License.
 #include "tensorflow/stream_executor/platform/port.h"
 #include "third_party/gpus/cuda/cuda_config.h"
 #include "third_party/tensorrt/tensorrt_config.h"
-#include "DirectMLConfig.h"
 
 namespace stream_executor {
 namespace internal {
@@ -39,12 +39,6 @@ string GetTensorRTVersion() { return TF_TENSORRT_VERSION; }
 string GetDirectMLPath() {
   const char* path = getenv("TF_DIRECTML_PATH");
   return (path != nullptr ? path : "");
-}
-
-string GetDirectMLVersion() {
-  // If TF_DIRECTML_PATH is set, use DirectML.dll / libdirectml.so.
-  // Otherwise, use DirectML<ver>.dll / libdirectml.so.<ver>.
-  return GetDirectMLPath().empty() ? DIRECTML_SOURCE_VERSION : "";
 }
 
 port::StatusOr<void*> GetDsoHandle(const string& name, const string& version,
@@ -152,17 +146,32 @@ port::StatusOr<void*> GetRocrandDsoHandle() {
 
 port::StatusOr<void*> GetHipDsoHandle() { return GetDsoHandle("hip_hcc", ""); }
 
+port::StatusOr<void*> GetDirectMLLibraryHandle(const string& basename) {
+  auto path = GetDirectMLPath();
+
+  // Bundled DirectML libraries have a mangled name to avoid collision:
+  //
+  // Original Name  | Mangled Name
+  // ---------------|-------------
+  // directml.dll   | directml.<sha>.dll
+  // libdirectml.so | libdirectml.<sha>.so
+  //
+  // We use the original name if TF_DIRECTML_PATH is set.
+  // We use the mangled name if TF_DIRECTML_PATH isn't set (most cases).
+  string name = basename;
+  if (path.empty()) {
+    name += string(".") + DIRECTML_SOURCE_VERSION;
+  }
+
+  return GetDsoHandle(name, "", path);
+}
+
 port::StatusOr<void*> GetDirectMLDsoHandle() {
-#ifdef _WIN32
-  return GetDsoHandle("DirectML", GetDirectMLVersion(), GetDirectMLPath());
-#else
-  return GetDsoHandle("directml", GetDirectMLVersion(), GetDirectMLPath());
-#endif
+  return GetDirectMLLibraryHandle("directml");
 }
 
 port::StatusOr<void*> GetDirectMLDebugDsoHandle() {
-  return GetDsoHandle("DirectML.Debug", GetDirectMLVersion(),
-                      GetDirectMLPath());
+  return GetDirectMLLibraryHandle("directml.debug");
 }
 
 }  // namespace DsoLoader

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -100,13 +100,13 @@ function copy_dml_redist_files() {
   if is_windows; then
     dml_version=$(awk '/^#define DIRECTML_SOURCE_VERSION "([abcdef0-9]+)"/ { gsub("\"","",$3); print $3 }' $dml_config_path)
     echo "DML Version = '$dml_version'"
-    dml_dll=$(find "${dml_redist_root}/bin/x64-win/" -type f -name "*.dll" ! -name "DirectML.Debug.*.dll")
-    cp "$dml_dll" "${dml_redist_dir}"/DirectML${dml_version}.dll
+    dml_dll=$(find "${dml_redist_root}/bin/x64-win/" -type f -name "*.dll" ! -name "DirectML.Debug.*")
+    cp "$dml_dll" "${dml_redist_dir}"/DirectML.${dml_version}.dll
   else
     dml_version=$(awk -v RS='\r\n' '/^#define DIRECTML_SOURCE_VERSION "([abcdef0-9]+)"/ { gsub("\"","",$3); print $3 }' $dml_config_path)
     echo "DML Version = '$dml_version'"
-    dml_so=$(find "$dml_redist_root/bin/x64-linux/" -type f)
-    cp "$dml_so" "${dml_redist_dir}"/libdirectml.so.${dml_version}
+    dml_so=$(find "$dml_redist_root/bin/x64-linux/" -type f -name "*.so" ! -name libdirectml.debug.*)
+    cp "$dml_so" "${dml_redist_dir}"/libdirectml.${dml_version}.so
   fi
   cp "${dml_redist_root}/LICENSE.txt" ${dml_redist_dir}
   cp "${dml_redist_root}/ThirdPartyNotices.txt" ${dml_redist_dir}

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -88,9 +88,9 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
 
     dml_repository(
         name = "dml_redist",
-        package = "DirectML",
-        version = "1.5.0-dev1",
-        source = "https://pkgs.dev.azure.com/ms/DirectML/_packaging/tensorflow-directml/nuget/v3/index.json",
+        package = "Microsoft.AI.DirectML",
+        version = "1.4.0",
+        source = "https://api.nuget.org/v3/index.json",
         build_file = "//third_party/dml/redist:BUILD.bazel",
     )
 

--- a/third_party/dml/redist/BUILD.bazel
+++ b/third_party/dml/redist/BUILD.bazel
@@ -7,15 +7,15 @@ licenses(["notice"]) # MIT license for headers
 
 cc_library(
     name = "headers",
-    hdrs = glob(["DirectML/include/*.h"]),
-    includes = ["DirectML/include"],
+    hdrs = glob(["Microsoft.AI.DirectML/include/*.h"]),
+    includes = ["Microsoft.AI.DirectML/include"],
 )
 
 filegroup(
     name = "pip_files",
     srcs = glob([
-        "DirectML/bin/**", 
-        "DirectML/include/DirectMLConfig.h", 
-        "DirectML/*.txt"]),
+        "Microsoft.AI.DirectML/bin/**", 
+        "Microsoft.AI.DirectML/include/DirectMLConfig.h", 
+        "Microsoft.AI.DirectML/*.txt"]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Use the stable/public DirectML 1.4.0 package. Unfortunately, we'll need to deregister two kernels that require 8D tensor support that isn't in 1.4.0: SpaceToBatch and SpaceToBatchND. 