### PR TITLE
Fix list kernels and tensor array ops registration

### DIFF
--- a/build.py
+++ b/build.py
@@ -200,7 +200,7 @@ def build(args):
   if args.subcommands:
     cl.append("--subcommands")
   cl.append("--config=opt")
-  cl.append("--config=dml")
+  cl.append("--config=cuda")
   if args.telemetry:
     cl.append("--config=dml_telemetry")
   if args.config == "debug":

--- a/build.py
+++ b/build.py
@@ -200,7 +200,7 @@ def build(args):
   if args.subcommands:
     cl.append("--subcommands")
   cl.append("--config=opt")
-  cl.append("--config=cuda")
+  cl.append("--config=dml")
   if args.telemetry:
     cl.append("--config=dml_telemetry")
   if args.config == "debug":

--- a/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/gpu/gpu_id_manager.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_id_utils.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_init.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_mem_allocator.h"
 #include "tensorflow/core/common_runtime/pool_allocator.h"
 #include "tensorflow/core/common_runtime/shared_counter.h"
 #include "tensorflow/core/framework/allocator.h"

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2735,6 +2735,9 @@ tf_kernel_library(
     gpu_srcs = [
         "list_kernels.cu.cc",
         "list_kernels.h",
+        "tensor_array.h",
+        "aggregate_ops.h",
+        "split_lib.h",
     ],
     deps = [
         ":concat_lib",

--- a/tensorflow/core/kernels/list_kernels.cc
+++ b/tensorflow/core/kernels/list_kernels.cc
@@ -264,7 +264,7 @@ REGISTER_KERNEL_BUILDER(Name("EmptyTensorList").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(Name("EmptyTensorList")
-                            .Device(DEVICE_GPU)
+                            .Device(DEVICE_DML)
                             .HostMemory("element_shape")
                             .HostMemory("max_num_elements"),
                         EmptyTensorList);
@@ -331,7 +331,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListPushBack").Device(DEVICE_CPU),
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-REGISTER_KERNEL_BUILDER(Name("TensorListPushBack").Device(DEVICE_GPU),
+REGISTER_KERNEL_BUILDER(Name("TensorListPushBack").Device(DEVICE_DML),
                         TensorListPushBack);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -363,7 +363,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListLength").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(
-    Name("TensorListLength").Device(DEVICE_GPU).HostMemory("length"),
+    Name("TensorListLength").Device(DEVICE_DML).HostMemory("length"),
     TensorListLength);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -411,7 +411,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListElementShape").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(Name("TensorListElementShape")
-                            .Device(DEVICE_GPU)
+                            .Device(DEVICE_DML)
                             .HostMemory("element_shape"),
                         TensorListElementShape);
 
@@ -457,7 +457,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListReserve").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(Name("TensorListReserve")
-                            .Device(DEVICE_GPU)
+                            .Device(DEVICE_DML)
                             .HostMemory("element_shape")
                             .HostMemory("num_elements"),
                         TensorListReserve);
@@ -530,7 +530,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListResize").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(
-    Name("TensorListResize").Device(DEVICE_GPU).HostMemory("size"),
+    Name("TensorListResize").Device(DEVICE_DML).HostMemory("size"),
     TensorListResize);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -586,7 +586,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListSetItem").Device(DEVICE_CPU),
 #define REGISTER_TENSOR_LIST_SET_ITEM_GPU(T)                      \
   REGISTER_KERNEL_BUILDER(Name("TensorListSetItem")               \
                               .TypeConstraint<T>("element_dtype") \
-                              .Device(DEVICE_GPU)                 \
+                              .Device(DEVICE_DML)                 \
                               .HostMemory("index"),               \
                           TensorListSetItem);
 
@@ -714,7 +714,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListConcatLists").Device(DEVICE_CPU),
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-REGISTER_KERNEL_BUILDER(Name("TensorListConcatLists").Device(DEVICE_GPU),
+REGISTER_KERNEL_BUILDER(Name("TensorListConcatLists").Device(DEVICE_DML),
                         TensorListConcatLists);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -825,6 +825,17 @@ REGISTER_UNARY_VARIANT_UNARY_OP_FUNCTION(ZEROS_LIKE_VARIANT_UNARY_OP,
                               .Device(DEVICE_DML)                          \
                               .HostMemory("lengths"),                      \
                           TensorListConcat<DMLDevice, T>)                  \
+  REGISTER_KERNEL_BUILDER(Name("TensorListConcatV2")                       \
+                              .TypeConstraint<T>("element_dtype")          \
+                              .Device(DEVICE_DML)                          \
+                              .HostMemory("leading_dims")                  \
+                              .HostMemory("element_shape")                 \
+                              .HostMemory("lengths"),                      \
+                          TensorListConcat<DMLDevice, T>)                  \
+  REGISTER_KERNEL_BUILDER(Name("TensorListPushBackBatch")                  \
+                              .TypeConstraint<T>("element_dtype")          \
+                              .Device(DEVICE_DML),                         \
+                          TensorListPushBackBatch<DMLDevice, T>)           \
   REGISTER_KERNEL_BUILDER(Name("TensorListFromTensor")                     \
                               .TypeConstraint<T>("element_dtype")          \
                               .Device(DEVICE_DML)                          \
@@ -843,10 +854,6 @@ REGISTER_UNARY_VARIANT_UNARY_OP_FUNCTION(ZEROS_LIKE_VARIANT_UNARY_OP,
                               .HostMemory("num_elements")                  \
                               .HostMemory("indices"),                      \
                           TensorListScatter<DMLDevice, T>)                 \
-  REGISTER_KERNEL_BUILDER(Name("TensorListPushBackBatch")                  \
-                              .TypeConstraint<T>("element_dtype")          \
-                              .Device(DEVICE_DML),                         \
-                          TensorListPushBackBatch<DMLDevice, T>)           \
   REGISTER_KERNEL_BUILDER(Name("TensorListScatterIntoExistingList")        \
                               .TypeConstraint<T>("element_dtype")          \
                               .Device(DEVICE_DML)                          \
@@ -859,7 +866,15 @@ REGISTER_UNARY_VARIANT_UNARY_OP_FUNCTION(ZEROS_LIKE_VARIANT_UNARY_OP,
                               .HostMemory("lengths"),                      \
                           TensorListSplit<DMLDevice, T>)
 
-TF_CALL_ALL_TYPES(REGISTER_TENSOR_LIST_OPS_DML);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_TENSOR_LIST_OPS_DML);
+REGISTER_TENSOR_LIST_OPS_DML(bfloat16);
+TF_CALL_complex64(REGISTER_TENSOR_LIST_OPS_DML);
+TF_CALL_complex128(REGISTER_TENSOR_LIST_OPS_DML);
+TF_CALL_int32(REGISTER_TENSOR_LIST_OPS_DML);
+TF_CALL_int64(REGISTER_TENSOR_LIST_OPS_DML);
+REGISTER_TENSOR_LIST_OPS_DML(bool);
+
+#undef REGISTER_TENSOR_LIST_OPS_DML
 
 #endif  // TENSORFLOW_USE_DIRECTML
 

--- a/tensorflow/core/kernels/list_kernels.cc
+++ b/tensorflow/core/kernels/list_kernels.cc
@@ -264,7 +264,7 @@ REGISTER_KERNEL_BUILDER(Name("EmptyTensorList").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(Name("EmptyTensorList")
-                            .Device(DEVICE_DML)
+                            .Device(DEVICE_GPU)
                             .HostMemory("element_shape")
                             .HostMemory("max_num_elements"),
                         EmptyTensorList);
@@ -331,7 +331,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListPushBack").Device(DEVICE_CPU),
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-REGISTER_KERNEL_BUILDER(Name("TensorListPushBack").Device(DEVICE_DML),
+REGISTER_KERNEL_BUILDER(Name("TensorListPushBack").Device(DEVICE_GPU),
                         TensorListPushBack);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -363,7 +363,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListLength").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(
-    Name("TensorListLength").Device(DEVICE_DML).HostMemory("length"),
+    Name("TensorListLength").Device(DEVICE_GPU).HostMemory("length"),
     TensorListLength);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -411,7 +411,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListElementShape").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(Name("TensorListElementShape")
-                            .Device(DEVICE_DML)
+                            .Device(DEVICE_GPU)
                             .HostMemory("element_shape"),
                         TensorListElementShape);
 
@@ -457,7 +457,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListReserve").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(Name("TensorListReserve")
-                            .Device(DEVICE_DML)
+                            .Device(DEVICE_GPU)
                             .HostMemory("element_shape")
                             .HostMemory("num_elements"),
                         TensorListReserve);
@@ -530,7 +530,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListResize").Device(DEVICE_CPU),
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_KERNEL_BUILDER(
-    Name("TensorListResize").Device(DEVICE_DML).HostMemory("size"),
+    Name("TensorListResize").Device(DEVICE_GPU).HostMemory("size"),
     TensorListResize);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -586,7 +586,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListSetItem").Device(DEVICE_CPU),
 #define REGISTER_TENSOR_LIST_SET_ITEM_GPU(T)                      \
   REGISTER_KERNEL_BUILDER(Name("TensorListSetItem")               \
                               .TypeConstraint<T>("element_dtype") \
-                              .Device(DEVICE_DML)                 \
+                              .Device(DEVICE_GPU)                 \
                               .HostMemory("index"),               \
                           TensorListSetItem);
 
@@ -714,7 +714,7 @@ REGISTER_KERNEL_BUILDER(Name("TensorListConcatLists").Device(DEVICE_CPU),
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-REGISTER_KERNEL_BUILDER(Name("TensorListConcatLists").Device(DEVICE_DML),
+REGISTER_KERNEL_BUILDER(Name("TensorListConcatLists").Device(DEVICE_GPU),
                         TensorListConcatLists);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/list_kernels.h
+++ b/tensorflow/core/kernels/list_kernels.h
@@ -36,6 +36,7 @@ using DMLDevice = tensorflow::tensor_array::DMLDeviceTag;
 #include "tensorflow/core/framework/variant_op_registry.h"
 #include "tensorflow/core/kernels/concat_lib.h"
 #include "tensorflow/core/kernels/fill_functor.h"
+#include "tensorflow/core/kernels/tensor_array.h"
 #include "tensorflow/core/lib/core/coding.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/refcount.h"

--- a/tensorflow/core/kernels/tensor_array.cc
+++ b/tensorflow/core/kernels/tensor_array.cc
@@ -27,6 +27,15 @@ typedef Eigen::GpuDevice GPUDevice;
 
 namespace tensor_array {
 
+#define TENSOR_ARRAY_WRITE_OR_ADD_UNSUPPORTED(Device, T)                    \
+  template <>                                                               \
+  Status AddToTensor<Device, T>(OpKernelContext * ctx, Tensor * sum,        \
+                                const Tensor* current, const Tensor* add) { \
+    return errors::InvalidArgument(                                         \
+        "tensor_array::AddToTensor type not supported: ",                   \
+        DataTypeString(DataTypeToEnum<T>::value));                          \
+  }
+
 #define TENSOR_ARRAY_WRITE_OR_ADD(Device, T)                                \
   template <>                                                               \
   Status AddToTensor<Device, T>(OpKernelContext * ctx, Tensor * sum,        \
@@ -37,8 +46,14 @@ namespace tensor_array {
     return Status::OK();                                                    \
   }
 
+#define TENSOR_ARRAY_WRITE_OR_ADD_CPU_UNSUPPORTED(T) \
+  TENSOR_ARRAY_WRITE_OR_ADD_UNSUPPORTED(CPUDevice, T)
 #define TENSOR_ARRAY_WRITE_OR_ADD_CPU(T) TENSOR_ARRAY_WRITE_OR_ADD(CPUDevice, T)
-TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_CPU)
+TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
+TF_CALL_string(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
+TF_CALL_bool(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
+TF_CALL_variant(TENSOR_ARRAY_WRITE_OR_ADD_CPU_UNSUPPORTED);
+TF_CALL_resource(TENSOR_ARRAY_WRITE_OR_ADD_CPU_UNSUPPORTED);
 #undef TENSOR_ARRAY_WRITE_OR_ADD_CPU
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -47,11 +62,20 @@ TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_CPU)
 TF_CALL_GPU_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 TF_CALL_complex64(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 TF_CALL_complex128(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
+TF_CALL_bfloat16(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 #undef TENSOR_ARRAY_WRITE_OR_ADD_GPU
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #undef TENSOR_ARRAY_WRITE_OR_ADD
+
+#define TENSOR_ARRAY_SET_ZERO_UNSUPPORTED(Device, T)                       \
+  template <>                                                              \
+  Status TensorSetZero<Device, T>(OpKernelContext * ctx, Tensor * value) { \
+    return errors::InvalidArgument(                                        \
+        "tensor_array::TensorSetZero type not supported: ",                \
+        DataTypeString(DataTypeToEnum<T>::value));                         \
+  }
 
 #define TENSOR_ARRAY_SET_ZERO(Device, T)                                      \
   template <>                                                                 \
@@ -61,9 +85,19 @@ TF_CALL_complex128(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
     return Status::OK();                                                      \
   }
 
+#define TENSOR_ARRAY_SET_ZERO_CPU_UNSUPPORTED(T) \
+  TENSOR_ARRAY_SET_ZERO_UNSUPPORTED(CPUDevice, T)
 #define TENSOR_ARRAY_SET_ZERO_CPU(T) TENSOR_ARRAY_SET_ZERO(CPUDevice, T)
 TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_SET_ZERO_CPU);
 TF_CALL_bool(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_qint8(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_qint16(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_qint32(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_quint8(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_quint16(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_string(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_variant(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_resource(TENSOR_ARRAY_SET_ZERO_CPU_UNSUPPORTED);
 #undef TENSOR_ARRAY_SET_ZERO_CPU
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -72,6 +106,10 @@ TF_CALL_bool(TENSOR_ARRAY_SET_ZERO_CPU);
 TF_CALL_GPU_NUMBER_TYPES(TENSOR_ARRAY_SET_ZERO_GPU);
 TF_CALL_complex64(TENSOR_ARRAY_SET_ZERO_GPU);
 TF_CALL_complex128(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_int32(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_int64(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_bfloat16(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_bool(TENSOR_ARRAY_SET_ZERO_GPU);
 #undef TENSOR_ARRAY_SET_ZERO_GPU
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -91,6 +129,13 @@ TF_CALL_complex128(TENSOR_ARRAY_SET_ZERO_GPU);
 #define TENSOR_COPY_UNALIGNED_CPU(T) TENSOR_COPY_UNALIGNED(CPUDevice, T)
 TF_CALL_NUMBER_TYPES(TENSOR_COPY_UNALIGNED_CPU);
 TF_CALL_bool(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_qint8(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_qint16(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_qint32(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_quint8(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_quint16(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_string(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_variant(TENSOR_COPY_UNALIGNED_CPU);
 #undef TENSOR_COPY_UNALIGNED_CPU
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -99,6 +144,10 @@ TF_CALL_bool(TENSOR_COPY_UNALIGNED_CPU);
 TF_CALL_GPU_NUMBER_TYPES(TENSOR_COPY_UNALIGNED_GPU);
 TF_CALL_complex64(TENSOR_COPY_UNALIGNED_GPU);
 TF_CALL_complex128(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_int32(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_int64(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_bfloat16(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_bool(TENSOR_COPY_UNALIGNED_GPU);
 #undef TENSOR_COPY_UNALIGNED_GPU
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/tensor_array.h
+++ b/tensorflow/core/kernels/tensor_array.h
@@ -46,7 +46,7 @@ namespace tensor_array {
 // Full implementations are in tensor_array.cc
 template <typename Device, typename T>
 Status AddToTensor(OpKernelContext* ctx, Tensor* sum, const Tensor* current,
-                   const Tensor* add);
+                   const Tensor* add) = delete;
 
 #define TENSOR_ARRAY_WRITE_OR_ADD(Device, T)                         \
   template <>                                                        \
@@ -75,7 +75,7 @@ TF_CALL_bfloat16(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 #undef TENSOR_ARRAY_WRITE_OR_ADD
 
 template <typename Device, typename T>
-Status TensorSetZero(OpKernelContext* ctx, Tensor* value);
+Status TensorSetZero(OpKernelContext* ctx, Tensor* value) = delete;
 
 #define TENSOR_ARRAY_SET_ZERO(Device, T) \
   template <>                            \
@@ -111,7 +111,8 @@ TF_CALL_bool(TENSOR_ARRAY_SET_ZERO_GPU);
 #undef TENSOR_ARRAY_SET_ZERO
 
 template <typename Device, typename T>
-Status TensorCopyUnaligned(OpKernelContext* ctx, Tensor* src, Tensor* dst);
+Status TensorCopyUnaligned(OpKernelContext* ctx, Tensor* src,
+                           Tensor* dst) = delete;
 
 #define TENSOR_COPY_UNALIGNED(Device, T)                                     \
   template <>                                                                \

--- a/tensorflow/core/kernels/tensor_array.h
+++ b/tensorflow/core/kernels/tensor_array.h
@@ -17,8 +17,10 @@ limitations under the License.
 #define TENSORFLOW_CORE_KERNELS_TENSOR_ARRAY_H_
 
 #include <limits.h>
+
 #include <vector>
 
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/partial_tensor_shape.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -45,11 +47,7 @@ namespace tensor_array {
 // Full implementations are in tensor_array.cc
 template <typename Device, typename T>
 Status AddToTensor(OpKernelContext* ctx, Tensor* sum, const Tensor* current,
-                   const Tensor* add) {
-  return errors::InvalidArgument(
-      "tensor_array::AddToTensor type not supported: ",
-      DataTypeString(DataTypeToEnum<T>::value));
-};
+                   const Tensor* add);
 
 #define TENSOR_ARRAY_WRITE_OR_ADD(Device, T)                         \
   template <>                                                        \
@@ -57,7 +55,11 @@ Status AddToTensor(OpKernelContext* ctx, Tensor* sum, const Tensor* current,
                                 const Tensor* current, const Tensor* add);
 
 #define TENSOR_ARRAY_WRITE_OR_ADD_CPU(T) TENSOR_ARRAY_WRITE_OR_ADD(CPUDevice, T)
-TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_CPU)
+TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
+TF_CALL_string(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
+TF_CALL_bool(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
+TF_CALL_variant(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
+TF_CALL_resource(TENSOR_ARRAY_WRITE_OR_ADD_CPU);
 #undef TENSOR_ARRAY_WRITE_OR_ADD_CPU
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -66,6 +68,7 @@ TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_CPU)
 TF_CALL_GPU_NUMBER_TYPES(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 TF_CALL_complex64(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 TF_CALL_complex128(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
+TF_CALL_bfloat16(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 #undef TENSOR_ARRAY_WRITE_OR_ADD_GPU
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -73,11 +76,7 @@ TF_CALL_complex128(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 #undef TENSOR_ARRAY_WRITE_OR_ADD
 
 template <typename Device, typename T>
-Status TensorSetZero(OpKernelContext* ctx, Tensor* value) {
-  return errors::InvalidArgument(
-      "tensor_array::TensorSetZero type not supported: ",
-      DataTypeString(DataTypeToEnum<T>::value));
-};
+Status TensorSetZero(OpKernelContext* ctx, Tensor* value);
 
 #define TENSOR_ARRAY_SET_ZERO(Device, T) \
   template <>                            \
@@ -86,6 +85,14 @@ Status TensorSetZero(OpKernelContext* ctx, Tensor* value) {
 #define TENSOR_ARRAY_SET_ZERO_CPU(T) TENSOR_ARRAY_SET_ZERO(CPUDevice, T)
 TF_CALL_NUMBER_TYPES(TENSOR_ARRAY_SET_ZERO_CPU);
 TF_CALL_bool(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_qint8(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_qint16(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_qint32(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_quint8(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_quint16(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_string(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_variant(TENSOR_ARRAY_SET_ZERO_CPU);
+TF_CALL_resource(TENSOR_ARRAY_SET_ZERO_CPU);
 #undef TENSOR_ARRAY_SET_ZERO_CPU
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -94,6 +101,10 @@ TF_CALL_bool(TENSOR_ARRAY_SET_ZERO_CPU);
 TF_CALL_GPU_NUMBER_TYPES(TENSOR_ARRAY_SET_ZERO_GPU);
 TF_CALL_complex64(TENSOR_ARRAY_SET_ZERO_GPU);
 TF_CALL_complex128(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_int32(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_int64(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_bfloat16(TENSOR_ARRAY_SET_ZERO_GPU);
+TF_CALL_bool(TENSOR_ARRAY_SET_ZERO_GPU);
 #undef TENSOR_ARRAY_SET_ZERO_GPU
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -101,11 +112,7 @@ TF_CALL_complex128(TENSOR_ARRAY_SET_ZERO_GPU);
 #undef TENSOR_ARRAY_SET_ZERO
 
 template <typename Device, typename T>
-Status TensorCopyUnaligned(OpKernelContext* ctx, Tensor* src, Tensor* dst) {
-  return errors::InvalidArgument(
-      "tensor_array::TensorSetZero type not supported: ",
-      DataTypeString(DataTypeToEnum<T>::value));
-};
+Status TensorCopyUnaligned(OpKernelContext* ctx, Tensor* src, Tensor* dst);
 
 #define TENSOR_COPY_UNALIGNED(Device, T)                                     \
   template <>                                                                \
@@ -115,6 +122,13 @@ Status TensorCopyUnaligned(OpKernelContext* ctx, Tensor* src, Tensor* dst) {
 #define TENSOR_COPY_UNALIGNED_CPU(T) TENSOR_COPY_UNALIGNED(CPUDevice, T)
 TF_CALL_NUMBER_TYPES(TENSOR_COPY_UNALIGNED_CPU);
 TF_CALL_bool(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_qint8(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_qint16(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_qint32(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_quint8(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_quint16(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_string(TENSOR_COPY_UNALIGNED_CPU);
+TF_CALL_variant(TENSOR_COPY_UNALIGNED_CPU);
 #undef TENSOR_COPY_UNALIGNED_CPU
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -123,6 +137,10 @@ TF_CALL_bool(TENSOR_COPY_UNALIGNED_CPU);
 TF_CALL_GPU_NUMBER_TYPES(TENSOR_COPY_UNALIGNED_GPU);
 TF_CALL_complex64(TENSOR_COPY_UNALIGNED_GPU);
 TF_CALL_complex128(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_int32(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_int64(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_bfloat16(TENSOR_COPY_UNALIGNED_GPU);
+TF_CALL_bool(TENSOR_COPY_UNALIGNED_GPU);
 #undef TENSOR_COPY_UNALIGNED_GPU
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/tensor_array.h
+++ b/tensorflow/core/kernels/tensor_array.h
@@ -20,7 +20,6 @@ limitations under the License.
 
 #include <vector>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/partial_tensor_shape.h"
 #include "tensorflow/core/framework/register_types.h"

--- a/tensorflow/stream_executor/platform/default/BUILD
+++ b/tensorflow/stream_executor/platform/default/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow/stream_executor:__subpackages__"])
 
-load("//tensorflow:tensorflow.bzl", "tf_copts")
+load("//tensorflow:tensorflow.bzl", "tf_copts", "if_windows")
 
 cc_library(
     name = "platform",
@@ -30,4 +30,5 @@ cc_library(
         "@local_config_tensorrt//:tensorrt_headers",
         "@dml_redist//:headers",
     ],
+    linkopts = if_windows(["-DEFAULTLIB:pathcch.lib"]) 
 )


### PR DESCRIPTION
Tensor array template helpers had default implementations because Variant and Resource don't have eigen implementations. The problem with having default implementations though is that the compiler can't tell us if we forgot to add registrations for new datatypes, which caused regression for DML, CPU and GPU devices when refactoring the List kernels recently.

The new approach that we're taking is to remove the default implementation and to instead explicitly register the unsupported types (e.g. Variant and Resource) to the old default implementation. This will make sure that the compiler will stop us in the future when we add kernels that use different datatypes.

This change also fixes lingering GPU issues since we haven't built the GPU flavor in a while.