### PR TITLE
Fix shape simplification for Pad

### DIFF
--- a/tensorflow/core/kernels/dml_pad_op.cc
+++ b/tensorflow/core/kernels/dml_pad_op.cc
@@ -51,7 +51,7 @@ absl::optional<SimplePad> SimplifyPad(const TensorShape& input_shape,
                                       const Tensor& paddings_tensor,
                                       bool constant_pad,
                                       size_t min_output_size = 4,
-                                      size_t max_output_size = 5) {
+                                      size_t max_output_size = 8) {
   auto paddings = paddings_tensor.matrix<Tpadding>();
   DCHECK(input_shape.dims() == paddings.dimension(0));
 


### PR DESCRIPTION
We use more aggressive shape simplification than the CPU for Pad, but this can only really work for Constant padding. For Reflect and Symmetric padding, we cannot collapse padded dimensions with non-padded dimensions since the padding values depend on the shape.