### PR TITLE
Fix archive path for network share copies of build artifacts

### DIFF
--- a/third_party/dml/ci/pipeline/build.yml
+++ b/third_party/dml/ci/pipeline/build.yml
@@ -218,8 +218,9 @@ jobs:
       - powershell: |
           $ZipPath = "$(System.ArtifactsDirectory)\${{artifact}}.zip"
           Compress-Archive -Path '$(TfArtifactsPathWin)\artifacts' -DestinationPath $ZipPath -Verbose
-          New-Item -ItemType Directory -Path '${{parameters.archiveSharePath}}' -Force
-          Copy-Item -Path $ZipPath -Destination '${{parameters.archiveSharePath}}' -Verbose
+          $TargetPath = "${{parameters.archiveSharePath}}\$(Build.BuildID)"
+          New-Item -ItemType Directory -Path $TargetPath -Force
+          Copy-Item -Path $ZipPath -Destination $TargetPath -Verbose
         displayName: Copy to Network Share
         continueOnError: true
 


### PR DESCRIPTION
Artifacts should be copied to a subdirectory, not the root path.