### PR TITLE
Revert "Switch to DirectML 1.4.0 (#93)"

### DIFF
--- a/tensorflow/core/kernels/dml_space_to_batch_op.cc
+++ b/tensorflow/core/kernels/dml_space_to_batch_op.cc
@@ -431,9 +431,8 @@ class DmlSpaceToBatchKernel : public DmlKernel {
       DmlKernelWrapper<DmlSpaceToBatchKernel<SpaceToBatchInitHelper>,   \
                        SpaceToBatchShapeHelper>);
 
-// TODO: #30565402 - re-register these kernels when we can depend on DML 1.15.
-// TF_CALL_float(REGISTER_DML_KERNEL);
-// TF_CALL_half(REGISTER_DML_KERNEL);
+TF_CALL_float(REGISTER_DML_KERNEL);
+TF_CALL_half(REGISTER_DML_KERNEL);
 #undef REGISTER_DML_KERNEL
 
 }  // namespace tensorflow

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -100,13 +100,13 @@ function copy_dml_redist_files() {
   if is_windows; then
     dml_version=$(awk '/^#define DIRECTML_SOURCE_VERSION "([abcdef0-9]+)"/ { gsub("\"","",$3); print $3 }' $dml_config_path)
     echo "DML Version = '$dml_version'"
-    dml_dll=$(find "${dml_redist_root}/bin/x64-win/" -type f -name "*.dll" ! -name "DirectML.Debug.*")
-    cp "$dml_dll" "${dml_redist_dir}"/DirectML.${dml_version}.dll
+    dml_dll=$(find "${dml_redist_root}/bin/x64-win/" -type f -name "*.dll" ! -name "DirectML.Debug.*.dll")
+    cp "$dml_dll" "${dml_redist_dir}"/DirectML${dml_version}.dll
   else
     dml_version=$(awk -v RS='\r\n' '/^#define DIRECTML_SOURCE_VERSION "([abcdef0-9]+)"/ { gsub("\"","",$3); print $3 }' $dml_config_path)
     echo "DML Version = '$dml_version'"
-    dml_so=$(find "$dml_redist_root/bin/x64-linux/" -type f -name "*.so" ! -name libdirectml.debug.*)
-    cp "$dml_so" "${dml_redist_dir}"/libdirectml.${dml_version}.so
+    dml_so=$(find "$dml_redist_root/bin/x64-linux/" -type f)
+    cp "$dml_so" "${dml_redist_dir}"/libdirectml.so.${dml_version}
   fi
   cp "${dml_redist_root}/LICENSE.txt" ${dml_redist_dir}
   cp "${dml_redist_root}/ThirdPartyNotices.txt" ${dml_redist_dir}

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -88,9 +88,9 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
 
     dml_repository(
         name = "dml_redist",
-        package = "Microsoft.AI.DirectML",
-        version = "1.4.0",
-        source = "https://api.nuget.org/v3/index.json",
+        package = "DirectML",
+        version = "1.5.0-dev1",
+        source = "https://pkgs.dev.azure.com/ms/DirectML/_packaging/tensorflow-directml/nuget/v3/index.json",
         build_file = "//third_party/dml/redist:BUILD.bazel",
     )
 

--- a/third_party/dml/redist/BUILD.bazel
+++ b/third_party/dml/redist/BUILD.bazel
@@ -7,15 +7,15 @@ licenses(["notice"]) # MIT license for headers
 
 cc_library(
     name = "headers",
-    hdrs = glob(["Microsoft.AI.DirectML/include/*.h"]),
-    includes = ["Microsoft.AI.DirectML/include"],
+    hdrs = glob(["DirectML/include/*.h"]),
+    includes = ["DirectML/include"],
 )
 
 filegroup(
     name = "pip_files",
     srcs = glob([
-        "Microsoft.AI.DirectML/bin/**", 
-        "Microsoft.AI.DirectML/include/DirectMLConfig.h", 
-        "Microsoft.AI.DirectML/*.txt"]),
+        "DirectML/bin/**", 
+        "DirectML/include/DirectMLConfig.h", 
+        "DirectML/*.txt"]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This reverts commit 3978df5913f6e978f7649a2bd95801f22a07e3d9. We want DML a bit farther ahead in directml for performance testing, but changes for the next pypi release will go into release/2020-11.