### PR TITLE
Fix GetLocalDMLInfo calls in grappler optimizers

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_device_cache.h
+++ b/tensorflow/core/common_runtime/dml/dml_device_cache.h
@@ -38,12 +38,43 @@ class DmlDeviceCache {
 
   const DmlAdapter& GetAdapter(uint32_t adapter_index) const;
 
+  // Parts of the grappler will look up physical hardware properties using a TF
+  // device specification (e.g. '/device:DML:0'). However, TF device IDs are not
+  // directly equivalent to the adapter index. Device IDs to adapter index
+  // mappings are influenced by two separate mechanisms:
+  //
+  // 1. ConfigProto.gpu_options.visible_device_list : can hide or permute the
+  //    order of adapter indices. For example, "1,0" maps "DML:0" to
+  //    adapter index 1 and "DML:1" to adapter index 0.
+  //
+  // 2. ConfigProto.gpu_options.experimental.virtual_devices : can partition a
+  //    single physical adapter into multiple logical devices. For example,
+  //    "DML:0" and "DML:1" may both use the same adapter 0.
+  //
+  // These two methods serve as a way to translate a device ID to the correct
+  // adapter index, but there is a problem: the visible_device_list is scoped to
+  // a TF session, and a single process can have multiple sessions. This would
+  // be manageable if sessions had unique IDs and the grappler code propagated
+  // this ID to its hardware lookup functions, but alas this is not the case.
+  // Consequently, these helpers are on a process-wide singleton and they may
+  // fail if multiple sessions use different visible device lists (same as GPU
+  // helpers).
+  //
+  // NOTE: the virtual_devices can only be configured once, so they're
+  // effectively scoped to the process and do not cause problems with this
+  // singleton approach.
+  Status MapDeviceIdToAdapterIndex(int device_id, uint32_t adapter_index);
+  Status GetAdapterIndexFromDeviceId(int device_id, uint32_t* adapter_index);
+
  private:
   DmlDeviceCache();
 
   mutable std::mutex mutex_;
 
   std::vector<DmlAdapter> adapters_;
+
+  using TDeviceToAdapterMap = std::unordered_map<int, uint32_t>;
+  TDeviceToAdapterMap device_id_to_adapter_index_map_;
 
   // Lazily constructed
   std::vector<std::unique_ptr<DmlDeviceState>> device_states_;

--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -169,8 +169,7 @@ class DmlDeviceFactory : public DeviceFactory {
         } else {
           // No per_process_gpu_memory_fraction was specified: use a memory
           // limit equal to the AVAILALBLE GPU memory
-          uint64_t available_gpu_memory =
-              adapter.QueryAvailableLocalMemory();
+          uint64_t available_gpu_memory = adapter.QueryAvailableLocalMemory();
 
           memory_limit = available_gpu_memory;
         }
@@ -179,8 +178,11 @@ class DmlDeviceFactory : public DeviceFactory {
             device_cache.GetOrCreateDeviceState(i, gpu_options, memory_limit);
 
         auto dml_device =
-            CreateDevice(options, name_prefix, virtual_device_index++,
+            CreateDevice(options, name_prefix, virtual_device_index,
                          device_state, memory_limit);
+
+        TF_RETURN_IF_ERROR(
+            device_cache.MapDeviceIdToAdapterIndex(virtual_device_index++, i));
 
         devices->push_back(std::move(dml_device));
       } else {
@@ -195,8 +197,11 @@ class DmlDeviceFactory : public DeviceFactory {
           const DmlDeviceState* device_state =
               device_cache.GetOrCreateDeviceState(i, gpu_options, memory_limit);
           auto dml_device =
-              CreateDevice(options, name_prefix, virtual_device_index++,
+              CreateDevice(options, name_prefix, virtual_device_index,
                            device_state, memory_limit);
+
+          TF_RETURN_IF_ERROR(device_cache.MapDeviceIdToAdapterIndex(
+              virtual_device_index++, i));
 
           devices->push_back(std::move(dml_device));
         }

--- a/tensorflow/core/grappler/clusters/utils.h
+++ b/tensorflow/core/grappler/clusters/utils.h
@@ -32,7 +32,7 @@ DeviceProperties GetLocalGPUInfo(PlatformGpuId platform_gpu_id);
 
 // Returns the DeviceProperties for the specified DML-compatible adapter
 // attached to the server on which grappler is running.
-DeviceProperties GetLocalDMLInfo(int device_id);
+DeviceProperties GetLocalDMLInfo(uint32_t adapter_index);
 
 // Returns the DeviceProperties of the specified device
 DeviceProperties GetDeviceInfo(const DeviceNameUtils::ParsedName& device);


### PR DESCRIPTION
Some parts of grappler look up physical device properties when clustering or building a cost model. Our current implementation assumes that TF device IDs map directly to DX adapter IDs, which is _usually_ correct but not always. It's easy to break the grappler simply by using virtual device mappings (i.e. treating a single physical device as multiple logical devices), and reordering the visible device list will result in the wrong hardware properties being used.

Sadly, the solution to this problem is imperfect: the grappler doesn't have enough context to correctly map device IDs to adapter IDs in all cases because visible device lists are unique to each TF session. We adopt the same (unfortunate) solution that GPU devices use: maintain device ID to adapter ID mappings in a process-wide singleton and raise an error if a client tries to reorder visible device mappings.