### PR TITLE
Register emulated kernel implementations for RandomStandardNormal and TruncatedNormal

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -8152,6 +8152,7 @@ tf_kernel_library(
         "dml_kernel_wrapper.h",
         "dml_ops_common.h",
         "assign_op.h",
+        "random_op.h",
         "stateless_random_ops.h",
         "tensor_array.h",
         "concat_lib.h",


### PR DESCRIPTION
For some reason, on some models, TensorFlow has a habit of forcibly colocating kernels like ApplyAdam with RandomUniform, RandomStandardNormal, and TruncatedNormal. This may be because the initial weights, which is what Adam optimizes, are initialized at training start by one of the Random operators.

This change registers a set of kernels to "emulate" support for RandomStandardNormal and TruncatedNormal. These kernels re-use the CPU implementations and merely upload the values to a GPU tensor. This means that computation is still done on the CPU (which is okay, since it's usually only done once during initialization), but the DML registration means they can now be colocated with other operators, like ApplyAdam.

This change should improve our AI-Benchmark scores by about 5-10%.