### PR TITLE
Double test timeout to 2 hours

### DIFF
--- a/third_party/dml/ci/pipeline/test.yml
+++ b/third_party/dml/ci/pipeline/test.yml
@@ -55,7 +55,7 @@ jobs:
     name: $(agentPool)
     demands:
     - agent.name -equals $(agentName)
-  timeoutInMinutes: 60
+  timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
   continueOnError: true
   workspace:


### PR DESCRIPTION
Our nightly test pass is sufficiently large that some of our slower machines (e.g. the quad cores) are hitting the 1 hour timeout.