### PR TITLE
Fix Select's flat output shape calculation when batch size is 0

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.cc
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.cc
@@ -154,4 +154,21 @@ std::vector<TensorShape> BatchNormGradShapeHelper::GetOutputShapes(
   };
 }
 
+TensorShape ComputeFlatOuterDims(const TensorShape& orig, int64 num_out_dims) {
+  TensorShape out_dims;
+
+  for (int64 out_dim = 0; out_dim < num_out_dims - 1; ++out_dim) {
+    int64 new_dim_size = out_dim >= orig.dims() ? 1 : orig.dim_size(out_dim);
+    out_dims.AddDim(new_dim_size);
+  }
+
+  int64 last_dim_size = 1;
+  for (int64 in_dim = num_out_dims - 1; in_dim < orig.dims(); ++in_dim) {
+    last_dim_size *= orig.dim_size(in_dim);
+  }
+  out_dims.AddDim(last_dim_size);
+
+  return out_dims;
+}
+
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.h
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.h
@@ -187,5 +187,6 @@ absl::InlinedVector<T, 5> IntTensorToVec(const tensorflow::Tensor& tensor) {
 }
 
 TensorShape BroadcastTensorShapes(absl::Span<const TensorShape> shapes);
+TensorShape ComputeFlatOuterDims(const TensorShape& orig, int64 num_out_dims);
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/dml_select_op.cc
+++ b/tensorflow/core/kernels/dml_select_op.cc
@@ -195,10 +195,13 @@ class SelectInitHelper : public BaseSelectInitHelper {
     }
 
     const uint32_t batch_size = static_cast<uint32_t>(then_shape.dim_size(0));
-    const uint32_t outer_dims_size =
-        then_shape.num_elements() / then_shape.dim_size(0);
+    TensorShape flat_outer_shape = ComputeFlatOuterDims(then_shape, 2);
 
-    dml::TensorDesc::Dimensions simple_shape({batch_size, outer_dims_size});
+    dml::TensorDesc::Dimensions simple_shape({
+        batch_size,
+        static_cast<uint32_t>(flat_outer_shape.dim_size(1)),
+    });
+
     simple_ternary_.cond_shape = {batch_size, 1};
     simple_ternary_.then_shape = simple_shape;
     simple_ternary_.else_shape = simple_shape;


### PR DESCRIPTION
Computing the flat outer dims as `TensorShape::num_elements() / TensorShape::dim_size(0)` doesn't work when the shape has dimensions of size 0. So I added a helper `ComputeFlatOuterDims`, which is basically a copy of the `Tensor` function, which we can't use because DML isn't an eigen device.