### PR TITLE
Link disabled test to grappler optimization task

### DIFF
--- a/tensorflow/python/training/experimental/mixed_precision_test.py
+++ b/tensorflow/python/training/experimental/mixed_precision_test.py
@@ -117,7 +117,10 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
     self.assertFalse(config.get_optimizer_experimental_options()
                      .get('auto_mixed_precision', False))
 
-  # TFDML #25510022
+  # DML doesn't have float16 optimizations in grappler yet, so we wouldn't
+  # overflow in this case
+  # TODO #26542950: Enable Tensorcore specific grappler optimizations
+  # TFDML #26542950
   @test_util.skip_dml
   @test_util.run_gpu_only
   @test_util.run_in_graph_and_eager_modes


### PR DESCRIPTION
DML devices don't have auto-mixed precision fast paths in grappler yet, so the float32 -> float16 overflow test doesn't work for us since it would never overflow.