### PR TITLE
Stop gathering device placement logs during CI

### DIFF
--- a/third_party/dml/ci/test/run_tests_data.json
+++ b/third_party/dml/ci/test/run_tests_data.json
@@ -6,9 +6,6 @@
         "--test_binaries_path": "test_binaries/python",
         "--test_framework": "abseil"
       },
-      "flags": [
-        "--log_device_placement"
-      ],
       "pipDeps": [
         "numpy==1.18.5",
         "h5py<3.0.0",


### PR DESCRIPTION
We don't use this data anymore, so we can save quite a bit of time during CI by disabling device placement log gathering.