### PR TITLE
Return JSON-encoded adapter properties via physical_device_desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following resources provide additional background on DirectML and TensorFlow
 * Python x86-64 3.5, 3.6, or 3.7<sup>2</sup>
 * One of the following supported GPUs:
   * AMD Radeon R5/R7/R9 2xx series or newer, and [20.20.01.05 WSL driver](https://www.amd.com/en/support/kb/release-notes/rn-rad-win-wsl-support)
-  * Intel HD Graphics 5xx or newer, and [28.20.100.8322 WSL driver](https://downloadcenter.intel.com/download/29526)
+  * Intel HD Graphics 6xx or newer, and [28.20.100.8322 WSL driver](https://downloadcenter.intel.com/download/29526)
   * NVIDIA GeForce GTX 9xx series GPU or newer, and [460.20 WSL driver](https://developer.nvidia.com/cuda/wsl/download)
 
 <sup>2</sup> Note: Python 3.8 or newer is **not** currently supported. To use the official PyPi packages, the CPython interpreter is required.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ The following resources provide additional background on DirectML and TensorFlow
 - [RFC: TensorFlow on DirectML](https://github.com/tensorflow/community/pull/243)
 - [TensorFlow homepage](https://www.tensorflow.org/)
 
+## System Requirements
+
+### Windows 10
+
+* Windows 10 Version 1709, 64-bit (Build 16299 or higher)
+* Python x86-64 3.5, 3.6, or 3.7<sup>1</sup>
+* One of the following supported GPUs:
+  * AMD Radeon R5/R7/R9 2xx series or newer
+  * Intel HD Graphics 5xx or newer
+  * NVIDIA GeForce GTX 9xx series GPU or newer
+
+<sup>1</sup> Note: Python 3.8 or newer is **not** currently supported. To use the official PyPi packages, the CPython interpreter is required. NumPy 1.19.4 is [currently experiencing issues on Windows](https://github.com/numpy/numpy/wiki/FMod-Bug-on-Windows); this can be resolved by pinning the NumPy version, e.g. `pip install numpy==1.19.3`.
+
+### Windows Subsystem for Linux
+
+* Windows 10 Insider Preview, 64-bit (Build 20150 or higher)
+* Python x86-64 3.5, 3.6, or 3.7<sup>2</sup>
+* One of the following supported GPUs:
+  * AMD Radeon R5/R7/R9 2xx series or newer, and [20.20.01.05 WSL driver](https://www.amd.com/en/support/kb/release-notes/rn-rad-win-wsl-support)
+  * Intel HD Graphics 5xx or newer, and [28.20.100.8322 WSL driver](https://downloadcenter.intel.com/download/29526)
+  * NVIDIA GeForce GTX 9xx series GPU or newer, and [460.20 WSL driver](https://developer.nvidia.com/cuda/wsl/download)
+
+<sup>2</sup> Note: Python 3.8 or newer is **not** currently supported. To use the official PyPi packages, the CPython interpreter is required.
+
 ## Feedback
 
 For comments, questions, feedback, or if you're having problems, please [file an issue](https://github.com/microsoft/tensorflow-directml/issues) or contact us directly at askdirectml@microsoft.com.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following resources provide additional background on DirectML and TensorFlow
   * Intel HD Graphics 5xx or newer
   * NVIDIA GeForce GTX 9xx series GPU or newer
 
-<sup>1</sup> Note: Python 3.8 or newer is **not** currently supported. To use the official PyPi packages, the CPython interpreter is required. NumPy 1.19.4 is [currently experiencing issues on Windows](https://github.com/numpy/numpy/wiki/FMod-Bug-on-Windows); this can be resolved by pinning the NumPy version, e.g. `pip install numpy==1.19.3`.
+<sup>1</sup> Note: Python 3.8 or newer is **not** currently supported. To use the official PyPi packages, the CPython interpreter is required. NumPy 1.19.4 is [currently experiencing issues on Windows](https://github.com/numpy/numpy/wiki/FMod-Bug-on-Windows); this can be resolved by pinning the NumPy version, e.g. `pip install numpy==1.18.5`.
 
 ### Windows Subsystem for Linux
 


### PR DESCRIPTION
Changes DML devices to return JSON-encoded vendor IDs, device IDs, and driver versions in the physical_device_desc string. The physical_device_desc is part of the `DeviceAttributes` proto, and can be retrieved via `device_lib.list_local_devices()`.

This change also updates our README with some more detailed information about our minimuim system requirements for TFDML