### PR TITLE
Add device removal detection and troubleshooting steps

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3771,6 +3771,7 @@ cc_library(
     srcs = [
         "common_runtime/dml/dml_adapter.cc",
         "common_runtime/dml/dml_adapter_impl.cc",
+        "common_runtime/dml/dml_error_handling.cc",
     ],
     hdrs = [
         "common_runtime/dml/dml_common.h",

--- a/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_recorder.cc
@@ -362,22 +362,9 @@ void DmlCommandRecorder::CloseAndExecute() {
   // opened.
   current_descriptor_heap_ = nullptr;
 
-  HRESULT device_removed_reason = dml_device_->GetDeviceRemovedReason();
-
-  if (SUCCEEDED(device_removed_reason)) {
-    device_removed_reason = d3d_device_->GetDeviceRemovedReason();
-  }
-
   // Fail early if something horrifying happens
-  if (FAILED(device_removed_reason)) {
-    status_ = errors::Unknown(
-        "Device was removed because of the following reason: ",
-        dml_util::StringifyDeviceRemovedReason(device_removed_reason),
-        ". This can happen when the GPU times out or when there's a problem in "
-        "the driver. You won't be able to use this DML device again in the "
-        "current process.");
-    return;
-  }
+  DML_CHECK_SUCCEEDED(dml_device_->GetDeviceRemovedReason());
+  DML_CHECK_SUCCEEDED(d3d_device_->GetDeviceRemovedReason());
 
   // Always keep the command recorder in an opened state
   Open();

--- a/tensorflow/core/common_runtime/dml/dml_error_handling.cc
+++ b/tensorflow/core/common_runtime/dml/dml_error_handling.cc
@@ -1,0 +1,49 @@
+/* Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "tensorflow/core/common_runtime/dml/dml_error_handling.h"
+
+#include "absl/strings/str_cat.h"
+
+namespace tensorflow {
+[[noreturn]] void DmlHandleFailedHr(HRESULT hr, const char* expression,
+                                    const char* file, int line) {
+  DCHECK(FAILED(hr));
+
+  // Detect device removal and print a diagnostic
+  switch (hr) {
+    case DXGI_ERROR_DEVICE_REMOVED:
+    case DXGI_ERROR_DEVICE_HUNG:
+    case DXGI_ERROR_DEVICE_RESET:
+    case DXGI_ERROR_DRIVER_INTERNAL_ERROR:
+      tensorflow::internal::LogMessage(file, line, tensorflow::ERROR)
+          << "The DirectML device has encountered an unrecoverable error. This "
+             "is most often caused by a timeout occurring on the GPU. Please "
+             "visit https://aka.ms/??? for more information and "
+             "troubleshooting steps.";
+      break;
+  }
+
+  // Emit a generic error message and exit
+  tensorflow::internal::LogMessageFatal(file, line)
+      << absl::StrCat("HRESULT failed with 0x", absl::Hex(hr, absl::kSpacePad8),
+                      ": ", expression);
+
+  // Should never get here
+  DCHECK(false);
+}
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_error_handling.cc
+++ b/tensorflow/core/common_runtime/dml/dml_error_handling.cc
@@ -36,8 +36,8 @@ namespace dml_util {
           << "The DirectML device has encountered an unrecoverable error ("
           << StringifyDeviceRemovedReason(hr)
           << "). This is most often caused by a timeout occurring on the GPU. "
-             "Please visit https://aka.ms/ilikecheese for more information and "
-             "troubleshooting steps.";
+             "Please visit https://aka.ms/tfdmltimeout for more information "
+             "and troubleshooting steps.";
       break;
   }
 

--- a/tensorflow/core/common_runtime/dml/dml_error_handling.cc
+++ b/tensorflow/core/common_runtime/dml/dml_error_handling.cc
@@ -36,7 +36,7 @@ namespace dml_util {
           << "The DirectML device has encountered an unrecoverable error ("
           << StringifyDeviceRemovedReason(hr)
           << "). This is most often caused by a timeout occurring on the GPU. "
-             "Please visit https://aka.ms/tastycheese for more information and "
+             "Please visit https://aka.ms/ilikecheese for more information and "
              "troubleshooting steps.";
       break;
   }

--- a/tensorflow/core/common_runtime/dml/dml_error_handling.cc
+++ b/tensorflow/core/common_runtime/dml/dml_error_handling.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/dml/dml_error_handling.h"
 
 #include "absl/strings/str_cat.h"
+#include "tensorflow/core/common_runtime/dml/dml_util.h"
 
 namespace tensorflow {
 [[noreturn]] void DmlHandleFailedHr(HRESULT hr, const char* expression,
@@ -31,9 +32,10 @@ namespace tensorflow {
     case DXGI_ERROR_DEVICE_RESET:
     case DXGI_ERROR_DRIVER_INTERNAL_ERROR:
       tensorflow::internal::LogMessage(file, line, tensorflow::ERROR)
-          << "The DirectML device has encountered an unrecoverable error. This "
-             "is most often caused by a timeout occurring on the GPU. Please "
-             "visit https://aka.ms/??? for more information and "
+          << "The DirectML device has encountered an unrecoverable error ("
+          << dml_util::StringifyDeviceRemovedReason(hr)
+          << "). This is most often caused by a timeout occurring on the GPU. "
+             "Please visit https://aka.ms/tastycheese for more information and "
              "troubleshooting steps.";
       break;
   }

--- a/tensorflow/core/common_runtime/dml/dml_error_handling.h
+++ b/tensorflow/core/common_runtime/dml/dml_error_handling.h
@@ -15,9 +15,23 @@ limitations under the License.
 
 #pragma once
 
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include "winadapter.h"
+#endif
+
 #include "tensorflow/core/platform/default/logging.h"
 
-#define DML_CHECK_SUCCEEDED(hr)      \
-  do {                               \
-    CHECK_EQ(SUCCEEDED((hr)), true); \
+namespace tensorflow {
+[[noreturn]] void DmlHandleFailedHr(HRESULT hr, const char* expression,
+                                    const char* file, int line);
+}  // namespace tensorflow
+
+#define DML_CHECK_SUCCEEDED(x)                                    \
+  do {                                                            \
+    HRESULT _hr = (x);                                            \
+    if (TF_PREDICT_FALSE(FAILED(_hr))) {                          \
+      tensorflow::DmlHandleFailedHr(_hr, #x, __FILE__, __LINE__); \
+    }                                                             \
   } while (0)

--- a/tensorflow/core/common_runtime/dml/dml_error_handling.h
+++ b/tensorflow/core/common_runtime/dml/dml_error_handling.h
@@ -24,14 +24,20 @@ limitations under the License.
 #include "tensorflow/core/platform/default/logging.h"
 
 namespace tensorflow {
-[[noreturn]] void DmlHandleFailedHr(HRESULT hr, const char* expression,
-                                    const char* file, int line);
+namespace dml_util {
+[[noreturn]] void HandleFailedHr(HRESULT hr, const char* expression,
+                                 const char* file, int line);
+
+bool HrIsOutOfMemory(HRESULT hr);
+absl::string_view StringifyDeviceRemovedReason(HRESULT reason);
+
+}  // namespace dml_util
 }  // namespace tensorflow
 
-#define DML_CHECK_SUCCEEDED(x)                                    \
-  do {                                                            \
-    HRESULT _hr = (x);                                            \
-    if (TF_PREDICT_FALSE(FAILED(_hr))) {                          \
-      tensorflow::DmlHandleFailedHr(_hr, #x, __FILE__, __LINE__); \
-    }                                                             \
+#define DML_CHECK_SUCCEEDED(x)                                           \
+  do {                                                                   \
+    HRESULT _hr = (x);                                                   \
+    if (TF_PREDICT_FALSE(FAILED(_hr))) {                                 \
+      tensorflow::dml_util::HandleFailedHr(_hr, #x, __FILE__, __LINE__); \
+    }                                                                    \
   } while (0)

--- a/tensorflow/core/common_runtime/dml/dml_util.h
+++ b/tensorflow/core/common_runtime/dml/dml_util.h
@@ -93,31 +93,6 @@ Microsoft::WRL::ComPtr<T> MakeOrAbort(TArgs&&... args) {
   return obj;
 }
 
-inline bool HrIsOutOfMemory(HRESULT hr) {
-  // E_OUTOFMEMORY has a different value depending on whether _WIN32 is defined
-  // when building winerror.h, so we check both potential values here
-  return hr == 0x80000002 || hr == 0x8007000e;
-}
-
-inline absl::string_view StringifyDeviceRemovedReason(HRESULT reason) {
-  switch (reason) {
-    case DXGI_ERROR_DEVICE_HUNG:
-      return "DXGI_ERROR_DEVICE_HUNG";
-    case DXGI_ERROR_DEVICE_REMOVED:
-      return "DXGI_ERROR_DEVICE_REMOVED";
-    case DXGI_ERROR_DEVICE_RESET:
-      return "DXGI_ERROR_DEVICE_RESET";
-    case DXGI_ERROR_DRIVER_INTERNAL_ERROR:
-      return "DXGI_ERROR_DRIVER_INTERNAL_ERROR";
-    case DXGI_ERROR_INVALID_CALL:
-      return "DXGI_ERROR_INVALID_CALL";
-    case S_OK:
-      return "S_OK";
-    default:
-      return "UNKNOWN";
-  }
-}
-
 }  // namespace dml_util
 
 }  // namespace tensorflow

--- a/tensorflow/docs/Troubleshooting-Timeouts.md
+++ b/tensorflow/docs/Troubleshooting-Timeouts.md
@@ -9,7 +9,7 @@ If you encounter a GPU timeout in tensorflow-directml, you'll see an error messa
 ```
 The DirectML device has encountered an unrecoverable error (DXGI_ERROR_DEVICE_HUNG).
 This is most often caused by a timeout occurring on the GPU. Please visit
-https://aka.ms/tastycheese for more information and troubleshooting steps.
+https://aka.ms/ilikecheese for more information and troubleshooting steps.
 
 HRESULT failed with 0x887a0005: readback_heap->Map(0, nullptr, &readback_heap_data)
 ```

--- a/tensorflow/docs/Troubleshooting-Timeouts.md
+++ b/tensorflow/docs/Troubleshooting-Timeouts.md
@@ -1,0 +1,55 @@
+# Troubleshooting GPU timeouts in tensorflow-directml
+
+Because tensorflow-directml supports such a wide range of hardware (including consumer gaming and integrated GPUs), it is occasionally possible to encounter a training workload that causes a *GPU timeout* on some hardware/drivers.
+
+GPU timeouts are caused by long-running workloads that exceed the system-defined GPU preemption timeout, which is 2 seconds by default. The exact circumstances that cause a GPU timeout depend on a wide variety of factors, including the specific hardware and driver configuration used.
+
+If you encounter a GPU timeout in tensorflow-directml, you'll see an error message similar to the following:
+
+```
+The DirectML device has encountered an unrecoverable error (DXGI_ERROR_DEVICE_HUNG).
+This is most often caused by a timeout occurring on the GPU. Please visit
+https://aka.ms/??? for more information and troubleshooting steps.
+
+HRESULT failed with 0x887a0005: readback_heap->Map(0, nullptr, &readback_heap_data)
+```
+
+If you see this error, there are several ways to mitigate the problem:
+
+### #1: Ensure you are using the latest version of tensorflow-directml
+
+tensorflow-directml is still in active development. With each release we continually make improvements to stability and performance, which can help to resolve timeouts caused by large training workloads. It's highly recommended to keep your copy of tensorflow-directml updated to the latest whenever possible.
+
+To install the latest [tensorflow-directml package](https://pypi.org/project/tensorflow-directml/) from PyPi, run the following on your command line:
+
+```
+pip install tensorflow-directml --upgrade
+```
+
+### #2: Ensure your GPU drivers are up-to-date
+
+We recommend using the latest stable drivers from your GPU vendor wherever possible. GPU driver updates can be downloaded from the following locations:
+
+* **For AMD GPUs:** [AMD Drivers and Support](https://www.amd.com/en/support)
+* **For Intel GPUs:** [Intel Download Center](https://downloadcenter.intel.com/)
+* **For NVIDIA GPUs:** [NVIDIA Driver Downloads](https://www.nvidia.com/Download/index.aspx)
+
+### #3: Exclude smaller GPUs from being used with DirectML
+
+By default, all compatible GPUs are made available to be used by DirectML. This means that both integrated and discrete GPUs can be used with DirectML.
+
+On hybrid systems that have *both* integrated and discrete GPUs available (such as those found in many laptops), it may be desirable to limit tensorflow-directml to use only one of the two GPUs. This can be done using the `DML_VISIBLE_DEVICES` environment variable.
+
+For example if your system has both an integrated and a discrete GPU (with device IDs of 0 and 1 respectively) and you want tensorflow-directml to only use the discrete GPU, you can `set DML_VISIBLE_DEVICES=1` to force only the second GPU to be visible.
+
+For more detailed instructions on controlling GPU visibility with tensorflow-directml, see the [FAQ for TensorFlow with DirectML](https://docs.microsoft.com/windows/win32/direct3d12/gpu-faq#i-have-multiple-gpus-how-do-i-select-which-one-is-used-by-directml).
+
+### #4: Try a smaller workload, for example by reducing the batch size
+
+GPU timeouts occur when a non-preemptable workload runs on the GPU for too long. During training, this is most likely to occur when performing expensive operations with very large tensors and/or large batch size.
+
+If timeouts are occurring on your GPU, you can try using smaller tensors or lowering the batch size during training to reduce the compute workload.
+
+### #5: Disable GPU timeouts using system-wide registry key (advanced users only)
+
+

--- a/tensorflow/docs/Troubleshooting-Timeouts.md
+++ b/tensorflow/docs/Troubleshooting-Timeouts.md
@@ -9,7 +9,7 @@ If you encounter a GPU timeout in tensorflow-directml, you'll see an error messa
 ```
 The DirectML device has encountered an unrecoverable error (DXGI_ERROR_DEVICE_HUNG).
 This is most often caused by a timeout occurring on the GPU. Please visit
-https://aka.ms/??? for more information and troubleshooting steps.
+https://aka.ms/tastycheese for more information and troubleshooting steps.
 
 HRESULT failed with 0x887a0005: readback_heap->Map(0, nullptr, &readback_heap_data)
 ```
@@ -46,10 +46,33 @@ For more detailed instructions on controlling GPU visibility with tensorflow-dir
 
 ### #4: Try a smaller workload, for example by reducing the batch size
 
-GPU timeouts occur when a non-preemptable workload runs on the GPU for too long. During training, this is most likely to occur when performing expensive operations with very large tensors and/or large batch size.
+GPU timeouts occur when a non-preemptable workload runs on the GPU for too long. During training, this is most likely to occur when performing expensive operations with very large tensors and/or large batch size. Examples of this include convolutions with large filters and/or large batch sizes, and matrix multiplications with very large tensors.
 
 If timeouts are occurring on your GPU, you can try using smaller tensors or lowering the batch size during training to reduce the compute workload.
 
 ### #5: Disable GPU timeouts using system-wide registry key (advanced users only)
 
+If you have tried all of the above and are still experiencing GPU timeouts, it is possible to modify or disable GPU timeout protections (known as Timeout Detection and Recovery, or TDR) in Windows 10.
 
+Note that modifying or disabling timeout protections carries risks to your computer. GPU timeouts protect your system from intentional or accidental denial-of-service of GPU resources, and help to ensure a stable and responsive user experience. If timeouts are disabled and an extremely long-running workload is dispatched to the GPU, you may experience system hangs or other instabilities.
+
+For this reason, it is only recommended to modify timeout settings as a last resort. For more information, see [Timeout detection and recovery (TDR) (docs.microsoft.com)](https://docs.microsoft.com/windows-hardware/drivers/display/timeout-detection-and-recovery).
+
+#### Modifying TDR settings
+
+> **Note:** this is for advanced users only. Incorrectly editing the system registry can result in system instability. Make sure you understand the risks before modifying system registry keys.
+
+To modify the system TDR settings, you will need to edit the following registry key (or create it if it doesn't already exist):
+
+```
+KeyPath   : HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\GraphicsDrivers
+KeyValue  : TdrDelay
+ValueType : REG_DWORD
+ValueData : Number of seconds to delay. The default value is 2 seconds.
+```
+
+You should pick a value that is sufficiently large for your training workload to run successfully on your particular GPU. For example, a timeout of 10 seconds is often sufficient for all but the most extreme of workloads.
+
+Changes to this registry key require a system reboot to take effect.
+
+For more information about TDR registry keys, see [Testing and debugging TDR](https://docs.microsoft.com/windows-hardware/drivers/display/tdr-registry-keys).

--- a/tensorflow/docs/Troubleshooting-Timeouts.md
+++ b/tensorflow/docs/Troubleshooting-Timeouts.md
@@ -2,14 +2,14 @@
 
 Because tensorflow-directml supports such a wide range of hardware (including consumer gaming and integrated GPUs), it is occasionally possible to encounter a training workload that causes a *GPU timeout* on some hardware/drivers.
 
-GPU timeouts are caused by long-running workloads that exceed the system-defined GPU preemption timeout, which is 2 seconds by default. The exact circumstances that cause a GPU timeout depend on a wide variety of factors, including the specific hardware and driver configuration used.
+GPU timeouts are caused by long-running workloads that exceed the system-defined GPU preemption timeout, which is 2 seconds by default. At the lowest level, the exact circumstance that causes a GPU timeout is when a non-preemptable dispatch runs on the GPU for a time that exceeds the defined limit. A "dispatch" often corresponds to the evaluation of a single TensorFlow operator (like conv2d, or matmul) on the GPU. Because of this, the prevalence of timeouts depends on a wide variety of factors, including the specific hardware and driver configuration used.
 
 If you encounter a GPU timeout in tensorflow-directml, you'll see an error message similar to the following:
 
 ```
 The DirectML device has encountered an unrecoverable error (DXGI_ERROR_DEVICE_HUNG).
 This is most often caused by a timeout occurring on the GPU. Please visit
-https://aka.ms/ilikecheese for more information and troubleshooting steps.
+https://aka.ms/tfdmltimeout for more information and troubleshooting steps.
 
 HRESULT failed with 0x887a0005: readback_heap->Map(0, nullptr, &readback_heap_data)
 ```


### PR DESCRIPTION
* Device removals now universally abort instead of trying to recover
* Add detection of device removal in DML_CHECK_SUCEEDED, and print a diagnostic
* Add doc containing troubleshooting steps