### PR TITLE
Untangle DML/GPU in remapper and add _FusedMatMul for DML

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -255,7 +255,7 @@ bool IsDmlCompatibleDataType(const NodeDef* contraction,
                              const string& type_attr = "T") {
   DataType dtype = GetDataTypeFromAttr(*contraction, type_attr);
   if (IsConv2D(*contraction) || IsMatMul(*contraction)) {
-    return dtype == DT_FLOAT || dtype == DT_HALF;
+    return dtype == DT_FLOAT;
   } else {
     return false;
   }
@@ -1066,7 +1066,7 @@ bool FindFusedBatchNormEx(const RemapperContext& ctx, int node_index,
       if (!valid_channel_dim) return false;
 
       // cuDNN must support CUDNN_BATCHNORM_SPATIAL_PERSISTENT mode.
-      if (!BatchnormSpatialPersistentEnabled()) return false;
+      if (NodeIsOnGpu(fused_batch_norm_node_def) && !BatchnormSpatialPersistentEnabled()) return false;
     }
 
     // FusedBatchNormV2 and V3 have an extra type parameter.

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -363,7 +363,7 @@ bool IsGpuCompatible(const RemapperContext& ctx,
   return false;
 }
 
-// Checks if we can rewrite a pattern to the `_FusedConv2D` on GPU device.
+// Checks if we can rewrite a pattern to the `_Fused{Conv2D,MatMul}` on DML.
 bool IsDmlCompatible(const RemapperContext& ctx,
                      const ContractionWithBiasAddAndActivation& matched) {
   const GraphDef* graph = ctx.graph_view.graph();

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1029,9 +1029,9 @@ bool FindFusedBatchNormEx(const RemapperContext& ctx, int node_index,
     const auto* fused_batch_norm_node_def = fused_batch_norm.node();
     if (!IsFusedBatchNorm(*fused_batch_norm_node_def)) return false;
 
-    // We fuse FusedBatchNorm only on GPU, because on CPU we fuse it with
+    // We fuse FusedBatchNorm only on GPU/DML, because on CPU we fuse it with
     // contraction (MatMul or Conv2D node).
-    if (!NodeIsOnGpu(fused_batch_norm_node_def)) return false;
+    if (NodeIsOnCpu(fused_batch_norm_node_def)) return false;
 
     DataType t_dtype = GetDataTypeFromAttr(*fused_batch_norm_node_def, "T");
     if (t_dtype != DT_FLOAT && t_dtype != DT_HALF) return false;

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -308,12 +308,6 @@ bool IsCpuCompatibleMatMul(const NodeDef* matmul) {
 #endif  // !INTEL_MKL
 }
 
-bool IsGpuCompatibleMatMul(const NodeDef* matmul) {
-  DCHECK(IsMatMul(*matmul)) << "Expected MatMul op";
-  return NodeIsOnGpu(matmul) && IsGpuCompatibleDataType(matmul) &&
-         IsGpuCompatibleDataFormat(matmul);
-}
-
 bool IsDmlCompatibleMatMul(const NodeDef* matmul) {
   DCHECK(IsMatMul(*matmul)) << "Expected MatMul op";
   return NodeIsOnDml(matmul) && IsDmlCompatibleDataType(matmul);

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -310,6 +310,7 @@ bool IsGpuCompatible(const RemapperContext& ctx,
                      const ContractionWithBiasAddAndActivation& matched) {
   const GraphDef* graph = ctx.graph_view.graph();
   const NodeDef& contraction_node = graph->node(matched.contraction);
+  if (IsMatMul(contraction_node)) return true;
   if (!IsConv2D(contraction_node)) return false;
 
   const std::vector<OpInfo::TensorProperties>& input_props =

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -222,105 +222,110 @@ TEST_F(RemapperTest, FusedBatchNormNCHW) {
 TEST_F(RemapperTest, FuseBatchNormWithRelu) {
   using ::tensorflow::ops::Placeholder;
 
-  for (bool is_training : {true, false}) {
-    tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+  for (const string& device : {"/device:GPU:0", "/device:DML:0"}) {
+    for (bool is_training : {true, false}) {
+      tensorflow::Scope s = tensorflow::Scope::NewRootScope();
 
 #if !defined(GOOGLE_CUDA) || !(CUDNN_VERSION >= 7402)
-    if (is_training) {
-      LOG(INFO) << "Skip FuseBatchNormWithRelu"
-                << "[is_training=" << is_training << "] "
-                << "test. It requires CUDNN_VERSION >= 7402.";
-      continue;
-    }
+      if (is_training && device == "/device:GPU:0") {
+        LOG(INFO) << "Skip FuseBatchNormWithRelu"
+                  << "[is_training=" << is_training << "] "
+                  << "test. It requires CUDNN_VERSION >= 7402.";
+        continue;
+      }
 #endif
 
 #if !defined(GOOGLE_CUDA)
-    if (!is_training) {
-      LOG(INFO) << "Skip FuseBatchNormWithRelu"
-                << "[is_training=" << is_training << "]";
-      continue;
-    }
+      if (!is_training && device == "/device:GPU:0") {
+        LOG(INFO) << "Skip FuseBatchNormWithRelu"
+                  << "[is_training=" << is_training << "]";
+        continue;
+      }
 #endif
 
-    const int num_channels = 24;
+      const int num_channels = 24;
 
-    TensorShape channel_shape({num_channels});
-    TensorShape empty_shape({0});
+      TensorShape channel_shape({num_channels});
+      TensorShape empty_shape({0});
 
-    auto input = Placeholder(s.WithOpName("input"), DT_FLOAT,
-                             ops::Placeholder::Shape({2, 8, 8, num_channels}));
-    auto input_cast = ops::Cast(s.WithOpName("input_cast"), input, DT_HALF);
-    auto scale = Placeholder(s.WithOpName("scale"), DT_FLOAT);
-    auto offset = Placeholder(s.WithOpName("offset"), DT_FLOAT);
-    auto mean = Placeholder(s.WithOpName("mean"), DT_FLOAT);
-    auto var = Placeholder(s.WithOpName("var"), DT_FLOAT);
+      auto input =
+          Placeholder(s.WithOpName("input"), DT_FLOAT,
+                      ops::Placeholder::Shape({2, 8, 8, num_channels}));
+      auto input_cast = ops::Cast(s.WithOpName("input_cast"), input, DT_HALF);
+      auto scale = Placeholder(s.WithOpName("scale"), DT_FLOAT);
+      auto offset = Placeholder(s.WithOpName("offset"), DT_FLOAT);
+      auto mean = Placeholder(s.WithOpName("mean"), DT_FLOAT);
+      auto var = Placeholder(s.WithOpName("var"), DT_FLOAT);
 
-    float epsilon = 0.1f;
-    auto fbn = ops::FusedBatchNormV3(
-        s.WithOpName("fused_batch_norm"), input_cast, scale, offset, mean, var,
-        ops::FusedBatchNormV3::IsTraining(is_training)
-            .Epsilon(epsilon)
-            .DataFormat("NHWC"));
-    auto relu = ops::Relu(s.WithOpName("relu"), fbn.y);
-    auto fetch = ops::Identity(s.WithOpName("fetch"), relu);
+      float epsilon = 0.1f;
+      auto fbn =
+          ops::FusedBatchNormV3(s.WithOpName("fused_batch_norm"), input_cast,
+                                scale, offset, mean, var,
+                                ops::FusedBatchNormV3::IsTraining(is_training)
+                                    .Epsilon(epsilon)
+                                    .DataFormat("NHWC"));
+      auto relu = ops::Relu(s.WithOpName("relu"), fbn.y);
+      auto fetch = ops::Identity(s.WithOpName("fetch"), relu);
 
-    auto input_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
-    auto scale_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
-    auto offset_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
-    auto mean_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
-                                                             : channel_shape);
-    auto var_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
-                                                            : channel_shape);
+      auto input_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
+      auto scale_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+      auto offset_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+      auto mean_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
+                                                               : channel_shape);
+      auto var_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
+                                                              : channel_shape);
 
-    GrapplerItem item;
-    item.fetch = {"fetch"};
-    item.feed = {{"input", input_t},
-                 {"scale", scale_t},
-                 {"offset", offset_t},
-                 {"mean", mean_t},
-                 {"var", var_t}};
-    TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+      GrapplerItem item;
+      item.fetch = {"fetch"};
+      item.feed = {{"input", input_t},
+                   {"scale", scale_t},
+                   {"offset", offset_t},
+                   {"mean", mean_t},
+                   {"var", var_t}};
+      TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
-    // Place all nodes on GPU.
-    for (int i = 0; i < item.graph.node_size(); ++i) {
-      item.graph.mutable_node(i)->set_device("/device:GPU:0");
-    }
-
-    Remapper optimizer(RewriterConfig::AGGRESSIVE);  // trust placeholders shape
-    GraphDef output;
-    TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
-
-    int found = 0;
-    for (const NodeDef& node : output.node()) {
-      if (node.name() == "relu") {
-        EXPECT_EQ(node.op(), "Identity");
-        ASSERT_EQ(node.input_size(), 1);
-        EXPECT_EQ(node.input(0), "fused_batch_norm");
-        found++;
+      for (int i = 0; i < item.graph.node_size(); ++i) {
+        item.graph.mutable_node(i)->set_device(device);
       }
-      if (node.name() == "fused_batch_norm") {
-        EXPECT_EQ(node.op(), "_FusedBatchNormEx");
-        ASSERT_EQ(node.input_size(), 5);
-        EXPECT_EQ(node.input(0), "input_cast");
-        EXPECT_EQ(node.input(1), "scale");
-        EXPECT_EQ(node.input(2), "offset");
-        EXPECT_EQ(node.input(3), "mean");
-        EXPECT_EQ(node.input(4), "var");
 
-        auto attr = node.attr();
-        EXPECT_EQ(attr["num_side_inputs"].i(), 0);
-        EXPECT_EQ(attr["activation_mode"].s(), "Relu");
-        found++;
+      Remapper optimizer(
+          RewriterConfig::AGGRESSIVE);  // trust placeholders shape
+      GraphDef output;
+      TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+      int found = 0;
+      for (const NodeDef& node : output.node()) {
+        if (node.name() == "relu") {
+          EXPECT_EQ(node.op(), "Identity");
+          ASSERT_EQ(node.input_size(), 1);
+          EXPECT_EQ(node.input(0), "fused_batch_norm");
+          found++;
+        }
+        if (node.name() == "fused_batch_norm") {
+          EXPECT_EQ(node.op(), "_FusedBatchNormEx");
+          ASSERT_EQ(node.input_size(), 5);
+          EXPECT_EQ(node.input(0), "input_cast");
+          EXPECT_EQ(node.input(1), "scale");
+          EXPECT_EQ(node.input(2), "offset");
+          EXPECT_EQ(node.input(3), "mean");
+          EXPECT_EQ(node.input(4), "var");
+
+          auto attr = node.attr();
+          EXPECT_EQ(attr["num_side_inputs"].i(), 0);
+          EXPECT_EQ(attr["activation_mode"].s(), "Relu");
+          found++;
+        }
       }
-    }
-    EXPECT_EQ(found, 2);
+      EXPECT_EQ(found, 2);
 
-    if (GetNumAvailableGPUs() > 0) {
-      auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
-      ASSERT_EQ(tensors_expected.size(), 1);
-      auto tensors = EvaluateNodes(output, item.fetch, item.feed);
-      ASSERT_EQ(tensors.size(), 1);
-      test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, /*rtol=*/1e-2);
+      if (GetNumAvailableGPUs() > 0) {
+        auto tensors_expected =
+            EvaluateNodes(item.graph, item.fetch, item.feed);
+        ASSERT_EQ(tensors_expected.size(), 1);
+        auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+        ASSERT_EQ(tensors.size(), 1);
+        test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, /*rtol=*/1e-2);
+      }
     }
   }
 }
@@ -328,111 +333,117 @@ TEST_F(RemapperTest, FuseBatchNormWithRelu) {
 TEST_F(RemapperTest, FuseBatchNormWithAddAndRelu) {
   using ::tensorflow::ops::Placeholder;
 
-  for (bool is_training : {true, false}) {
-    tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+  for (const string& device : {"/device:GPU:0", "/device:DML:0"}) {
+    for (bool is_training : {true, false}) {
+      tensorflow::Scope s = tensorflow::Scope::NewRootScope();
 
 #if !defined(GOOGLE_CUDA) || !(CUDNN_VERSION >= 7402)
-    if (is_training) {
-      LOG(INFO) << "Skip FuseBatchNormWithAddAndRelu"
-                << "[is_training=" << is_training << "] "
-                << "test. It requires CUDNN_VERSION >= 7402.";
-      continue;
-    }
+      if (is_training) {
+        LOG(INFO) << "Skip FuseBatchNormWithAddAndRelu"
+                  << "[is_training=" << is_training << "] "
+                  << "test. It requires CUDNN_VERSION >= 7402.";
+        continue;
+      }
 #endif
 
 #if !defined(GOOGLE_CUDA)
-    if (!is_training) {
-      LOG(INFO) << "Skip FuseBatchNormWithAddAndRelu"
-                << "[is_training=" << is_training << "]";
-      continue;
-    }
+      if (!is_training) {
+        LOG(INFO) << "Skip FuseBatchNormWithAddAndRelu"
+                  << "[is_training=" << is_training << "]";
+        continue;
+      }
 #endif
 
-    const int num_channels = 24;
+      const int num_channels = 24;
 
-    TensorShape input_shape({2, 8, 8, num_channels});
-    TensorShape channel_shape({num_channels});
-    TensorShape empty_shape({0});
+      TensorShape input_shape({2, 8, 8, num_channels});
+      TensorShape channel_shape({num_channels});
+      TensorShape empty_shape({0});
 
-    auto input = Placeholder(s.WithOpName("input"), DT_FLOAT,
-                             ops::Placeholder::Shape(input_shape));
-    auto input_cast = ops::Cast(s.WithOpName("input_cast"), input, DT_HALF);
-    auto scale = Placeholder(s.WithOpName("scale"), DT_FLOAT);
-    auto offset = Placeholder(s.WithOpName("offset"), DT_FLOAT);
-    auto mean = Placeholder(s.WithOpName("mean"), DT_FLOAT);
-    auto var = Placeholder(s.WithOpName("var"), DT_FLOAT);
-    auto side_input = Placeholder(s.WithOpName("side_input"), DT_FLOAT,
-                                  ops::Placeholder::Shape(input_shape));
-    auto side_input_cast =
-        ops::Cast(s.WithOpName("side_input_cast"), side_input, DT_HALF);
+      auto input = Placeholder(s.WithOpName("input"), DT_FLOAT,
+                               ops::Placeholder::Shape(input_shape));
+      auto input_cast = ops::Cast(s.WithOpName("input_cast"), input, DT_HALF);
+      auto scale = Placeholder(s.WithOpName("scale"), DT_FLOAT);
+      auto offset = Placeholder(s.WithOpName("offset"), DT_FLOAT);
+      auto mean = Placeholder(s.WithOpName("mean"), DT_FLOAT);
+      auto var = Placeholder(s.WithOpName("var"), DT_FLOAT);
+      auto side_input = Placeholder(s.WithOpName("side_input"), DT_FLOAT,
+                                    ops::Placeholder::Shape(input_shape));
+      auto side_input_cast =
+          ops::Cast(s.WithOpName("side_input_cast"), side_input, DT_HALF);
 
-    float epsilon = 0.1f;
-    auto fbn = ops::FusedBatchNormV3(
-        s.WithOpName("fused_batch_norm"), input_cast, scale, offset, mean, var,
-        ops::FusedBatchNormV3::IsTraining(is_training)
-            .Epsilon(epsilon)
-            .DataFormat("NHWC"));
-    auto add = ops::Add(s.WithOpName("add"), fbn.y, side_input_cast);
-    auto relu = ops::Relu(s.WithOpName("relu"), add);
-    auto fetch = ops::Identity(s.WithOpName("fetch"), relu);
+      float epsilon = 0.1f;
+      auto fbn =
+          ops::FusedBatchNormV3(s.WithOpName("fused_batch_norm"), input_cast,
+                                scale, offset, mean, var,
+                                ops::FusedBatchNormV3::IsTraining(is_training)
+                                    .Epsilon(epsilon)
+                                    .DataFormat("NHWC"));
+      auto add = ops::Add(s.WithOpName("add"), fbn.y, side_input_cast);
+      auto relu = ops::Relu(s.WithOpName("relu"), add);
+      auto fetch = ops::Identity(s.WithOpName("fetch"), relu);
 
-    auto input_t = GenerateRandomTensor<DT_FLOAT>(input_shape);
-    auto scale_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
-    auto offset_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
-    auto mean_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
-                                                             : channel_shape);
-    auto var_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
-                                                            : channel_shape);
-    auto side_input_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
+      auto input_t = GenerateRandomTensor<DT_FLOAT>(input_shape);
+      auto scale_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+      auto offset_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+      auto mean_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
+                                                               : channel_shape);
+      auto var_t = GenerateRandomTensor<DT_FLOAT>(is_training ? empty_shape
+                                                              : channel_shape);
+      auto side_input_t =
+          GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
 
-    GrapplerItem item;
-    item.fetch = {"fetch"};
-    item.feed = {{"input", input_t},   {"scale", scale_t},
-                 {"offset", offset_t}, {"mean", mean_t},
-                 {"var", var_t},       {"side_input", side_input_t}};
-    TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+      GrapplerItem item;
+      item.fetch = {"fetch"};
+      item.feed = {{"input", input_t},   {"scale", scale_t},
+                   {"offset", offset_t}, {"mean", mean_t},
+                   {"var", var_t},       {"side_input", side_input_t}};
+      TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
-    // Place all nodes on GPU.
-    for (int i = 0; i < item.graph.node_size(); ++i) {
-      item.graph.mutable_node(i)->set_device("/device:GPU:0");
-    }
-
-    Remapper optimizer(RewriterConfig::AGGRESSIVE);  // trust placeholders shape
-    GraphDef output;
-    TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
-
-    int found = 0;
-    for (const NodeDef& node : output.node()) {
-      if (node.name() == "relu") {
-        EXPECT_EQ(node.op(), "Identity");
-        ASSERT_EQ(node.input_size(), 1);
-        EXPECT_EQ(node.input(0), "fused_batch_norm");
-        found++;
+      // Place all nodes on GPU.
+      for (int i = 0; i < item.graph.node_size(); ++i) {
+        item.graph.mutable_node(i)->set_device(device);
       }
-      if (node.name() == "fused_batch_norm") {
-        EXPECT_EQ(node.op(), "_FusedBatchNormEx");
-        ASSERT_EQ(node.input_size(), 6);
-        EXPECT_EQ(node.input(0), "input_cast");
-        EXPECT_EQ(node.input(1), "scale");
-        EXPECT_EQ(node.input(2), "offset");
-        EXPECT_EQ(node.input(3), "mean");
-        EXPECT_EQ(node.input(4), "var");
-        EXPECT_EQ(node.input(5), "side_input_cast");
 
-        auto attr = node.attr();
-        EXPECT_EQ(attr["num_side_inputs"].i(), 1);
-        EXPECT_EQ(attr["activation_mode"].s(), "Relu");
-        found++;
+      Remapper optimizer(
+          RewriterConfig::AGGRESSIVE);  // trust placeholders shape
+      GraphDef output;
+      TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+      int found = 0;
+      for (const NodeDef& node : output.node()) {
+        if (node.name() == "relu") {
+          EXPECT_EQ(node.op(), "Identity");
+          ASSERT_EQ(node.input_size(), 1);
+          EXPECT_EQ(node.input(0), "fused_batch_norm");
+          found++;
+        }
+        if (node.name() == "fused_batch_norm") {
+          EXPECT_EQ(node.op(), "_FusedBatchNormEx");
+          ASSERT_EQ(node.input_size(), 6);
+          EXPECT_EQ(node.input(0), "input_cast");
+          EXPECT_EQ(node.input(1), "scale");
+          EXPECT_EQ(node.input(2), "offset");
+          EXPECT_EQ(node.input(3), "mean");
+          EXPECT_EQ(node.input(4), "var");
+          EXPECT_EQ(node.input(5), "side_input_cast");
+
+          auto attr = node.attr();
+          EXPECT_EQ(attr["num_side_inputs"].i(), 1);
+          EXPECT_EQ(attr["activation_mode"].s(), "Relu");
+          found++;
+        }
       }
-    }
-    EXPECT_EQ(found, 2);
+      EXPECT_EQ(found, 2);
 
-    if (GetNumAvailableGPUs() > 0) {
-      auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
-      ASSERT_EQ(tensors_expected.size(), 1);
-      auto tensors = EvaluateNodes(output, item.fetch, item.feed);
-      ASSERT_EQ(tensors.size(), 1);
-      test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, /*rtol=*/1e-2);
+      if (GetNumAvailableGPUs() > 0) {
+        auto tensors_expected =
+            EvaluateNodes(item.graph, item.fetch, item.feed);
+        ASSERT_EQ(tensors_expected.size(), 1);
+        auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+        ASSERT_EQ(tensors.size(), 1);
+        test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, /*rtol=*/1e-2);
+      }
     }
   }
 }
@@ -465,7 +476,7 @@ TEST_F(RemapperTest, FuseConv2DWithBias) {
   TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
   // DML doesn't fuse because of the filter shape in this test: #31294633
-  for (const string& device : {"/device:CPU:0"/*, "/device:DML:0"*/}) {
+  for (const string& device : {"/device:CPU:0" /*, "/device:DML:0"*/}) {
     for (int i = 0; i < item.graph.node_size(); ++i) {
       item.graph.mutable_node(i)->set_device(device);
     }
@@ -607,7 +618,7 @@ TEST_F(RemapperTest, FuseConv2DWithBiasAndActivation) {
     TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
     // DML doesn't fuse because of the filter shape in this test: #31294633
-    for (const string& device : {"/device:CPU:0"/*, "/device:DML:0"*/}) {
+    for (const string& device : {"/device:CPU:0" /*, "/device:DML:0"*/}) {
       for (int i = 0; i < item.graph.node_size(); ++i) {
         item.graph.mutable_node(i)->set_device(device);
       }
@@ -770,7 +781,7 @@ TEST_F(RemapperTest, FuseConv2DWithBatchNorm) {
   TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
   // DML doesn't fuse because of the filter shape in this test: #31294633
-  for (const string& device : {"/device:CPU:0"/*, "/device:DML:0"*/}) {
+  for (const string& device : {"/device:CPU:0" /*, "/device:DML:0"*/}) {
     for (int i = 0; i < item.graph.node_size(); ++i) {
       item.graph.mutable_node(i)->set_device(device);
     }
@@ -865,7 +876,7 @@ TEST_F(RemapperTest, FuseConv2DWithBatchNormAndActivation) {
     TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
     // DML doesn't fuse because of the filter shape in this test: #31294633
-    for (const string& device : {"/device:CPU:0"/*, "/device:DML:0"*/}) {
+    for (const string& device : {"/device:CPU:0" /*, "/device:DML:0"*/}) {
       for (int i = 0; i < item.graph.node_size(); ++i) {
         item.graph.mutable_node(i)->set_device(device);
       }

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -527,7 +527,7 @@ TEST_F(RemapperTest, FuseMatMulWithBias) {
 
   // Place all nodes on CPU.
   for (int i = 0; i < item.graph.node_size(); ++i) {
-    item.graph.mutable_node(i)->set_device("/device:CPU:0");
+    item.graph.mutable_node(i)->set_device("/device:DML:0");
   }
 
   Remapper optimizer(RewriterConfig::ON);

--- a/tensorflow/core/grappler/utils.cc
+++ b/tensorflow/core/grappler/utils.cc
@@ -231,8 +231,13 @@ bool NodeIsOnCpu(const NodeDef* node) {
 bool NodeIsOnGpu(const NodeDef* node) {
   string task, device;
   return DeviceNameUtils::SplitDeviceName(node->device(), &task, &device) &&
-         (absl::StartsWith(device, DEVICE_GPU) ||
-          absl::StartsWith(device, DEVICE_DML));
+         absl::StartsWith(device, DEVICE_GPU);
+}
+
+bool NodeIsOnDml(const NodeDef* node) {
+  string task, device;
+  return DeviceNameUtils::SplitDeviceName(node->device(), &task, &device) &&
+         absl::StartsWith(device, DEVICE_DML);
 }
 
 int NumOutputs(const NodeDef& node, GraphDef* graph) {

--- a/tensorflow/core/grappler/utils.h
+++ b/tensorflow/core/grappler/utils.h
@@ -205,6 +205,9 @@ bool NodeIsOnCpu(const NodeDef* node);
 // Returns true if the node is assigned to run on GPU device.
 bool NodeIsOnGpu(const NodeDef* node);
 
+// Returns true if the node is assigned to run on DML device.
+bool NodeIsOnDml(const NodeDef* node);
+
 // Returns the number of outputs of a node according to its OpDef. Note that
 // some of the outputs may be unconnected.
 int NumOutputs(const NodeDef& node, GraphDef* graph);

--- a/tensorflow/core/kernels/dml_conv_ops.cc
+++ b/tensorflow/core/kernels/dml_conv_ops.cc
@@ -659,7 +659,8 @@ class DmlFusedConv2DKernel : public DmlKernel {
   REGISTER_KERNEL_BUILDER(                                               \
       Name("_FusedConv2D").Device(DEVICE_DML).TypeConstraint<type>("T"), \
       DmlKernelWrapper<DmlFusedConv2DKernel<type>, ConvShapeHelper>);
-TF_CALL_DML_FLOAT_TYPES(DML_REGISTER_KERNEL);
+// FusedConv2D only supports float32
+TF_CALL_float(DML_REGISTER_KERNEL);
 #undef DML_REGISTER_KERNEL
 
 class DmlConv2DBackpropInputKernel : public DmlKernel {

--- a/tensorflow/core/kernels/dml_conv_ops.cc
+++ b/tensorflow/core/kernels/dml_conv_ops.cc
@@ -659,8 +659,7 @@ class DmlFusedConv2DKernel : public DmlKernel {
   REGISTER_KERNEL_BUILDER(                                               \
       Name("_FusedConv2D").Device(DEVICE_DML).TypeConstraint<type>("T"), \
       DmlKernelWrapper<DmlFusedConv2DKernel<type>, ConvShapeHelper>);
-// FusedConv2D only supports float32
-TF_CALL_float(DML_REGISTER_KERNEL);
+TF_CALL_DML_FLOAT_TYPES(DML_REGISTER_KERNEL);
 #undef DML_REGISTER_KERNEL
 
 class DmlConv2DBackpropInputKernel : public DmlKernel {

--- a/tensorflow/core/kernels/dml_matmul_op.cc
+++ b/tensorflow/core/kernels/dml_matmul_op.cc
@@ -450,13 +450,15 @@ class DmlFusedMatMulKernel : public DmlKernel {
     }
 
     DmlKernelParams params;
-    params.kernel_input_indices = {0, 1, 2};
-
-    // TODO: ensure C (bias) shape is correct
-    // need to massage C tensor size to match product of A and B accounting for
-    // transposes
+    params.kernel_input_indices = {0, 1};
 
     DmlKernelTensors tensors = GetTensorInfos(ctx, params);
+    tensors.inputs.emplace_back();
+    tensors.inputs[2]->kernel_index = 2;
+    tensors.inputs[2]->desc = DmlTensorDesc::Create(
+      ctx->GetInputDataType(2), 
+      ctx->GetOutputTensorShape(0), 
+      ctx->GetInputTensorShape(2));
 
     auto input_descs = GetDmlTensorDescs(tensors.inputs);
     auto output_descs = GetDmlTensorDescs(tensors.outputs);

--- a/tensorflow/core/kernels/dml_matmul_op.cc
+++ b/tensorflow/core/kernels/dml_matmul_op.cc
@@ -502,7 +502,8 @@ class DmlFusedMatMulKernel : public DmlKernel {
   REGISTER_KERNEL_BUILDER(                                               \
       Name("_FusedMatMul").Device(DEVICE_DML).TypeConstraint<type>("T"), \
       DmlKernelWrapper<DmlFusedMatMulKernel, MatMulShapeHelper>);
-TF_CALL_DML_FLOAT_TYPES(DML_REGISTER_KERNEL);
+// _FusedMatMul only supports float32
+TF_CALL_float(DML_REGISTER_KERNEL);
 #undef DML_REGISTER_KERNEL
 
 }  // namespace tensorflow


### PR DESCRIPTION
The grappler remapper should treat GPU and DML devices differently, so this change splits out logic that was previously nested into the existing GPU functions into separate DML functions. I kept the existing restrictions on conv2d fusions that apply to GPU devices, but we should investigate if these are relevant for DML devices as well (opened bug 31294633).

This change also enables _FusedMatMul (MatMul + Bias + [Activation]), which is  a straight mapping to DML's GEMM operator, and allows float16 fusions for the fused conv kernel.