### PR TITLE
Fix reduce special cases when the input is empty but the output is non-empty

### DIFF
--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -175,11 +175,10 @@ class DmlReduceKernel : public DmlKernel {
       DmlKernelTensors tensors;
       tensors.outputs.resize(1);
 
-      constexpr uint32_t dml_output_shape[] = {1u};
-
       tensors.outputs[0].emplace();
-      tensors.outputs[0]->desc = DmlTensorDesc::Create(
-          output_type, dml_output_shape, dml_output_shape);
+      tensors.outputs[0]->desc =
+          DmlTensorDesc::Create(output_type, ctx->GetOutputTensorShape(0),
+                                ctx->GetOutputTensorShape(0));
       tensors.outputs[0]->kernel_index = 0;
 
       auto output_descs = GetDmlTensorDescs(tensors.outputs);

--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -175,10 +175,13 @@ class DmlReduceKernel : public DmlKernel {
       DmlKernelTensors tensors;
       tensors.outputs.resize(1);
 
+      TensorShape dml_output_shape({
+          ctx->GetOutputTensorShape(0).num_elements(),
+      });
+
       tensors.outputs[0].emplace();
-      tensors.outputs[0]->desc =
-          DmlTensorDesc::Create(output_type, ctx->GetOutputTensorShape(0),
-                                ctx->GetOutputTensorShape(0));
+      tensors.outputs[0]->desc = DmlTensorDesc::Create(
+          output_type, dml_output_shape, dml_output_shape);
       tensors.outputs[0]->kernel_index = 0;
 
       auto output_descs = GetDmlTensorDescs(tensors.outputs);


### PR DESCRIPTION
We were assuming that the output would always be a scalar in this case, but it can be a tensor of any dimension.