### PR TITLE
Make some debug tests run only on a CPU device

### DIFF
--- a/tensorflow/python/debug/wrappers/dumping_wrapper_test.py
+++ b/tensorflow/python/debug/wrappers/dumping_wrapper_test.py
@@ -46,17 +46,18 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
   def setUp(self):
     self.session_root = tempfile.mkdtemp()
 
-    self.v = variables.VariableV1(10.0, dtype=dtypes.float32, name="v")
-    self.delta = constant_op.constant(1.0, dtype=dtypes.float32, name="delta")
-    self.eta = constant_op.constant(-1.4, dtype=dtypes.float32, name="eta")
-    self.inc_v = state_ops.assign_add(self.v, self.delta, name="inc_v")
-    self.dec_v = state_ops.assign_add(self.v, self.eta, name="dec_v")
+    with test_util.device(use_gpu=False):
+      self.v = variables.VariableV1(10.0, dtype=dtypes.float32, name="v")
+      self.delta = constant_op.constant(1.0, dtype=dtypes.float32, name="delta")
+      self.eta = constant_op.constant(-1.4, dtype=dtypes.float32, name="eta")
+      self.inc_v = state_ops.assign_add(self.v, self.delta, name="inc_v")
+      self.dec_v = state_ops.assign_add(self.v, self.eta, name="dec_v")
 
-    self.ph = array_ops.placeholder(dtypes.float32, shape=(), name="ph")
-    self.inc_w_ph = state_ops.assign_add(self.v, self.ph, name="inc_w_ph")
+      self.ph = array_ops.placeholder(dtypes.float32, shape=(), name="ph")
+      self.inc_w_ph = state_ops.assign_add(self.v, self.ph, name="inc_w_ph")
 
-    self.sess = session.Session()
-    self.sess.run(self.v.initializer)
+      self.sess = session.Session()
+      self.sess.run(self.v.initializer)
 
   def tearDown(self):
     ops.reset_default_graph()
@@ -96,8 +97,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     # Cleanup.
     gfile.DeleteRecursively(new_dir_path)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingOnASingleRunWorks(self):
     sess = dumping_wrapper.DumpingDebugWrapperSession(
         self.sess, session_root=self.session_root, log_usage=False)
@@ -113,8 +112,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     self.assertEqual(repr(self.inc_v), dump.run_fetches_info)
     self.assertEqual(repr(None), dump.run_feed_keys_info)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingOnASingleRunWorksWithRelativePathForDebugDumpDir(self):
     sess = dumping_wrapper.DumpingDebugWrapperSession(
         self.sess, session_root=self.session_root, log_usage=False)
@@ -129,8 +126,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     finally:
       os.chdir(cwd)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingOnASingleRunWithFeedDictWorks(self):
     sess = dumping_wrapper.DumpingDebugWrapperSession(
         self.sess, session_root=self.session_root, log_usage=False)
@@ -147,8 +142,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     self.assertEqual(repr(self.inc_w_ph), dump.run_fetches_info)
     self.assertEqual(repr(feed_dict.keys()), dump.run_feed_keys_info)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingOnMultipleRunsWorks(self):
     sess = dumping_wrapper.DumpingDebugWrapperSession(
         self.sess, session_root=self.session_root, log_usage=False)
@@ -176,8 +169,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
           watch_fn=bad_watch_fn,
           log_usage=False)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingWithLegacyWatchFnOnFetchesWorks(self):
     """Use a watch_fn that returns different whitelists for different runs."""
 
@@ -220,8 +211,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
         self.assertEqual(repr(self.dec_v), dump.run_fetches_info)
         self.assertEqual(repr(None), dump.run_feed_keys_info)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingWithLegacyWatchFnWithNonDefaultDebugOpsWorks(self):
     """Use a watch_fn that specifies non-default debug ops."""
 
@@ -245,8 +234,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     self.assertEqual(14,
                      len(dump.get_tensors("v", 0, "DebugNumericSummary")[0]))
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingWithWatchFnWithNonDefaultDebugOpsWorks(self):
     """Use a watch_fn that specifies non-default debug ops."""
 
@@ -278,8 +265,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     self.assertNotIn("inc_v", dumped_nodes)
     self.assertNotIn("delta", dumped_nodes)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingDebugHookWithoutWatchFnWorks(self):
     dumping_hook = hooks.DumpingDebugHook(self.session_root, log_usage=False)
     mon_sess = monitored_session._HookedSession(self.sess, [dumping_hook])
@@ -295,8 +280,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     self.assertEqual(repr(self.inc_v), dump.run_fetches_info)
     self.assertEqual(repr(None), dump.run_feed_keys_info)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingDebugHookWithStatefulWatchFnWorks(self):
     watch_fn_state = {"run_counter": 0}
 
@@ -340,8 +323,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
       self.assertEqual(repr(self.inc_v), dump.run_fetches_info)
       self.assertEqual(repr(None), dump.run_feed_keys_info)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingDebugHookWithStatefulLegacyWatchFnWorks(self):
     watch_fn_state = {"run_counter": 0}
 
@@ -396,12 +377,7 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     dump_dirs = glob.glob(os.path.join(self.session_root, "run_*"))
     self.assertEqual(1, len(dump_dirs))
     dump = debug_data.DebugDumpDir(dump_dirs[0])
-
-    if test_util.is_gpu_available():
-      self.assertGreaterEqual(2, dump.size)
-    else:
-      self.assertEqual(1, dump.size)
-
+    self.assertEqual(1, dump.size)
     self.assertEqual("delta", dump.dumped_tensor_data[0].node_name)
 
   def testDumpingWrapperWithEmptyFetchWorks(self):

--- a/tensorflow/python/debug/wrappers/dumping_wrapper_test.py
+++ b/tensorflow/python/debug/wrappers/dumping_wrapper_test.py
@@ -378,8 +378,6 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
       self.assertEqual(repr(self.inc_v), dump.run_fetches_info)
       self.assertEqual(repr(None), dump.run_feed_keys_info)
 
-  # TFDML #25509707
-  @test_util.skip_dml
   def testDumpingFromMultipleThreadsObeysThreadNameFilter(self):
     sess = dumping_wrapper.DumpingDebugWrapperSession(
         self.sess, session_root=self.session_root, log_usage=False,
@@ -398,7 +396,12 @@ class DumpingDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     dump_dirs = glob.glob(os.path.join(self.session_root, "run_*"))
     self.assertEqual(1, len(dump_dirs))
     dump = debug_data.DebugDumpDir(dump_dirs[0])
-    self.assertEqual(1, dump.size)
+
+    if test_util.is_gpu_available():
+      self.assertGreaterEqual(2, dump.size)
+    else:
+      self.assertEqual(1, dump.size)
+
     self.assertEqual("delta", dump.dumped_tensor_data[0].node_name)
 
   def testDumpingWrapperWithEmptyFetchWorks(self):

--- a/tensorflow/python/debug/wrappers/framework_test.py
+++ b/tensorflow/python/debug/wrappers/framework_test.py
@@ -166,33 +166,34 @@ class DebugWrapperSessionTest(test_util.TensorFlowTestCase):
 
     self._sess = session.Session(config=self._no_rewrite_session_config())
 
-    self._a_init_val = np.array([[5.0, 3.0], [-1.0, 0.0]])
-    self._b_init_val = np.array([[2.0], [-1.0]])
-    self._c_val = np.array([[-4.0], [6.0]])
+    with test_util.device(use_gpu=False):
+      self._a_init_val = np.array([[5.0, 3.0], [-1.0, 0.0]])
+      self._b_init_val = np.array([[2.0], [-1.0]])
+      self._c_val = np.array([[-4.0], [6.0]])
 
-    self._a_init = constant_op.constant(
-        self._a_init_val, shape=[2, 2], name="a_init")
-    self._b_init = constant_op.constant(
-        self._b_init_val, shape=[2, 1], name="b_init")
+      self._a_init = constant_op.constant(
+          self._a_init_val, shape=[2, 2], name="a_init")
+      self._b_init = constant_op.constant(
+          self._b_init_val, shape=[2, 1], name="b_init")
 
-    self._ph = array_ops.placeholder(dtype=dtypes.float64, name="ph")
+      self._ph = array_ops.placeholder(dtype=dtypes.float64, name="ph")
 
-    self._a = variables.Variable(self._a_init, name="a1")
-    self._b = variables.Variable(self._b_init, name="b")
-    self._c = constant_op.constant(self._c_val, shape=[2, 1], name="c")
+      self._a = variables.Variable(self._a_init, name="a1")
+      self._b = variables.Variable(self._b_init, name="b")
+      self._c = constant_op.constant(self._c_val, shape=[2, 1], name="c")
 
-    # Matrix product of a and b.
-    self._p = math_ops.matmul(self._a, self._b, name="p1")
+      # Matrix product of a and b.
+      self._p = math_ops.matmul(self._a, self._b, name="p1")
 
-    # Matrix product of a and ph.
-    self._q = math_ops.matmul(self._a, self._ph, name="q")
+      # Matrix product of a and ph.
+      self._q = math_ops.matmul(self._a, self._ph, name="q")
 
-    # Sum of two vectors.
-    self._s = math_ops.add(self._p, self._c, name="s")
+      # Sum of two vectors.
+      self._s = math_ops.add(self._p, self._c, name="s")
 
-    # Initialize the variables.
-    self._sess.run(self._a.initializer)
-    self._sess.run(self._b.initializer)
+      # Initialize the variables.
+      self._sess.run(self._a.initializer)
+      self._sess.run(self._b.initializer)
 
   def tearDown(self):
     # Tear down temporary dump directory.


### PR DESCRIPTION
Some debug tests were not written to run on GPU devices and will fail if a GPU device (CUDA or DML) is used because it dumps more tensors than expected. This was verified with the main TensorFlow 1.15.4 branch where these tests fail when CUDA devices are enabled.