### PR TITLE
Stop including AVX2 instructions in WSL builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -66,7 +66,7 @@ def configure(args):
   if sys.platform == "win32":
     os.environ["CC_OPT_FLAGS"] = "/arch:AVX"
   elif sys.platform == "linux":
-    os.environ["CC_OPT_FLAGS"] = "-march=native -Wno-sign-compare"
+    os.environ["CC_OPT_FLAGS"] = "-mavx"
     # GCC doesn't support some of the MS extensions we rely on, such as __declspec(uuid(x)).
     # Setting this var will switch over to building with Clang (still uses GNU C/C++ libs).
     os.environ["TF_DOWNLOAD_CLANG"] = "1"


### PR DESCRIPTION
Using "-march=native" builds with all optimizations the build machine supports. However, we should really be restricting to AVX only for our CI releases. Verified on our of our test machine:

```
2020-11-18 12:25:37.665391: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
```

This matches the official CI build scripts.