### PR TITLE
Use compute queue for AMD devices

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_device_state.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_state.cc
@@ -70,8 +70,14 @@ namespace tensorflow {
   ComPtr<IDMLDevice> dml_device;
   dml_device = CreateDmlDevice(d3d_device.Get(), dml_flags);
 
+  D3D12_COMMAND_LIST_TYPE queue_type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+
+  if (adapter.VendorID() == VendorID::kAmd) {
+    queue_type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
+  }
+
   D3D12_COMMAND_QUEUE_DESC command_queue_desc = {};
-  command_queue_desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+  command_queue_desc.Type = queue_type;
   command_queue_desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
   command_queue_desc.Flags = D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT;
   command_queue_desc.NodeMask = 0;


### PR DESCRIPTION
All the evidence we've seen so far points to compute queues being better at preventing TDRs, but also being more performant on AMD. We can always revert the change later if it turns out to not be stable enough, but we should at least have this change be tested by Autopilot and ai-benchmark tests.