### PR TITLE
Change the datatype of tensors in debug tests from float64 to float32

### DIFF
--- a/tensorflow/python/debug/lib/session_debug_testlib.py
+++ b/tensorflow/python/debug/lib/session_debug_testlib.py
@@ -173,8 +173,8 @@ class SessionDebugTestBase(test_util.TensorFlowTestCase):
 
   def _generate_dump_from_simple_addition_graph(self):
     with session.Session(config=no_rewrite_session_config()) as sess:
-      u_init_val = np.array([[5.0, 3.0], [-1.0, 0.0]])
-      v_init_val = np.array([[2.0], [-1.0]])
+      u_init_val = np.array([[5.0, 3.0], [-1.0, 0.0]], dtype=np.float32)
+      v_init_val = np.array([[2.0], [-1.0]], dtype=np.float32)
 
       # Use node names with overlapping namespace (i.e., parent directory) to
       # test concurrent, non-racing directory creation.


### PR DESCRIPTION
The debug tests use np.array, which creates arrays of float64 by default. The specific datatypes for debug tests are completely irrelevant because we don't even compare the values, but since DML doesn't support float64, the tensors won't get placed on the device and the tests will fail.