### PR TITLE
Implement 3D conv ops

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.cc
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.cc
@@ -19,14 +19,6 @@ limitations under the License.
 
 namespace tensorflow {
 
-std::vector<TensorShape> GetOutputShapeAsInputShapeHelper::GetOutputShapes(
-    OpKernelContext* ctx,
-    const InitializationHelper* initialization_helper) const {
-  const Tensor& input_tensor =
-      ctx->input_is_ref(0) ? ctx->mutable_input(0, false) : ctx->input(0);
-  return {input_tensor.shape()};
-}
-
 static TensorShape BroadcastTensorShape(const TensorShape& input_shape_0,
                                         const TensorShape& input_shape_1) {
   if (input_shape_0 == input_shape_1) {

--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.h
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.h
@@ -107,7 +107,7 @@ class GetOutputShapeFromInputShapeHelper : public ShapeHelper {
  public:
   std::vector<TensorShape> GetOutputShapes(
       OpKernelContext* ctx,
-      const InitializationHelper* initialization_helper) const {
+      const InitializationHelper* initialization_helper) const override {
     const Tensor& input_tensor =
         ctx->input_is_ref(input_tensor_index)
             ? ctx->mutable_input(input_tensor_index, false)

--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.h
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.h
@@ -102,12 +102,21 @@ class ScalarOutputShapeHelper : public ShapeHelper {
   };
 };
 
-class GetOutputShapeAsInputShapeHelper : public ShapeHelper {
+template <int input_tensor_index>
+class GetOutputShapeFromInputShapeHelper : public ShapeHelper {
  public:
   std::vector<TensorShape> GetOutputShapes(
       OpKernelContext* ctx,
-      const InitializationHelper* initialization_helper) const override;
+      const InitializationHelper* initialization_helper) const {
+    const Tensor& input_tensor =
+        ctx->input_is_ref(input_tensor_index)
+            ? ctx->mutable_input(input_tensor_index, false)
+            : ctx->input(input_tensor_index);
+    return {input_tensor.shape()};
+  }
 };
+
+using GetOutputShapeAsInputShapeHelper = GetOutputShapeFromInputShapeHelper<0>;
 
 class BroadcastedOutputShapeInitHelper : public InitializationHelper {
  public:

--- a/tensorflow/core/kernels/dml_conv_ops.cc
+++ b/tensorflow/core/kernels/dml_conv_ops.cc
@@ -1911,8 +1911,9 @@ class DmlConv3DBackpropFilterKernel : public DmlKernel {
     conv_desc.Mode = DML_CONVOLUTION_MODE_CROSS_CORRELATION;
     conv_desc.Direction = DML_CONVOLUTION_DIRECTION_FORWARD;
     conv_desc.DimensionCount = kSpatialDimensionCount;
-    conv_desc.Strides = init_helper->GetStrides().data();
-    conv_desc.Dilations = init_helper->GetDilations().data();
+    // Not a typo: strides and dilations are swapped when computing filter backprop:
+    conv_desc.Strides = init_helper->GetDilations().data();
+    conv_desc.Dilations = init_helper->GetStrides().data();
     conv_desc.StartPadding = init_helper->GetStartPadding().data();
     conv_desc.EndPadding = init_helper->GetEndPadding().data();
     conv_desc.OutputPadding = init_helper->GetOutPadding().data();

--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -42,8 +42,7 @@ def GetTestConfigs():
   """
   test_configs = [("NDHWC", False)]
 
-  # "NDHWC" format is not supported on DML.
-  if test.is_gpu_available(skip_devices=["DML"]):
+  if test.is_gpu_available():
     test_configs.append(("NDHWC", True))
 
   # "NCDHW" format is not supported on SYCL.
@@ -204,8 +203,6 @@ class Conv3DTest(test.TestCase):
             self.assertAllClose(
                 e_value.flatten(), c_value.flatten(), atol=tolerance, rtol=1e-6)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3D1x1x1Filter(self):
     expected_output = [
         0.18518519, 0.22222222, 0.25925926, 0.40740741, 0.5, 0.59259259,
@@ -233,8 +230,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         expected=expected_output)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3D1x1x1Filter2x1x1Dilation(self):
     if test.is_gpu_available(skip_devices=["SYCL"]) or test_util.IsMklEnabled():
       self._VerifyDilatedConvValues(
@@ -245,8 +240,6 @@ class Conv3DTest(test.TestCase):
           dilations=[2, 1, 1])
 
   # Expected values computed using scipy's correlate function.
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3D2x2x2Filter(self):
     expected_output = [
         3.77199074, 3.85069444, 3.92939815, 4.2650463, 4.35763889, 4.45023148,
@@ -262,8 +255,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         expected=expected_output)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3D2x2x2Filter1x2x1Dilation(self):
     if test.is_gpu_available(skip_devices=["SYCL"]) or test_util.IsMklEnabled():
       self._VerifyDilatedConvValues(
@@ -273,8 +264,6 @@ class Conv3DTest(test.TestCase):
           padding="VALID",
           dilations=[1, 2, 1])
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3DStrides(self):
     expected_output = [
         0.06071429, 0.08988095, 0.10238095, 0.11488095, 0.12738095, 0.13988095,
@@ -296,8 +285,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         expected=expected_output)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3D2x2x2FilterStride2(self):
     expected_output = [
         3.77199074, 3.85069444, 3.92939815, 9.68865741, 9.93402778, 10.17939815
@@ -309,8 +296,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         expected=expected_output)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3DStride3(self):
     expected_output = [
         1.51140873, 1.57167659, 1.63194444, 1.56349206, 1.62673611, 1.68998016,
@@ -327,8 +312,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         expected=expected_output)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testConv3D2x2x2FilterStride2Same(self):
     expected_output = [
         3.77199074, 3.85069444, 3.92939815, 2.0162037, 2.06597222, 2.11574074,
@@ -368,8 +351,6 @@ class Conv3DTest(test.TestCase):
       values = self.evaluate(conv)
       self.assertEqual(values.shape, tensor_shape.TensorShape(output_shape))
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testKernelSmallerThanStride(self):
     expected_output = [
         0.03703704, 0.11111111, 0.25925926, 0.33333333, 0.7037037, 0.77777778,
@@ -413,8 +394,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         expected=expected_output)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   def testKernelSizeMatchesInputSize(self):
     self._VerifyValues(
         tensor_in_sizes=[1, 2, 1, 2, 1],
@@ -521,8 +500,6 @@ class Conv3DTest(test.TestCase):
       self._ConstructAndTestGradientForConfig(data_format=data_format,
                                               use_gpu=use_gpu, **kwargs)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientValidPaddingStrideOne(self):
     self.ConstructAndTestGradient(
@@ -535,8 +512,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientValidPaddingStrideOne(self):
     self.ConstructAndTestGradient(
@@ -549,8 +524,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=False)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientValidPaddingStrideTwo(self):
     self.ConstructAndTestGradient(
@@ -563,8 +536,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientValidPaddingStrideTwo(self):
     self.ConstructAndTestGradient(
@@ -577,8 +548,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=False)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientValidPaddingStrideThree(self):
     self.ConstructAndTestGradient(
@@ -591,8 +560,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientValidPaddingStrideThree(self):
     self.ConstructAndTestGradient(
@@ -605,8 +572,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=False)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientSamePaddingStrideOne(self):
     self.ConstructAndTestGradient(
@@ -619,8 +584,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientSamePaddingStrideOne(self):
     self.ConstructAndTestGradient(
@@ -633,8 +596,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         test_input=False)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientSamePaddingStrideTwo(self):
     self.ConstructAndTestGradient(
@@ -647,8 +608,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientSamePaddingStrideTwo(self):
     self.ConstructAndTestGradient(
@@ -661,8 +620,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         test_input=False)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientSamePaddingStrideThree(self):
     self.ConstructAndTestGradient(
@@ -675,8 +632,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientSamePaddingStrideThree(self):
     self.ConstructAndTestGradient(
@@ -689,8 +644,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         test_input=False)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientSamePaddingDifferentStrides(self):
     self.ConstructAndTestGradient(
@@ -703,8 +656,6 @@ class Conv3DTest(test.TestCase):
         padding="SAME",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientKernelSizeMatchesInputSize(self):
     self.ConstructAndTestGradient(
@@ -717,8 +668,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=False)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientKernelSizeMatchesInputSize(self):
     self.ConstructAndTestGradient(
@@ -744,8 +693,6 @@ class Conv3DTest(test.TestCase):
 
   # Test the fast path in gemm_pack_rhs/gemm_pack_colmajor_block, when channel
   # dimension is a multiple of packet size.
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testInputGradientValidPaddingStrideOneFastPath(self):
     self.ConstructAndTestGradient(
@@ -758,8 +705,6 @@ class Conv3DTest(test.TestCase):
         padding="VALID",
         test_input=True)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testFilterGradientValidPaddingStrideOneFastPath(self):
     self.ConstructAndTestGradient(
@@ -834,8 +779,6 @@ class Conv3DTest(test.TestCase):
       self.assertArrayNear(expected_value.flatten(), actual_value.flatten(),
                            err)
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testConv3D2x2Depth3ValidBackpropFilterStride1x1Dilation2x1(self):
     if test.is_gpu_available(skip_devices=["SYCL"]):
@@ -852,8 +795,6 @@ class Conv3DTest(test.TestCase):
             err=1e-5,
             mode="filter")
 
-  # TFDML #31059117
-  @test_util.skip_dml
   @test_util.run_deprecated_v1
   def testConv3D2x2Depth3ValidBackpropInputStride1x1Dilation2x1(self):
     if test.is_gpu_available(skip_devices=["SYCL"]):


### PR DESCRIPTION
Adds kernels for the following ops:
- Conv3D
- Conv3DBackpropInput
- Conv3DBackpropInputV2
- Conv3DBackpropFilter
- Conv3DBackpropFilterV2

There are two differences between the "V1" and V2 gradient ops:
1. The V2 ops receive the non-backprop tensor as a shape tensor rather than the original tensor from the forward pass. For example, Conv3DBackpropInputV2 receives a filter_sizes instead of the filter tensor.
2. The V2 ops have a data_format attribute, but the V1 ops assume NDHWC.