### PR TITLE
Pipeline should continue if a test job fails

### DIFF
--- a/third_party/dml/ci/pipeline/test.yml
+++ b/third_party/dml/ci/pipeline/test.yml
@@ -57,6 +57,7 @@ jobs:
     - agent.name -equals $(agentName)
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
+  continueOnError: true
   workspace:
     clean: all
   steps:

--- a/third_party/dml/ci/pipeline/test.yml
+++ b/third_party/dml/ci/pipeline/test.yml
@@ -142,6 +142,7 @@ jobs:
   pool: ${{parameters.agentPools[0]}}
   timeoutInMinutes: 30
   condition: succeededOrFailed()
+  continueOnError: true
   variables:
     testArtifactsPath: $(System.ArtifactsDirectory)/${{parameters.resultsArtifactName}}
     testSummariesPath: $(System.ArtifactsDirectory)/summaries


### PR DESCRIPTION
Test jobs that fail because of test agents crashing, timing out, or otherwise failing shouldn't mark the entire build as failed.