### PR TITLE
Add missing HostMemory int32 registrations for _Arg and _RetVal

### DIFF
--- a/tensorflow/core/kernels/function_ops.cc
+++ b/tensorflow/core/kernels/function_ops.cc
@@ -186,6 +186,7 @@ REGISTER_KERNEL_BUILDER(
                               .TypeConstraint<type>("T"),                      \
                           RetvalOp);                                           \
 
+TF_CALL_int32(DML_REGISTER_KERNEL);
 TF_CALL_resource(DML_REGISTER_KERNEL);
 TF_CALL_string(DML_REGISTER_KERNEL);
 #undef DML_REGISTER_KERNEL


### PR DESCRIPTION
This registration is missing when compared with the registered data types for the GPU. This should fix a few test failures.