### PR TITLE
Fix a few more loading issues on older OS

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_device_cache.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_cache.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/dml/dml_adapter.h"
 #include "tensorflow/core/common_runtime/dml/dml_adapter_impl.h"
 #include "tensorflow/core/common_runtime/dml/dml_device.h"
+#include "tensorflow/stream_executor/platform/default/dso_loader.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -80,8 +81,14 @@ static std::vector<DmlAdapter> FilterAdapters() {
   auto dml_handle_or =
       stream_executor::internal::CachedDsoLoader::GetDirectMLDsoHandle();
   if (!dml_handle_or.ok()) {
-    LOG(WARNING) << "Could not load DirectML. TF_DIRECTML_PATH="
-                 << getenv("TF_DIRECTML_PATH");
+    auto path = getenv("TF_DIRECTML_PATH");
+    if (path) {
+      LOG(WARNING) << "Could not load DirectML. TF_DIRECTML_PATH is set: "
+                   << path;
+    } else {
+      LOG(WARNING) << "Could not load DirectML.";
+    }
+
     return {};
   }
 

--- a/tensorflow/core/common_runtime/dml/dml_device_cache.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_cache.cc
@@ -40,6 +40,7 @@ static bool SupportsAllDataTypes(const DmlAdapter& adapter) {
                                    IID_PPV_ARGS(&d3d12_device)))) {
     LOG(WARNING) << "Could not create Direct3D device for adapter: "
                  << adapter.Name();
+    return false;
   }
 
   ComPtr<IDMLDevice> dml_device =

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -26,8 +26,14 @@ Microsoft::WRL::ComPtr<IDMLDevice> TryCreateDmlDevice(
   auto dml_handle_or =
       stream_executor::internal::CachedDsoLoader::GetDirectMLDsoHandle();
   if (!dml_handle_or.ok()) {
-    LOG(WARNING) << "Could not load DirectML. TF_DIRECTML_PATH="
-                 << getenv("TF_DIRECTML_PATH");
+    auto path = getenv("TF_DIRECTML_PATH");
+    if (path) {
+      LOG(WARNING) << "Could not load DirectML. TF_DIRECTML_PATH is set: "
+                   << path;
+    } else {
+      LOG(WARNING) << "Could not load DirectML.";
+    }
+
     return nullptr;
   }
 
@@ -57,8 +63,13 @@ Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(
   auto dml_device = TryCreateDmlDevice(d3d12_device, dml_flags);
 
   if (!dml_device) {
-    LOG(FATAL) << "Could not load DirectML. TF_DIRECTML_PATH="
-               << getenv("TF_DIRECTML_PATH");
+    auto path = getenv("TF_DIRECTML_PATH");
+    if (path) {
+      LOG(FATAL) << "Could not load DirectML. TF_DIRECTML_PATH is set: "
+                 << path;
+    } else {
+      LOG(FATAL) << "Could not load DirectML.";
+    }
   }
 
   return dml_device;

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -21,24 +21,45 @@ limitations under the License.
 
 namespace tensorflow {
 
-Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(
+Microsoft::WRL::ComPtr<IDMLDevice> TryCreateDmlDevice(
     ID3D12Device* d3d12_device, DML_CREATE_DEVICE_FLAGS dml_flags) {
   auto dml_handle_or =
       stream_executor::internal::CachedDsoLoader::GetDirectMLDsoHandle();
   if (!dml_handle_or.ok()) {
-    LOG(FATAL) << "Could not load DirectML. TF_DIRECTML_PATH="
-               << getenv("TF_DIRECTML_PATH");
+    LOG(WARNING) << "Could not load DirectML. TF_DIRECTML_PATH="
+                 << getenv("TF_DIRECTML_PATH");
+    return nullptr;
   }
 
   using DMLCreateDeviceFn = decltype(DMLCreateDevice);
 
   DMLCreateDeviceFn* dmlCreateDevice;
-  Env::Default()->GetSymbolFromLibrary(
+  auto get_symbol_status = Env::Default()->GetSymbolFromLibrary(
       dml_handle_or.ValueOrDie(), "DMLCreateDevice", (void**)&dmlCreateDevice);
+  if (!get_symbol_status.ok()) {
+    LOG(WARNING) << "Could not find symbol DMLCreateDevice. ";
+    return nullptr;
+  }
 
   Microsoft::WRL::ComPtr<IDMLDevice> dml_device;
-  DML_CHECK_SUCCEEDED(
-      dmlCreateDevice(d3d12_device, dml_flags, IID_PPV_ARGS(&dml_device)));
+  HRESULT create_device_hr =
+      dmlCreateDevice(d3d12_device, dml_flags, IID_PPV_ARGS(&dml_device));
+  if (FAILED(create_device_hr)) {
+    LOG(WARNING) << "DMLCreateDevice failed with HRESULT " << create_device_hr;
+    return {};
+  }
+
+  return dml_device;
+}
+
+Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(
+    ID3D12Device* d3d12_device, DML_CREATE_DEVICE_FLAGS dml_flags) {
+  auto dml_device = TryCreateDmlDevice(d3d12_device, dml_flags);
+
+  if (!dml_device) {
+    LOG(FATAL) << "Could not load DirectML. TF_DIRECTML_PATH="
+               << getenv("TF_DIRECTML_PATH");
+  }
 
   return dml_device;
 }

--- a/tensorflow/core/common_runtime/dml/dml_util.h
+++ b/tensorflow/core/common_runtime/dml/dml_util.h
@@ -22,6 +22,11 @@ limitations under the License.
 
 namespace tensorflow {
 
+// Attempts to create an IDMLDevice. Returns an empty ComPtr if unsuccessful.
+Microsoft::WRL::ComPtr<IDMLDevice> TryCreateDmlDevice(
+    ID3D12Device* d3d12_device, DML_CREATE_DEVICE_FLAGS dml_flags);
+
+// Creates an IDMLDevice. Logs a fatal error and aborts if unsuccessful.
 Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(
     ID3D12Device* d3d12_device, DML_CREATE_DEVICE_FLAGS dml_flags);
 


### PR DESCRIPTION
IDXGIFactory4 is available since the first version of Windows 10, but it doesn't mean DirectML DLL will dload properly (needs RS3+). Currently, the first attempt to create a DML device loads the DLL into memory and logs a fatal error if unsuccessful. This change will attempt to load the DLL into memory before enumerating adapters and print warnings instead. Additionally, device creation is allowed to fail (with warnings) while filtering adapters in case any strange adapters are present.