### PR TITLE
Remove unreachable kernel registration and add a few C tests

### DIFF
--- a/build.py
+++ b/build.py
@@ -128,6 +128,13 @@ def build_tests(args):
                 "-manual",
                 "dml",
             ],
+        ),
+        (
+            "//tensorflow/c/...",
+            [
+                "-no_dml",
+                "-manual",
+            ],
         )
     ]
 

--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -427,6 +427,7 @@ tf_cc_test(
         ":env",
         ":kernels",
     ],
+    tags = ["no_windows"], # Uses UNIX system headers
 )
 
 tf_cuda_cc_test(
@@ -444,6 +445,7 @@ tf_cuda_cc_test(
     }),
     tags = [
         "noasan",
+        "no_dml", # XLA-related build breaks
     ],
     # We must ensure that the dependencies can be dynamically linked since
     # the shared library must be able to use core:framework.

--- a/tensorflow/c/c_api_function_test.cc
+++ b/tensorflow/c/c_api_function_test.cc
@@ -1260,11 +1260,10 @@ TEST_F(CApiFunctionTest, GraphToFunctionDefWithPlaceholderAttr) {
   NodeWithPlaceholderAttrHelper(func_graph.get(), s.get(), "node3", "v2",
                                 &node3);
 
-  TF_Output inputs[] = {};
   TF_Output outputs[] = {{node1, 0}, {node2, 0}, {node3, 0}};
   func_ = TF_GraphToFunction(
       func_graph.get(), "func", /*append_hash_to_fn_name=*/false, -1,
-      /*opers=*/nullptr, 0, inputs, 3, outputs,
+      /*opers=*/nullptr, 0, nullptr, 3, outputs,
       /*output_names=*/nullptr,
       /*opts=*/nullptr, /*description=*/nullptr, s.get());
   ASSERT_EQ(TF_OK, TF_GetCode(s.get())) << TF_Message(s.get());
@@ -1300,10 +1299,9 @@ TEST_F(CApiFunctionTest, GraphToFunctionDefWithArgAttr) {
                      &node);
 
   TF_Output inputs[] = {{node, 0}};
-  TF_Output outputs[] = {};
   func_ = TF_GraphToFunction(
       func_graph.get(), "func", /*append_hash_to_fn_name=*/false, -1,
-      /*opers=*/nullptr, 1, inputs, 0, outputs,
+      /*opers=*/nullptr, 1, inputs, 0, nullptr,
       /*output_names=*/nullptr,
       /*opts=*/nullptr, /*description=*/nullptr, s.get());
   ASSERT_EQ(TF_OK, TF_GetCode(s.get())) << TF_Message(s.get());
@@ -1603,11 +1601,10 @@ void DefineStatefulFunction(const char* name, TF_Function** func) {
   TF_Operation* random =
       RandomUniform(shape, TF_FLOAT, func_graph.get(), s.get());
 
-  TF_Output inputs[] = {};
   TF_Output outputs[] = {{random, 0}};
   *func = TF_GraphToFunction(func_graph.get(), name,
                              /*append_hash_to_fn_name=*/false, -1,
-                             /*opers=*/nullptr, 0, inputs, 1, outputs,
+                             /*opers=*/nullptr, 0, nullptr, 1, outputs,
                              /*output_names=*/nullptr,
                              /*opts=*/nullptr, "", s.get());
   ASSERT_EQ(TF_OK, TF_GetCode(s.get())) << TF_Message(s.get());

--- a/tensorflow/core/common_runtime/dml/dml_device_cache.h
+++ b/tensorflow/core/common_runtime/dml/dml_device_cache.h
@@ -38,12 +38,43 @@ class DmlDeviceCache {
 
   const DmlAdapter& GetAdapter(uint32_t adapter_index) const;
 
+  // Parts of the grappler will look up physical hardware properties using a TF
+  // device specification (e.g. '/device:DML:0'). However, TF device IDs are not
+  // directly equivalent to the adapter index. Device IDs to adapter index
+  // mappings are influenced by two separate mechanisms:
+  //
+  // 1. ConfigProto.gpu_options.visible_device_list : can hide or permute the
+  //    order of adapter indices. For example, "1,0" maps "DML:0" to
+  //    adapter index 1 and "DML:1" to adapter index 0.
+  //
+  // 2. ConfigProto.gpu_options.experimental.virtual_devices : can partition a
+  //    single physical adapter into multiple logical devices. For example,
+  //    "DML:0" and "DML:1" may both use the same adapter 0.
+  //
+  // These two methods serve as a way to translate a device ID to the correct
+  // adapter index, but there is a problem: the visible_device_list is scoped to
+  // a TF session, and a single process can have multiple sessions. This would
+  // be manageable if sessions had unique IDs and the grappler code propagated
+  // this ID to its hardware lookup functions, but alas this is not the case.
+  // Consequently, these helpers are on a process-wide singleton and they may
+  // fail if multiple sessions use different visible device lists (same as GPU
+  // helpers).
+  //
+  // NOTE: the virtual_devices can only be configured once, so they're
+  // effectively scoped to the process and do not cause problems with this
+  // singleton approach.
+  Status MapDeviceIdToAdapterIndex(int device_id, uint32_t adapter_index);
+  Status GetAdapterIndexFromDeviceId(int device_id, uint32_t* adapter_index);
+
  private:
   DmlDeviceCache();
 
   mutable std::mutex mutex_;
 
   std::vector<DmlAdapter> adapters_;
+
+  using TDeviceToAdapterMap = std::unordered_map<int, uint32_t>;
+  TDeviceToAdapterMap device_id_to_adapter_index_map_;
 
   // Lazily constructed
   std::vector<std::unique_ptr<DmlDeviceState>> device_states_;

--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -169,8 +169,7 @@ class DmlDeviceFactory : public DeviceFactory {
         } else {
           // No per_process_gpu_memory_fraction was specified: use a memory
           // limit equal to the AVAILALBLE GPU memory
-          uint64_t available_gpu_memory =
-              adapter.QueryAvailableLocalMemory();
+          uint64_t available_gpu_memory = adapter.QueryAvailableLocalMemory();
 
           memory_limit = available_gpu_memory;
         }
@@ -179,8 +178,11 @@ class DmlDeviceFactory : public DeviceFactory {
             device_cache.GetOrCreateDeviceState(i, gpu_options, memory_limit);
 
         auto dml_device =
-            CreateDevice(options, name_prefix, virtual_device_index++,
+            CreateDevice(options, name_prefix, virtual_device_index,
                          device_state, memory_limit);
+
+        TF_RETURN_IF_ERROR(
+            device_cache.MapDeviceIdToAdapterIndex(virtual_device_index++, i));
 
         devices->push_back(std::move(dml_device));
       } else {
@@ -195,8 +197,11 @@ class DmlDeviceFactory : public DeviceFactory {
           const DmlDeviceState* device_state =
               device_cache.GetOrCreateDeviceState(i, gpu_options, memory_limit);
           auto dml_device =
-              CreateDevice(options, name_prefix, virtual_device_index++,
+              CreateDevice(options, name_prefix, virtual_device_index,
                            device_state, memory_limit);
+
+          TF_RETURN_IF_ERROR(device_cache.MapDeviceIdToAdapterIndex(
+              virtual_device_index++, i));
 
           devices->push_back(std::move(dml_device));
         }

--- a/tensorflow/core/grappler/clusters/utils.h
+++ b/tensorflow/core/grappler/clusters/utils.h
@@ -32,7 +32,7 @@ DeviceProperties GetLocalGPUInfo(PlatformGpuId platform_gpu_id);
 
 // Returns the DeviceProperties for the specified DML-compatible adapter
 // attached to the server on which grappler is running.
-DeviceProperties GetLocalDMLInfo(int device_id);
+DeviceProperties GetLocalDMLInfo(uint32_t adapter_index);
 
 // Returns the DeviceProperties of the specified device
 DeviceProperties GetDeviceInfo(const DeviceNameUtils::ParsedName& device);

--- a/tensorflow/core/kernels/dml_training_ops.cc
+++ b/tensorflow/core/kernels/dml_training_ops.cc
@@ -1252,10 +1252,6 @@ class DmlApplyKerasMomentumKernel : public DmlTrainingKernel {
 
 #define REGISTER_KERNEL(type)                                                  \
   REGISTER_KERNEL_BUILDER(                                                     \
-      Name("ApplyKerasMomentum").Device(DEVICE_DML).TypeConstraint<type>("T"), \
-      DmlKernelWrapper<DmlApplyKerasMomentumKernel,                            \
-                       GetBroadcastedOutputShapeHelper>);                      \
-  REGISTER_KERNEL_BUILDER(                                                     \
       Name("ResourceApplyKerasMomentum")                                       \
           .Device(DEVICE_DML)                                                  \
           .HostMemory("var")                                                   \

--- a/third_party/dml/ci/gather_test_binaries.py
+++ b/third_party/dml/ci/gather_test_binaries.py
@@ -112,6 +112,15 @@ def main():
               "dml",
           ]
       ),
+      (
+          f"//tensorflow/c/...",
+          TargetKind.CC_TEST,
+          None,
+          [
+              "-no_dml",
+              "-manual",
+          ]
+      ),
   ]
 
   for _, _, _, tag_filters in test_groups:

--- a/third_party/dml/ci/pipeline/pipeline.yml
+++ b/third_party/dml/ci/pipeline/pipeline.yml
@@ -38,7 +38,7 @@ parameters:
 - name: testGroups
   displayName: Test Groups
   type: object
-  default: [python, core]
+  default: [python, core, c]
 
 - name: enableTests
   displayName: Enable Tests

--- a/third_party/dml/ci/run_tests_data.json
+++ b/third_party/dml/ci/run_tests_data.json
@@ -24,6 +24,14 @@
         "--test_framework": "gtest"
       },
       "isPythonTest": false
+    },
+    "c": {
+      "script": "tfdml_test_runner.py",
+      "arguments": {
+        "--test_binaries_path": "test_binaries/c",
+        "--test_framework": "gtest"
+      },
+      "isPythonTest": false
     }
   }
 }


### PR DESCRIPTION
Removes the "ApplyKerasMomentum" kernel, which doesn't map to any operator. Additionally, this change enables a few C API tests.