### PR TITLE
Register ZerosLike with Variant datatype

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -5598,8 +5598,6 @@ tf_dml_cc_test(
         "//tensorflow/core:testlib",
         "//tensorflow/core/kernels:dml_ops",
         "//tensorflow/core/kernels:stateless_random_ops",
-        "//tensorflow/core/kernels:list_kernels",
-        "//tensorflow/core/kernels:tensor_array",
     ],
     extra_copts = if_windows([
         "-DDML_BUILD_WINDOWS",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -5597,7 +5597,7 @@ tf_dml_cc_test(
         "//tensorflow/core:test_main",
         "//tensorflow/core:testlib",
         "//tensorflow/core/kernels:dml_ops",
-        "//tensorflow/core/kernels:stateless_random_ops",
+        "//tensorflow/core:tensorflow",
     ],
     extra_copts = if_windows([
         "-DDML_BUILD_WINDOWS",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -5598,6 +5598,7 @@ tf_dml_cc_test(
         "//tensorflow/core:testlib",
         "//tensorflow/core/kernels:dml_ops",
         "//tensorflow/core/kernels:stateless_random_ops",
+        "//tensorflow/core/kernels:list_kernels",
     ],
     extra_copts = if_windows([
         "-DDML_BUILD_WINDOWS",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -5599,6 +5599,7 @@ tf_dml_cc_test(
         "//tensorflow/core/kernels:dml_ops",
         "//tensorflow/core/kernels:stateless_random_ops",
         "//tensorflow/core/kernels:list_kernels",
+        "//tensorflow/core/kernels:tensor_array",
     ],
     extra_copts = if_windows([
         "-DDML_BUILD_WINDOWS",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -8163,6 +8163,7 @@ tf_kernel_library(
         "dml_tensor_array.h",
         "dml_matrix_diag_helpers.h",
         "dml_extract_patches_helpers.h",
+        "//tensorflow/core/kernels/data:optional_ops.h",
     ],
     deps = NN_DEPS + [
         "//tensorflow/core:dml_runtime",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -8164,6 +8164,7 @@ tf_kernel_library(
         "dml_matrix_diag_helpers.h",
         "dml_extract_patches_helpers.h",
         "//tensorflow/core/kernels/data:optional_ops.h",
+        "//tensorflow/core/kernels:list_kernels.h",
     ],
     deps = NN_DEPS + [
         "//tensorflow/core:dml_runtime",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -8176,8 +8176,6 @@ tf_kernel_library(
         ":pooling_ops",
         ":rnn_ops",
         ":fused_batch_norm_op",
-        ":list_kernels",
-        ":tensor_array",
     ],
     copts = tf_copts() + if_windows([
         "-DDML_BUILD_WINDOWS",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -8163,8 +8163,8 @@ tf_kernel_library(
         "dml_tensor_array.h",
         "dml_matrix_diag_helpers.h",
         "dml_extract_patches_helpers.h",
+        "list_kernels.h",
         "//tensorflow/core/kernels/data:optional_ops.h",
-        "//tensorflow/core/kernels:list_kernels.h",
     ],
     deps = NN_DEPS + [
         "//tensorflow/core:dml_runtime",
@@ -8176,6 +8176,8 @@ tf_kernel_library(
         ":pooling_ops",
         ":rnn_ops",
         ":fused_batch_norm_op",
+        ":list_kernels",
+        ":tensor_array",
     ],
     copts = tf_copts() + if_windows([
         "-DDML_BUILD_WINDOWS",

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -17,30 +17,122 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/dml/dml_operator_helper.h"
 #include "tensorflow/core/common_runtime/dml/dml_util.h"
 #include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/data/optional_ops.h"
 #include "tensorflow/core/kernels/dml_kernel_wrapper.h"
 #include "tensorflow/core/kernels/dml_ops_common.h"
 
 namespace tensorflow {
+
+static Status DmlUnaryOpVariant(OpKernelContext* ctx, VariantUnaryOp op,
+                                const Variant& v, Variant* v_out);
+
+static void SetTensorToZero(OpKernelContext* ctx, const Tensor& tensor) {
+  DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
+
+  D3D12BufferRegion output_buffer =
+      dml_util::CreateBufferForTensor(device, tensor);
+
+  uint8_t pattern[] = {0};
+
+  device->GetExecutionContext()->FillBufferWithPattern(
+      output_buffer.Resource(), output_buffer.Offset(),
+      output_buffer.SizeInBytes(), pattern);
+}
+
+static Status DmlZerosLikeTensor(OpKernelContext* ctx, const Tensor& x,
+                                 Tensor* out) {
+  AllocatorAttributes attr;
+  if (x.dtype() == DT_VARIANT) {
+    attr.set_on_host(true);
+  }
+  TF_RETURN_IF_ERROR(ctx->allocate_temp(x.dtype(), x.shape(), out, attr));
+
+  switch (out->dtype()) {
+#define DTYPE_CASE(dtype)            \
+  case DataTypeToEnum<dtype>::value: \
+    SetTensorToZero(ctx, *out);      \
+    break;
+
+    TF_CALL_POD_TYPES(DTYPE_CASE)
+#undef DTYPE_CASE
+
+    case DT_INVALID: {
+      *out = Tensor(DT_INVALID);
+      break;
+    }
+    case DataTypeToEnum<Variant>::value: {
+      Variant* out_variant = out->scalar<Variant>().data();
+      TF_RETURN_IF_ERROR(DmlUnaryOpVariant(ctx, ZEROS_LIKE_VARIANT_UNARY_OP,
+                                           x.scalar<Variant>()(), out_variant));
+      break;
+    }
+    default:
+      return errors::InvalidArgument(
+          "Trying to compute zeros_like for unsupported dtype ",
+          DataTypeString(out->dtype()));
+  }
+  return Status::OK();
+}
+
+static Status DmlOptionalZerosLike(OpKernelContext* ctx,
+                                   const data::OptionalVariant& x,
+                                   data::OptionalVariant* y) {
+  if (!x.has_value()) {
+    *y = x;
+    return Status::OK();
+  }
+  std::vector<Tensor> zero_tensors;
+  for (const Tensor& tensor : x.get_values()) {
+    Tensor zero_t;
+    TF_RETURN_IF_ERROR(DmlZerosLikeTensor(ctx, tensor, &zero_t));
+    zero_tensors.push_back(std::move(zero_t));
+  }
+  *y = data::OptionalVariant(zero_tensors);
+  return Status::OK();
+}
+
+static Status DmlUnaryOpVariant(OpKernelContext* ctx, VariantUnaryOp op,
+                                const Variant& v, Variant* v_out) {
+  DCHECK_NE(v_out, nullptr);
+  *v_out = data::OptionalVariant();
+  if (v.get<data::OptionalVariant>() == nullptr) {
+    return errors::Internal(
+        "VariantUnaryOpFn: Could not access object, type_index: ",
+        port::MaybeAbiDemangle(MakeTypeIndex<data::OptionalVariant>().name()));
+  }
+  const data::OptionalVariant& t = *v.get<data::OptionalVariant>();
+  data::OptionalVariant* t_out = v_out->get<data::OptionalVariant>();
+  return DmlOptionalZerosLike(ctx, t, t_out);
+}
 
 class DmlZerosLikeKernel : public OpKernel {
  public:
   explicit DmlZerosLikeKernel(OpKernelConstruction* ctx) : OpKernel(ctx) {}
 
   void Compute(OpKernelContext* ctx) override {
-    Tensor* output_tensor = nullptr;
-    OP_REQUIRES_OK(
-        ctx, ctx->allocate_output(0, ctx->input(0).shape(), &output_tensor));
+    const Tensor& input = ctx->input(0);
 
-    DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
+    if (input.dtype() == DT_VARIANT) {
+      OP_REQUIRES(
+          ctx, input.dims() == 0,
+          errors::InvalidArgument("ZerosLike non-scalar Tensor with "
+                                  "dtype=DT_VARIANT is not supported."));
+      const Variant& v = input.scalar<Variant>()();
+      // DT_VARIANT tensors must be allocated on CPU since they wrap C++
+      // objects which can not be efficiently represented in GPU memory.
+      int numa_node = DeviceNumaNode(ctx->device());
+      Tensor out(cpu_allocator(numa_node), DT_VARIANT, TensorShape({}));
+      Variant* out_v = &(out.scalar<Variant>()());
+      OP_REQUIRES_OK(
+          ctx, DmlUnaryOpVariant(ctx, ZEROS_LIKE_VARIANT_UNARY_OP, v, out_v));
+      ctx->set_output(0, out);
+    } else {
+      Tensor* output_tensor = nullptr;
+      OP_REQUIRES_OK(ctx,
+                     ctx->allocate_output(0, input.shape(), &output_tensor));
 
-    D3D12BufferRegion output_buffer =
-        dml_util::CreateBufferForTensor(device, *output_tensor);
-
-    uint8_t pattern[] = {0};
-
-    device->GetExecutionContext()->FillBufferWithPattern(
-        output_buffer.Resource(), output_buffer.Offset(),
-        output_buffer.SizeInBytes(), pattern);
+      SetTensorToZero(ctx, *output_tensor);
+    }
   }
 };
 
@@ -51,6 +143,7 @@ class DmlZerosLikeKernel : public OpKernel {
 
 // TODO(b/25387198): A special kernel exists for int32 (see constant_op.cc).
 TF_CALL_DML_ALL_TYPES_EXCEPT_INT32(REGISTER_DML_KERNEL)
+TF_CALL_variant(REGISTER_DML_KERNEL)
 #undef REGISTER_DML_KERNEL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -20,11 +20,15 @@ limitations under the License.
 #include "tensorflow/core/kernels/data/optional_ops.h"
 #include "tensorflow/core/kernels/dml_kernel_wrapper.h"
 #include "tensorflow/core/kernels/dml_ops_common.h"
+#include "tensorflow/core/kernels/list_kernels.h"
 
 namespace tensorflow {
 
 static Status DmlUnaryOpVariant(OpKernelContext* ctx, VariantUnaryOp op,
                                 const Variant& v, Variant* v_out);
+
+template <typename T>
+static Status DmlVariantZerosLike(OpKernelContext* ctx, const T& x, T* y);
 
 static void SetTensorToZero(OpKernelContext* ctx, const Tensor& tensor) {
   DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
@@ -74,9 +78,10 @@ static Status DmlZerosLikeTensor(OpKernelContext* ctx, const Tensor& x,
   return Status::OK();
 }
 
-static Status DmlOptionalZerosLike(OpKernelContext* ctx,
-                                   const data::OptionalVariant& x,
-                                   data::OptionalVariant* y) {
+template <>
+static Status DmlVariantZerosLike<data::OptionalVariant>(
+    OpKernelContext* ctx, const data::OptionalVariant& x,
+    data::OptionalVariant* y) {
   if (!x.has_value()) {
     *y = x;
     return Status::OK();
@@ -91,18 +96,33 @@ static Status DmlOptionalZerosLike(OpKernelContext* ctx,
   return Status::OK();
 }
 
+template <>
+static Status DmlVariantZerosLike<TensorList>(OpKernelContext* c,
+                                              const TensorList& x,
+                                              TensorList* y) {
+  y->element_dtype = x.element_dtype;
+  y->element_shape = x.element_shape;
+  y->tensors().reserve(x.tensors().size());
+  for (const Tensor& t : x.tensors()) {
+    Tensor out_tensor;
+    TF_RETURN_IF_ERROR(DmlZerosLikeTensor(c, t, &out_tensor));
+    y->tensors().emplace_back(out_tensor);
+  }
+  return Status::OK();
+}
+
 static Status DmlUnaryOpVariant(OpKernelContext* ctx, VariantUnaryOp op,
                                 const Variant& v, Variant* v_out) {
-  DCHECK_NE(v_out, nullptr);
-  *v_out = data::OptionalVariant();
-  if (v.get<data::OptionalVariant>() == nullptr) {
+  UnaryVariantOpRegistry::VariantUnaryOpFn* unary_op_fn =
+      UnaryVariantOpRegistry::Global()->GetUnaryOpFn(op, DEVICE_DML,
+                                                     v.TypeId());
+  if (unary_op_fn == nullptr) {
     return errors::Internal(
-        "VariantUnaryOpFn: Could not access object, type_index: ",
-        port::MaybeAbiDemangle(MakeTypeIndex<data::OptionalVariant>().name()));
+        "No unary variant unary_op function found for unary variant op enum: ",
+        op, " Variant type_name: ", v.TypeName(),
+        " for device type: ", DEVICE_DML);
   }
-  const data::OptionalVariant& t = *v.get<data::OptionalVariant>();
-  data::OptionalVariant* t_out = v_out->get<data::OptionalVariant>();
-  return DmlOptionalZerosLike(ctx, t, t_out);
+  return (*unary_op_fn)(ctx, v, v_out);
 }
 
 class DmlZerosLikeKernel : public OpKernel {
@@ -110,29 +130,34 @@ class DmlZerosLikeKernel : public OpKernel {
   explicit DmlZerosLikeKernel(OpKernelConstruction* ctx) : OpKernel(ctx) {}
 
   void Compute(OpKernelContext* ctx) override {
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(0, ctx->input(0).shape(), &output_tensor));
+
+    SetTensorToZero(ctx, *output_tensor);
+  }
+};
+
+class DmlZerosLikeKernelVariant : public OpKernel {
+ public:
+  explicit DmlZerosLikeKernelVariant(OpKernelConstruction* ctx)
+      : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* ctx) override {
     const Tensor& input = ctx->input(0);
 
-    if (input.dtype() == DT_VARIANT) {
-      OP_REQUIRES(
-          ctx, input.dims() == 0,
-          errors::InvalidArgument("ZerosLike non-scalar Tensor with "
-                                  "dtype=DT_VARIANT is not supported."));
-      const Variant& v = input.scalar<Variant>()();
-      // DT_VARIANT tensors must be allocated on CPU since they wrap C++
-      // objects which can not be efficiently represented in GPU memory.
-      int numa_node = DeviceNumaNode(ctx->device());
-      Tensor out(cpu_allocator(numa_node), DT_VARIANT, TensorShape({}));
-      Variant* out_v = &(out.scalar<Variant>()());
-      OP_REQUIRES_OK(
-          ctx, DmlUnaryOpVariant(ctx, ZEROS_LIKE_VARIANT_UNARY_OP, v, out_v));
-      ctx->set_output(0, out);
-    } else {
-      Tensor* output_tensor = nullptr;
-      OP_REQUIRES_OK(ctx,
-                     ctx->allocate_output(0, input.shape(), &output_tensor));
-
-      SetTensorToZero(ctx, *output_tensor);
-    }
+    OP_REQUIRES(ctx, input.dims() == 0,
+                errors::InvalidArgument("ZerosLike non-scalar Tensor with "
+                                        "dtype=DT_VARIANT is not supported."));
+    const Variant& v = input.scalar<Variant>()();
+    // DT_VARIANT tensors must be allocated on CPU since they wrap C++
+    // objects which can not be efficiently represented in GPU memory.
+    int numa_node = DeviceNumaNode(ctx->device());
+    Tensor out(cpu_allocator(numa_node), DT_VARIANT, TensorShape({}));
+    Variant* out_v = &(out.scalar<Variant>()());
+    OP_REQUIRES_OK(
+        ctx, DmlUnaryOpVariant(ctx, ZEROS_LIKE_VARIANT_UNARY_OP, v, out_v));
+    ctx->set_output(0, out);
   }
 };
 
@@ -143,7 +168,19 @@ class DmlZerosLikeKernel : public OpKernel {
 
 // TODO(b/25387198): A special kernel exists for int32 (see constant_op.cc).
 TF_CALL_DML_ALL_TYPES_EXCEPT_INT32(REGISTER_DML_KERNEL)
-TF_CALL_variant(REGISTER_DML_KERNEL)
 #undef REGISTER_DML_KERNEL
+
+REGISTER_KERNEL_BUILDER(
+    Name("ZerosLike").Device(DEVICE_DML).TypeConstraint<Variant>("T"),
+    DmlZerosLikeKernelVariant);
+
+#define REGISTER_VARIANT_DML_KERNEL(TYPE)                               \
+  REGISTER_UNARY_VARIANT_UNARY_OP_FUNCTION(ZEROS_LIKE_VARIANT_UNARY_OP, \
+                                           DEVICE_DML, TYPE,            \
+                                           DmlVariantZerosLike<TYPE>);
+
+REGISTER_VARIANT_DML_KERNEL(data::OptionalVariant)
+REGISTER_VARIANT_DML_KERNEL(TensorList)
+#undef REGISTER_VARIANT_DML_KERNEL
 
 }  // namespace tensorflow


### PR DESCRIPTION
The GPU supports 2 types of variants: OptionalVariant and TensorList. Therefore, we should support the same variants for DML. This fixes a few test failures caused by not having variant registrations for ZerosLike.