### PR TITLE
Switch network share path to use build number instead of build ID

### DIFF
--- a/third_party/dml/ci/pipeline/build.yml
+++ b/third_party/dml/ci/pipeline/build.yml
@@ -218,7 +218,7 @@ jobs:
       - powershell: |
           $ZipPath = "$(System.ArtifactsDirectory)\${{artifact}}.zip"
           Compress-Archive -Path '$(TfArtifactsPathWin)\artifacts' -DestinationPath $ZipPath -Verbose
-          $TargetPath = "${{parameters.archiveSharePath}}\$(Build.BuildID)"
+          $TargetPath = "${{parameters.archiveSharePath}}\$(Build.BuildNumber)"
           New-Item -ItemType Directory -Path $TargetPath -Force
           Copy-Item -Path $ZipPath -Destination $TargetPath -Verbose
         displayName: Copy to Network Share


### PR DESCRIPTION
I meant to use the build number (e.g. `201208-1548.1.directml`) instead of the pipeline build ID. Oops. 