### PR TITLE
Fix spurious OOMs on integrated GPUs

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_adapter.cc
+++ b/tensorflow/core/common_runtime/dml/dml_adapter.cc
@@ -37,12 +37,12 @@ uint64_t DmlAdapter::GetTotalDedicatedMemory() const {
   return impl_->GetTotalDedicatedMemory();
 }
 
-uint64_t DmlAdapter::QueryAvailableDedicatedMemory() const {
-  return impl_->QueryAvailableDedicatedMemory();
+uint64_t DmlAdapter::GetTotalSharedMemory() const {
+  return impl_->GetTotalSharedMemory();
 }
 
-uint64_t DmlAdapter::QueryAvailableSharedMemory() const {
-  return impl_->QueryAvailableSharedMemory();
+uint64_t DmlAdapter::QueryAvailableLocalMemory() const {
+  return impl_->QueryAvailableLocalMemory();
 }
 
 const char* GetVendorName(VendorID id) {

--- a/tensorflow/core/common_runtime/dml/dml_adapter.cc
+++ b/tensorflow/core/common_runtime/dml/dml_adapter.cc
@@ -41,6 +41,10 @@ uint64_t DmlAdapter::QueryAvailableDedicatedMemory() const {
   return impl_->QueryAvailableDedicatedMemory();
 }
 
+uint64_t DmlAdapter::QueryAvailableSharedMemory() const {
+  return impl_->QueryAvailableSharedMemory();
+}
+
 const char* GetVendorName(VendorID id) {
   switch (id) {
     case VendorID::kAmd:

--- a/tensorflow/core/common_runtime/dml/dml_adapter.h
+++ b/tensorflow/core/common_runtime/dml/dml_adapter.h
@@ -90,6 +90,7 @@ class DmlAdapter {
   bool IsComputeOnly() const;
   uint64_t GetTotalDedicatedMemory() const;
   uint64_t QueryAvailableDedicatedMemory() const;
+  uint64_t QueryAvailableSharedMemory() const;
 
  private:
   // This object is immutable, so this is shared to allow copies.

--- a/tensorflow/core/common_runtime/dml/dml_adapter.h
+++ b/tensorflow/core/common_runtime/dml/dml_adapter.h
@@ -89,8 +89,8 @@ class DmlAdapter {
   const std::string& Name() const;
   bool IsComputeOnly() const;
   uint64_t GetTotalDedicatedMemory() const;
-  uint64_t QueryAvailableDedicatedMemory() const;
-  uint64_t QueryAvailableSharedMemory() const;
+  uint64_t GetTotalSharedMemory() const;
+  uint64_t QueryAvailableLocalMemory() const;
 
  private:
   // This object is immutable, so this is shared to allow copies.

--- a/tensorflow/core/common_runtime/dml/dml_adapter_impl.cc
+++ b/tensorflow/core/common_runtime/dml/dml_adapter_impl.cc
@@ -167,6 +167,17 @@ uint64_t DmlAdapterImpl::QueryAvailableDedicatedMemory() const {
   return info.Budget;
 }
 
+uint64_t DmlAdapterImpl::QueryAvailableSharedMemory() const {
+  ComPtr<IDXGIAdapter3> adapter3;
+  DML_CHECK_SUCCEEDED(adapter_.As(&adapter3));
+
+  DXGI_QUERY_VIDEO_MEMORY_INFO info = {};
+  DML_CHECK_SUCCEEDED(adapter3->QueryVideoMemoryInfo(
+      0, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL, &info));
+
+  return info.Budget;
+}
+
 std::vector<DmlAdapterImpl> EnumerateAdapterImpls() {
   ComPtr<IDXGIFactory6> dxgi_factory;
   DML_CHECK_SUCCEEDED(CreateDXGIFactory(IID_PPV_ARGS(&dxgi_factory)));
@@ -258,6 +269,21 @@ uint64_t DmlAdapterImpl::QueryAvailableDedicatedMemory() const {
   DXCoreAdapterMemoryBudgetNodeSegmentGroup query = {};
   query.nodeIndex = 0;
   query.segmentGroup = DXCoreSegmentGroup::Local;
+
+  DXCoreAdapterMemoryBudget info = {};
+  DML_CHECK_SUCCEEDED(dxcore_adapter->QueryState(
+      DXCoreAdapterState::AdapterMemoryBudget, &query, &info));
+
+  return info.budget;
+}
+
+uint64_t DmlAdapterImpl::QueryAvailableSharedMemory() const {
+  ComPtr<IDXCoreAdapter> dxcore_adapter;
+  DML_CHECK_SUCCEEDED(adapter_.As(&dxcore_adapter));
+
+  DXCoreAdapterMemoryBudgetNodeSegmentGroup query = {};
+  query.nodeIndex = 0;
+  query.segmentGroup = DXCoreSegmentGroup::NonLocal;
 
   DXCoreAdapterMemoryBudget info = {};
   DML_CHECK_SUCCEEDED(dxcore_adapter->QueryState(

--- a/tensorflow/core/common_runtime/dml/dml_adapter_impl.h
+++ b/tensorflow/core/common_runtime/dml/dml_adapter_impl.h
@@ -45,6 +45,7 @@ class DmlAdapterImpl {
   }
 
   uint64_t QueryAvailableDedicatedMemory() const;
+  uint64_t QueryAvailableSharedMemory() const;
 
  private:
 #if _WIN32

--- a/tensorflow/core/common_runtime/dml/dml_adapter_impl.h
+++ b/tensorflow/core/common_runtime/dml/dml_adapter_impl.h
@@ -44,8 +44,11 @@ class DmlAdapterImpl {
     return dedicated_memory_in_bytes_;
   }
 
-  uint64_t QueryAvailableDedicatedMemory() const;
-  uint64_t QueryAvailableSharedMemory() const;
+  uint64_t GetTotalSharedMemory() const {
+    return shared_memory_in_bytes_;
+  }
+
+  uint64_t QueryAvailableLocalMemory() const;
 
  private:
 #if _WIN32
@@ -62,6 +65,7 @@ class DmlAdapterImpl {
   std::string description_;
   bool is_compute_only_;
   uint64_t dedicated_memory_in_bytes_;
+  uint64_t shared_memory_in_bytes_;
 };
 
 // Retrieves a list of DML-compatible hardware adapters on the system.

--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -159,24 +159,17 @@ class DmlDeviceFactory : public DeviceFactory {
           // limit as a fraction of TOTAL GPU memory
           uint64_t total_gpu_memory = adapter.GetTotalDedicatedMemory();
 
+          if (IsUmaAdapter(adapter)) {
+            // For adapters with unified memory architecture (UMA), add shared
+            // memory to the total GPU memory
+            total_gpu_memory += adapter.GetTotalSharedMemory();
+          }
+
           memory_limit = total_gpu_memory * memory_fraction;
         } else {
           // No per_process_gpu_memory_fraction was specified: use a memory
           // limit equal to the AVAILALBLE GPU memory
-          uint64_t available_gpu_memory =
-              adapter.QueryAvailableDedicatedMemory();
-
-          if (IsUmaAdapter(adapter)) {
-            // For adapters with unified memory architecture (UMA), add shared
-            // memory to the total available memory
-            available_gpu_memory += adapter.QueryAvailableSharedMemory();
-          }
-
-          LOG(INFO) << "!!! ADAPTER INFO:\n"
-                    << "Dedicated: " << adapter.QueryAvailableDedicatedMemory()
-                    << "\n"
-                    << "Shared: " << adapter.QueryAvailableSharedMemory()
-                    << "\n";
+          uint64_t available_gpu_memory = adapter.QueryAvailableLocalMemory();
 
           memory_limit = available_gpu_memory;
         }

--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -169,7 +169,8 @@ class DmlDeviceFactory : public DeviceFactory {
         } else {
           // No per_process_gpu_memory_fraction was specified: use a memory
           // limit equal to the AVAILALBLE GPU memory
-          uint64_t available_gpu_memory = adapter.QueryAvailableLocalMemory();
+          uint64_t available_gpu_memory =
+              adapter.QueryAvailableLocalMemory();
 
           memory_limit = available_gpu_memory;
         }


### PR DESCRIPTION
Fixes reported OOMs on integrated GPUs when per_process_gpu_memory_fraction is set. The cause of this bug was that we were only considering dedicated memory when computing the total GPU memory available, and integrated GPUs don't have any dedicated memory. Now, for UMA adapters we will include shared memory as part of a GPU's total memory.