### PR TITLE
Fix crash when attempting to copy string tensor from CPU to DML

### DIFF
--- a/tensorflow/core/common_runtime/eager/tensor_handle.cc
+++ b/tensorflow/core/common_runtime/eager/tensor_handle.cc
@@ -495,8 +495,8 @@ Status TensorHandle::CopyToDevice(EagerContext* ctx, tensorflow::Device* dstd,
     *output = *src;
     return Status::OK();
   }
-  if (!dst_device_context && (src->dtype() != tensorflow::DT_VARIANT &&
-                   !tensorflow::DataTypeCanUseMemcpy(src->dtype()))) {
+  if (dst_device_context && (src->dtype() != tensorflow::DT_VARIANT &&
+                             !tensorflow::DataTypeCanUseMemcpy(src->dtype()))) {
     return tensorflow::errors::InvalidArgument(
         "Can't copy Tensor with type ",
         tensorflow::DataTypeString(src->dtype()), " to device ", dstd->name(),


### PR DESCRIPTION
This code was modified a while ago, but there was a typo in the condition. The code is meant to be read as "throw an exception if the destination device is not CPU and the datatype is DT_STRING", but we were missing an exclamation mark in there.