### PR TITLE
Fix Grappler cost model graph fetching for DML

### DIFF
--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -2215,20 +2215,7 @@ bool ExecutorState::NodeDone(const Status& s, const Node* node,
   nodestats::SetAllEnd(stats);
   if (stats) {
     if (stats_collector_) {
-#if TENSORFLOW_USE_DIRECTML
-      const auto& physical_device_desc =
-          impl_->params_.device->attributes().physical_device_desc();
-      if (!physical_device_desc.empty()) {
-        auto device_name = absl::StrCat(impl_->params_.device->name(), " (",
-                                        physical_device_desc, ")");
-        stats->Done(device_name);
-      }
-      else {
-        stats->Done(impl_->params_.device->name());
-      }
-#else
       stats->Done(impl_->params_.device->name());
-#endif
     } else {
       delete stats;
     }


### PR DESCRIPTION
We were appending a JSON-encoded string at the end of the device name that we insert into the NodeExecStatsInterface, but then grappler was failing many comparisons since DML:0 != DML:0 ({json_data...})