### PR TITLE
Unregister segment ops

### DIFF
--- a/tensorflow/core/kernels/dml_segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/dml_segment_reduction_ops.cc
@@ -205,6 +205,7 @@ class DmlSegmentReductionKernel : public DmlKernel {
   }
 };
 
+/*
 #define REGISTER_UNSORTED_SEGMENT_REDUCTION_KERNEL_INDEX(type, name, op,  \
                                                          index_type)      \
   REGISTER_KERNEL_BUILDER(Name(name)                                      \
@@ -251,5 +252,6 @@ TF_CALL_int32(REGISTER_UNSORTED_SEGMENT_REDUCTION_DML_KERNEL);
 #undef REGISTER_UNSORTED_SEGMENT_REDUCTION_KERNEL
 #undef REGISTER_UNSORTED_SEGMENT_REDUCTION_KERNEL_INDEX
 #undef REGISTER_UNSORTED_SEGMENT_REDUCTION_DML_KERNEL
+*/
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/dml_segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/dml_segment_reduction_ops.cc
@@ -205,6 +205,8 @@ class DmlSegmentReductionKernel : public DmlKernel {
   }
 };
 
+// The memory of this implementation is too big at the moment, so we should
+// revisit this operator later if we want to support it with a new DML API
 /*
 #define REGISTER_UNSORTED_SEGMENT_REDUCTION_KERNEL_INDEX(type, name, op,  \
                                                          index_type)      \


### PR DESCRIPTION
Implementing the segment ops with dmlx requires way too much memory in some cases and can become too big for dmlx's temporary buffer which causes some models to crash. If we want to support this op in the future, we should add a new DML API for it. In the meantime, we have to unregister them.