### PR TITLE
Fix DirectML.dll loading issues

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -44,7 +44,7 @@ The development headers and libraries used to build DirectX-based applications a
    -  Direct3D/DXCore Headers: `third_party/dml/winadapter`
    -  Direct3D/DXCore Libraries: `/usr/lib/wsl/lib`
 
-For both Windows and WSL, the DirectML headers and libraries are pulled from a redistributable NuGet package. This package is downloaded automatically as a part of the build (see `third_party/dml/redist`). The use of the redistributable DirectML library is governed by a separate license that is found as part of the package (found in `_solib_directml/LICENSE.txt` when extracted).
+For both Windows and WSL, the DirectML headers and libraries are pulled from a redistributable NuGet package. This package is downloaded automatically as a part of the build (see `third_party/dml/redist`). The use of the redistributable DirectML library is governed by a separate license that is found as part of the package (found in `tensorflow_core/python/DirectML_LICENSE.txt` when extracted).
 
 ## Build Environment
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you would like to contribute to tensorflow-directml, please see our [contribu
 
 This project is licensed under [Apache License 2.0](LICENSE).
 
-The tensorflow-directml Python wheel binary package includes a redistributable version of the DirectML library, which is downloaded automatically as a part of the build. The use of the redistributable DirectML library is governed by a separate license that is found as part of the package (found in `_solib_directml/LICENSE.txt` when extracted).
+The tensorflow-directml Python wheel binary package includes a redistributable version of the DirectML library, which is downloaded automatically as a part of the build. The use of the redistributable DirectML library is governed by a separate license that is found as part of the package (found in `tensorflow_core/python/DirectML_LICENSE.txt` when extracted).
 
 ## Data Collection Notice
 

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3799,7 +3799,7 @@ cc_library(
     ]) + if_not_windows([
         "-ld3d12",
         "-ldxcore",
-        "-Wl,-rpath,$$ORIGIN/../_solib_directml"
+        "-Wl,-rpath,$$ORIGIN"
     ]),
 )
 

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3796,6 +3796,7 @@ cc_library(
     linkopts = if_windows([
         "d3d12.lib", 
         "dxgi.lib", 
+        "pathcch.lib",
     ]) + if_not_windows([
         "-ld3d12",
         "-ldxcore",

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -197,7 +197,13 @@ port::StatusOr<void*> GetDirectMLLibraryHandle(const string& basename) {
   string name = basename;
   if (path.empty()) {
     name += string(".") + DIRECTML_SOURCE_VERSION;
+
+    // Look for DML under the same directory as the core tensorflow module. This
+    // check isn't required for WSL since the RPATH of the tensorflow .so file
+    // is modified.
+#if _WIN32
     path = GetModuleDirectory();
+#endif
   }
 
   return GetDsoHandle(name, "", path);

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -73,10 +73,13 @@ string GetModuleDirectory() {
   }
   CHECK_NE(filePathSize, 0);
 
-  // Strip TF library filename from the path.
+  // Strip TF library filename from the path and truncate the buffer.
+  // PathCchRemoveFileSpec may return S_FALSE if nothing was removed, but
+  // this indicates an error (module path should be a filename, not a dir).
   CHECK_EQ(
       PathCchRemoveFileSpec(const_cast<wchar_t*>(wpath.data()), wpath.size()),
       S_OK);
+  wpath.resize(wcslen(wpath.c_str()));
 
   return tensorflow::WideCharToUtf8(wpath);
 }

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -210,9 +210,9 @@ function prepare_src() {
   # copied from "tensorflow" (see lines directly below).
   # - Windows : tensorflow_core/python/_pywrap_tensorflow_internal.pyd
   # - Linux   : tensorflow_core/libtensorflow_framework.so.1
-  if is_windows:
+  if is_windows
     copy_dml_redist_files "${TMPDIR}/tensorflow/python"
-  else:
+  else
     copy_dml_redist_files "${TMPDIR}/tensorflow"
 
   # In order to break the circular dependency between tensorflow and

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -76,9 +76,7 @@ function is_windows() {
 }
 
 function copy_dml_redist_files() {
-  # Dirs under ${TMPDIR} starting with _solib_ are special: setup.py will include any files under those dirs in package_data.
-  dml_redist_dir=${TMPDIR}/_solib_directml
-  mkdir -p ${dml_redist_dir}
+  dml_redist_dir="${1%/}"
 
   if is_windows; then
     runfiles_manifest_path=bazel-bin/tensorflow/tools/pip_package/build_pip_package.exe.runfiles_manifest
@@ -108,8 +106,8 @@ function copy_dml_redist_files() {
     dml_so=$(find "$dml_redist_root/bin/x64-linux/" -type f -name "*.so" ! -name libdirectml.debug.*)
     cp "$dml_so" "${dml_redist_dir}"/libdirectml.${dml_version}.so
   fi
-  cp "${dml_redist_root}/LICENSE.txt" ${dml_redist_dir}
-  cp "${dml_redist_root}/ThirdPartyNotices.txt" ${dml_redist_dir}
+  cp "${dml_redist_root}/LICENSE.txt" "${dml_redist_dir}/DirectML_LICENSE.txt"
+  cp "${dml_redist_root}/ThirdPartyNotices.txt" "${dml_redist_dir}/DirectML_ThirdPartyNotices.txt"
 }
 
 function prepare_src() {
@@ -128,8 +126,6 @@ function prepare_src() {
     echo "Could not find bazel-bin.  Did you run from the root of the build tree?"
     exit 1
   fi
-
-  copy_dml_redist_files
 
   if is_windows; then
     rm -rf ./bazel-bin/tensorflow/tools/pip_package/simple_console_for_window_unzip
@@ -204,6 +200,8 @@ function prepare_src() {
 
   rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so
   rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so.[0-9].*
+
+  copy_dml_redist_files "${TMPDIR}/tensorflow/python"
 
   # In order to break the circular dependency between tensorflow and
   # tensorflow_estimator which forces us to do a multi-step release, we are

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -205,7 +205,15 @@ function prepare_src() {
   rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so
   rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so.[0-9].*
 
-  copy_dml_redist_files "${TMPDIR}/tensorflow/python"
+  # TFDML will attempt to load the DirectML library from the same directory as the core
+  # TF libary. This location differs based on platform. Note that tensorflow_core is
+  # copied from "tensorflow" (see lines directly below).
+  # - Windows : tensorflow_core/python/_pywrap_tensorflow_internal.pyd
+  # - Linux   : tensorflow_core/libtensorflow_framework.so.1
+  if is_windows:
+    copy_dml_redist_files "${TMPDIR}/tensorflow/python"
+  else:
+    copy_dml_redist_files "${TMPDIR}/tensorflow"
 
   # In order to break the circular dependency between tensorflow and
   # tensorflow_estimator which forces us to do a multi-step release, we are

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -210,7 +210,7 @@ function prepare_src() {
   # copied from "tensorflow" (see lines directly below).
   # - Windows : tensorflow_core/python/_pywrap_tensorflow_internal.pyd
   # - Linux   : tensorflow_core/libtensorflow_framework.so.1
-  if is_windows
+  if is_windows; then
     copy_dml_redist_files "${TMPDIR}/tensorflow/python"
   else
     copy_dml_redist_files "${TMPDIR}/tensorflow"

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -63,6 +63,10 @@ function reorganize_includes() {
   move_to_root_if_exists external/com_google_protobuf/src/google
   rm -rf external/com_google_protobuf/python
 
+  # Select DML files are copied in the copy_dml_redist_files function; we should
+  # never include the entire contents of the redistributable package.
+  rm -rf external/dml_redist
+
   popd
 }
 

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -214,6 +214,7 @@ function prepare_src() {
     copy_dml_redist_files "${TMPDIR}/tensorflow/python"
   else
     copy_dml_redist_files "${TMPDIR}/tensorflow"
+  fi
 
   # In order to break the circular dependency between tensorflow and
   # tensorflow_estimator which forces us to do a multi-step release, we are

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -243,11 +243,11 @@ for path in so_lib_paths:
 if os.name == 'nt':
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.pyd'
   matches.extend(['../' + x for x in find_files("DirectML.*.dll", "tensorflow_core/python")])
+  matches.extend(['../' + x for x in find_files("DirectML_*.txt", "tensorflow_core/python")])
 else:
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.so'
-  matches.extend(['../' + x for x in find_files("libdirectml.*.so", "tensorflow_core/python")])
-
-matches.extend(['../' + x for x in find_files("DirectML_*.txt", "tensorflow_core/python")])
+  matches.extend(['../' + x for x in find_files("libdirectml.*.so", "tensorflow_core")])
+  matches.extend(['../' + x for x in find_files("DirectML_*.txt", "tensorflow_core")])
 
 headers = (
     list(find_files('*.h', 'tensorflow_core/core')) +

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -242,8 +242,12 @@ for path in so_lib_paths:
 
 if os.name == 'nt':
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.pyd'
+  matches.extend(['../' + x for x in find_files("DirectML.*.dll", "tensorflow_core/python")])
 else:
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.so'
+  matches.extend(['../' + x for x in find_files("libdirectml.*.so", "tensorflow_core/python")])
+
+matches.extend(['../' + x for x in find_files("DirectML_*.txt", "tensorflow_core/python")])
 
 headers = (
     list(find_files('*.h', 'tensorflow_core/core')) +

--- a/tensorflow/virtual_root_template_v1.__init__.py
+++ b/tensorflow/virtual_root_template_v1.__init__.py
@@ -24,14 +24,6 @@ import importlib as _importlib
 import types as _types
 import os as _os
 
-_extra_dll_dir = _os.path.join(_os.path.dirname(__file__), '..', '_solib_directml')
-if _sys.platform == 'win32' and _os.path.isdir(_extra_dll_dir):
-    if _sys.version_info >= (3, 8):
-        _os.add_dll_directory(_extra_dll_dir)
-    else:
-        _os.environ.setdefault('PATH', '')
-        _os.environ['PATH'] += _os.pathsep + _extra_dll_dir
-
 # Since TensorFlow Python code now resides in tensorflow_core but TensorFlow
 # ecosystem code (e.g. estimator, but also even tensorflow) imports tensorflow
 # we need to do forwarding between the two. To do so, we use a lazy loader to

--- a/third_party/dml/ci/test/run_tests.py
+++ b/third_party/dml/ci/test/run_tests.py
@@ -81,7 +81,7 @@ def main():
 
           # Rename the DLL to DirectML.dll since TF_DIRECTML_PATH only works
           # with that name
-          lib_folder = f"{temp_dir}/_solib_directml"
+          lib_folder = f"{temp_dir}/tensorflow_core/python"
 
           old_glob = "DirectML*.dll" if os.name == "nt" else "libdirectml.so.*"
           new_name = "DirectML.dll" if os.name == "nt" else "libdirectml.so"

--- a/third_party/dml/ci/test/run_tests.py
+++ b/third_party/dml/ci/test/run_tests.py
@@ -81,10 +81,14 @@ def main():
 
           # Rename the DLL to DirectML.dll since TF_DIRECTML_PATH only works
           # with that name
-          lib_folder = f"{temp_dir}/tensorflow_core/python"
-
-          old_glob = "DirectML*.dll" if os.name == "nt" else "libdirectml.so.*"
-          new_name = "DirectML.dll" if os.name == "nt" else "libdirectml.so"
+          if os.name == "nt":
+            lib_folder = f"{temp_dir}/tensorflow_core/python"
+            old_glob = "DirectML*.dll"
+            new_name = "DirectML.dll"
+          else:
+            lib_folder = f"{temp_dir}/tensorflow_core"
+            old_glob = "libdirectml.*.so"
+            new_name = "libdirectml.so"
 
           old_lib_path = glob.glob(f"{lib_folder}/{old_glob}")[0]
           new_lib_path = f"{lib_folder}/{new_name}"


### PR DESCRIPTION
This change should resolve the DLL loading issues we've encountered with, for example, store versions of python. Previously, we relied on TF augmenting the PATH environment variable in __init__.py. This solution doesn't work in all situations since LoadLibrary only inspects binaries on the PATH for traditional win32/desktop applications. Our WSL packages don't have this problem since they instead modify the RPATH of libtensorflow.so.

This change removes the _solib_directml directory and instead places the DML library in the same folder as the core TF library. The location of the core TF library is different for each platform (within Python site-packages):
- Windows: `tensorflow_core/python/_pywrap_tensorflow_internal.pyd`
- Linux: `tensorflow_core/libtensorflow_framework.so.1`

We continue to use the RPATH for WSL builds, and for Windows we call LoadLibrary with explicit path to the directory containing `_pywrap_tensorflow_internal.pyd`. We could have continued to use a relative path lookup (to _solib_directml or some other directory), but this approach should also work better for builds of the C library. Apps can put both the TF framework and DML redistributable and the same directory and it should simply work.

Finally, this change also removes the extra copies of DML redist files that were being placed in the linux wheels.