### PR TITLE
Add basic tracing for WPA

### DIFF
--- a/build.py
+++ b/build.py
@@ -238,9 +238,19 @@ def create_package(args):
   if sys.platform == "win32":
     build_pip_package_path += ".exe"
 
+  # The build_pip_package target invokes a bash shell script that, among other things,
+  # copies files needed for the package to a temporary directory. On Windows the temp
+  # directory is somewhere in the msys2 environment, and we recently started to see
+  # strange permission issues with the temp directories created in this environment.
+  # The workaround is to prepare package sources in a fixed location on the host OS
+  # file system.
+  src_path = os.path.join(args.build_output, "python_package_src")
+  if os.path.exists(src_path):
+    shutil.rmtree(src_path)
+
   dst_path = os.path.join(args.build_output, "python_package")
 
-  cl = [build_pip_package_path, "--dst", dst_path, "--directml"]
+  cl = [build_pip_package_path, "--src", src_path, "--dst", dst_path, "--directml"]
 
   subprocess.run(
       " ".join(cl),

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3776,6 +3776,7 @@ cc_library(
         "common_runtime/dml/dml_adapter.cc",
         "common_runtime/dml/dml_adapter_impl.cc",
         "common_runtime/dml/dml_error_handling.cc",
+        "common_runtime/dml/dml_tracing.cc",
     ],
     hdrs = [
         "common_runtime/dml/dml_common.h",
@@ -3783,6 +3784,7 @@ cc_library(
         "common_runtime/dml/dml_adapter.h",
         "common_runtime/dml/dml_adapter_impl.h",
         "common_runtime/dml/dml_adapter_heuristics.h",
+        "common_runtime/dml/dml_tracing.h",
     ],
     linkstatic = 1,
     deps = [

--- a/tensorflow/core/common_runtime/dml/dml_device.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "dml_event_queue.h"
 #include "dml_kernel_manager.h"
 #include "dml_readback_heap.h"
+#include "dml_tracing.h"
 #include "dml_upload_heap.h"
 #include "tensorflow/core/common_runtime/dml/dml_util.h"
 #include "tensorflow/core/framework/device_base.h"
@@ -169,6 +170,7 @@ Status DmlDevice::FillContextMap(const Graph* graph,
                                  DeviceContextMap* device_context_map) {
   // Fill in the context map. It is OK for this map to contain
   // duplicate DeviceContexts so long as we increment the refcount.
+  DmlTracing::Instance().LogDeviceFillContextMap();
   device_context_map->resize(graph->num_node_ids());
   for (Node* n : graph->nodes()) {
     device_context_->Ref();
@@ -179,6 +181,7 @@ Status DmlDevice::FillContextMap(const Graph* graph,
 }
 
 void DmlDevice::DebugOnSessionRunStart() {
+  DmlTracing::Instance().LogSessionRunStart();
   if (state_->sharing_contract) {
     state_->sharing_contract->BeginCapturableWork(
         PIX_EVAL_CAPTURABLE_WORK_GUID);
@@ -186,6 +189,7 @@ void DmlDevice::DebugOnSessionRunStart() {
 }
 
 void DmlDevice::DebugOnSessionRunEnd() {
+  DmlTracing::Instance().LogSessionRunEnd();
   if (state_->sharing_contract) {
     state_->sharing_contract->EndCapturableWork(PIX_EVAL_CAPTURABLE_WORK_GUID);
   }

--- a/tensorflow/core/common_runtime/dml/dml_device.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device.cc
@@ -170,7 +170,6 @@ Status DmlDevice::FillContextMap(const Graph* graph,
                                  DeviceContextMap* device_context_map) {
   // Fill in the context map. It is OK for this map to contain
   // duplicate DeviceContexts so long as we increment the refcount.
-  DmlTracing::Instance().LogDeviceFillContextMap();
   device_context_map->resize(graph->num_node_ids());
   for (Node* n : graph->nodes()) {
     device_context_->Ref();

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "dml_execution_context.h"
 
 #include "dml_bfc_allocator.h"
+#include "dml_tracing.h"
 
 namespace tensorflow {
 
@@ -41,6 +42,7 @@ DmlGpuEvent DmlExecutionContextImpl::CopyBufferRegion(
     D3D12_RESOURCE_STATES dst_state, ID3D12Resource* src_buffer,
     uint64_t src_offset, D3D12_RESOURCE_STATES src_state, uint64_t byte_count) {
   assert(!closed_);
+  DmlTracing::Instance().LogExecutionContextCopyBufferRegion();
 
   SetCommandRecorder(&dml_recorder_);
   dml_recorder_.CopyBufferRegion(dst_buffer, dst_offset, dst_state, src_buffer,
@@ -53,6 +55,8 @@ DmlGpuEvent DmlExecutionContextImpl::FillBufferWithPattern(
     absl::Span<const uint8_t>
         value /* Data type agnostic value, treated as raw bits */) {
   assert(!closed_);
+  DmlTracing::Instance().LogExecutionContextFillBufferWithPattern();
+
   SetCommandRecorder(&dml_recorder_);
   dml_recorder_.FillBufferWithPattern(dst, dst_offset, dst_size_in_bytes,
                                       value);
@@ -100,6 +104,7 @@ void DmlExecutionContextImpl::SetCommandRecorder(
 
 StatusOr<DmlGpuEvent> DmlExecutionContextImpl::Flush() {
   assert(!closed_);
+  DmlTracing::Instance().LogExecutionContextFlush();
 
   if (!current_recorder_) {
     // Nothing to flush

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -1,6 +1,9 @@
 #if _WIN32
+// clang-format off
 #include <Windows.h>
 #include <TraceLoggingProvider.h>
+#include <evntrace.h>
+// clang-format on
 #else
 // No-op macros for WSL
 #define TRACELOGGING_DECLARE_PROVIDER
@@ -10,8 +13,6 @@
 #define TraceLoggingWrite
 #define TraceLoggingValue
 #endif
-
-#include <cstdio>
 
 #include "dml_tracing.h"
 
@@ -31,7 +32,35 @@ DmlTracing::~DmlTracing() { TraceLoggingUnregister(g_providerHandle); }
   return traceLogger;
 }
 
-void DmlTracing::LogKernelCompute(const std::string& name) {
+void DmlTracing::LogSessionRunStart() {
+  TraceLoggingWrite(g_providerHandle, "SessionRun",
+                    TraceLoggingOpcode(EVENT_TRACE_TYPE_START));
+}
+
+void DmlTracing::LogSessionRunEnd() {
+  TraceLoggingWrite(g_providerHandle, "SessionRun",
+                    TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP));
+}
+
+void DmlTracing::LogDeviceFillContextMap() {
+  TraceLoggingWrite(g_providerHandle, "DeviceFillContextMap");
+}
+
+void DmlTracing::LogExecutionContextCopyBufferRegion() {
+  TraceLoggingWrite(g_providerHandle, "ExecutionContextCopyBufferRegion");
+}
+
+void DmlTracing::LogExecutionContextFillBufferWithPattern() {
+  TraceLoggingWrite(g_providerHandle, "ExecutionContextFillBufferWithPattern");
+}
+
+void DmlTracing::LogExecutionContextFlush() {
+  TraceLoggingWrite(g_providerHandle, "ExecutionContextFlush");
+}
+
+void DmlTracing::LogKernelCompute(const std::string& op_type,
+                                  const std::string& op_name) {
   TraceLoggingWrite(g_providerHandle, "KernelCompute",
-                    TraceLoggingString(name.c_str(), "OpName"));
+                    TraceLoggingString(op_type.c_str(), "Type"),
+                    TraceLoggingString(op_name.c_str(), "Name"));
 }

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -12,6 +12,10 @@
 #define TraceLoggingUnregister
 #define TraceLoggingWrite
 #define TraceLoggingValue
+#define TraceLoggingString
+#define TraceLoggingOpcode
+#define EVENT_TRACE_TYPE_START
+#define EVENT_TRACE_TYPE_STOP
 #endif
 
 #include "dml_tracing.h"

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -19,9 +19,10 @@
 TRACELOGGING_DECLARE_PROVIDER(g_providerHandle);
 
 // {0E57B9AE-5CE1-4BEF-86BC-24152F6A9560}
-TRACELOGGING_DEFINE_PROVIDER(g_providerHandle, "Microsoft.DirectML.TensorFlow",
-                             (0xe57b9ae, 0x5ce1, 0x4bef, 0x86, 0xbc, 0x24, 0x15,
-                              0x2f, 0x6a, 0x95, 0x60));
+TRACELOGGING_DEFINE_PROVIDER(
+    g_providerHandle, "Microsoft.Windows.AI.MachineLearning.Dml.TensorFlow",
+    (0xe57b9ae, 0x5ce1, 0x4bef, 0x86, 0xbc, 0x24, 0x15, 0x2f, 0x6a, 0x95,
+     0x60));
 
 DmlTracing::DmlTracing() { TraceLoggingRegister(g_providerHandle); }
 
@@ -40,10 +41,6 @@ void DmlTracing::LogSessionRunStart() {
 void DmlTracing::LogSessionRunEnd() {
   TraceLoggingWrite(g_providerHandle, "SessionRun",
                     TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP));
-}
-
-void DmlTracing::LogDeviceFillContextMap() {
-  TraceLoggingWrite(g_providerHandle, "DeviceFillContextMap");
 }
 
 void DmlTracing::LogExecutionContextCopyBufferRegion() {

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -6,14 +6,14 @@
 // clang-format on
 #else
 // No-op macros for WSL
-#define TRACELOGGING_DECLARE_PROVIDER
-#define TRACELOGGING_DEFINE_PROVIDER
-#define TraceLoggingRegister
-#define TraceLoggingUnregister
-#define TraceLoggingWrite
-#define TraceLoggingValue
-#define TraceLoggingString
-#define TraceLoggingOpcode
+#define TRACELOGGING_DECLARE_PROVIDER(...)
+#define TRACELOGGING_DEFINE_PROVIDER(...)
+#define TraceLoggingRegister(...)
+#define TraceLoggingUnregister(...)
+#define TraceLoggingWrite(...)
+#define TraceLoggingValue(...)
+#define TraceLoggingString(...)
+#define TraceLoggingOpcode(...)
 #define EVENT_TRACE_TYPE_START
 #define EVENT_TRACE_TYPE_STOP
 #endif

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -1,0 +1,37 @@
+#if _WIN32
+#include <Windows.h>
+#include <TraceLoggingProvider.h>
+#else
+// No-op macros for WSL
+#define TRACELOGGING_DECLARE_PROVIDER
+#define TRACELOGGING_DEFINE_PROVIDER
+#define TraceLoggingRegister
+#define TraceLoggingUnregister
+#define TraceLoggingWrite
+#define TraceLoggingValue
+#endif
+
+#include <cstdio>
+
+#include "dml_tracing.h"
+
+TRACELOGGING_DECLARE_PROVIDER(g_providerHandle);
+
+// {0E57B9AE-5CE1-4BEF-86BC-24152F6A9560}
+TRACELOGGING_DEFINE_PROVIDER(g_providerHandle, "Microsoft.DirectML.TensorFlow",
+                             (0xe57b9ae, 0x5ce1, 0x4bef, 0x86, 0xbc, 0x24, 0x15,
+                              0x2f, 0x6a, 0x95, 0x60));
+
+DmlTracing::DmlTracing() { TraceLoggingRegister(g_providerHandle); }
+
+DmlTracing::~DmlTracing() { TraceLoggingUnregister(g_providerHandle); }
+
+/*static*/ DmlTracing& DmlTracing::Instance() {
+  static DmlTracing traceLogger;
+  return traceLogger;
+}
+
+void DmlTracing::LogKernelCompute(const std::string& name) {
+  TraceLoggingWrite(g_providerHandle, "KernelCompute",
+                    TraceLoggingString(name.c_str(), "OpName"));
+}

--- a/tensorflow/core/common_runtime/dml/dml_tracing.h
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.h
@@ -12,5 +12,11 @@ class DmlTracing {
  public:
   static DmlTracing& Instance();
 
-  void LogKernelCompute(const std::string& name);
+  void LogSessionRunStart();
+  void LogSessionRunEnd();
+  void LogDeviceFillContextMap();
+  void LogExecutionContextCopyBufferRegion();
+  void LogExecutionContextFillBufferWithPattern();
+  void LogExecutionContextFlush();
+  void LogKernelCompute(const std::string& op_type, const std::string& op_name);
 };

--- a/tensorflow/core/common_runtime/dml/dml_tracing.h
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "dml_common.h"
+
+// Helper for adding tracing events useful in ETW-based perf analysis
+// (GPUView/WPA). No telemetry.
+class DmlTracing {
+ private:
+  DmlTracing();
+  ~DmlTracing();
+
+ public:
+  static DmlTracing& Instance();
+
+  void LogKernelCompute(const std::string& name);
+};

--- a/tensorflow/core/common_runtime/dml/dml_tracing.h
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.h
@@ -14,7 +14,6 @@ class DmlTracing {
 
   void LogSessionRunStart();
   void LogSessionRunEnd();
-  void LogDeviceFillContextMap();
   void LogExecutionContextCopyBufferRegion();
   void LogExecutionContextFillBufferWithPattern();
   void LogExecutionContextFlush();

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -17,8 +17,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/dml_kernel_wrapper.h"
 
 #include "tensorflow/core/common_runtime/dml/dml_operator_helper.h"
-#include "tensorflow/core/common_runtime/dml/dml_util.h"
 #include "tensorflow/core/common_runtime/dml/dml_tracing.h"
+#include "tensorflow/core/common_runtime/dml/dml_util.h"
 
 namespace tensorflow {
 
@@ -29,7 +29,8 @@ DmlKernelWrapperBase::DmlKernelWrapperBase(OpKernelConstruction* ctx,
       node_def_(std::make_shared<NodeDef>(ctx->def())) {}
 
 void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
-  DmlTracing::Instance().LogKernelCompute(ctx->op_kernel().name());
+  DmlTracing::Instance().LogKernelCompute(ctx->op_kernel().type_string(),
+                                          ctx->op_kernel().name());
 
   const DmlDevice* dml_device = static_cast<const DmlDevice*>(ctx->device());
   const DmlKernelManager& kernel_manager = *dml_device->GetKernelManager();

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "tensorflow/core/common_runtime/dml/dml_operator_helper.h"
 #include "tensorflow/core/common_runtime/dml/dml_util.h"
+#include "tensorflow/core/common_runtime/dml/dml_tracing.h"
 
 namespace tensorflow {
 
@@ -28,6 +29,8 @@ DmlKernelWrapperBase::DmlKernelWrapperBase(OpKernelConstruction* ctx,
       node_def_(std::make_shared<NodeDef>(ctx->def())) {}
 
 void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
+  DmlTracing::Instance().LogKernelCompute(ctx->op_kernel().name());
+
   const DmlDevice* dml_device = static_cast<const DmlDevice*>(ctx->device());
   const DmlKernelManager& kernel_manager = *dml_device->GetKernelManager();
 


### PR DESCRIPTION
Adds some events that may be useful when analyzing perf in WPA. Unfortunately, it seems that GPUView's event viewer has trouble distinguishing between events if we have more than one type submitted.