### PR TITLE
Batch execution context calls

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_command_queue.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_queue.cc
@@ -43,13 +43,4 @@ DmlGpuEvent DmlCommandQueue::GetNextCompletionEvent() {
   return DmlGpuEvent{last_fence_value_ + 1, fence_};
 }
 
-void DmlCommandQueue::Close() {
-  // Wait for flushed work:
-  assert(!closing_);
-  closing_ = true;
-  DmlGpuEvent event = GetCurrentCompletionEvent();
-  event.WaitForSignal();
-  closing_ = false;
-}
-
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_command_queue.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_queue.h
@@ -43,8 +43,6 @@ class DmlCommandQueue {
   // ExecuteCommandLists call.
   DmlGpuEvent GetNextCompletionEvent();
 
-  void Close();
-
  private:
   Microsoft::WRL::ComPtr<ID3D12CommandQueue> queue_;
   D3D12_COMMAND_LIST_TYPE type_;

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -492,7 +492,7 @@ DmlGpuEvent DmlExecutionContext::ResourceBarrier(
   // The caller may not keep the barriers referenced by the span alive for
   // longer than this function call, so make a copy and transfer ownership to
   // the lambda.
-  absl::InlinedVector<D3D12_RESOURCE_BARRIER, 4> barriers_copy;
+  absl::InlinedVector<D3D12_RESOURCE_BARRIER, 4> barriers_copy(barriers.begin(), barriers.end());
   shared_state_->WriteBatch().emplace_back(
       [=, barriers = std::move(barriers_copy)]() {
         shared_state_->impl->ResourceBarrier(barriers);

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -278,8 +278,6 @@ DmlGpuEvent DmlExecutionContextImpl::UavBarrier() {
 StatusOr<DmlGpuEvent> DmlExecutionContextImpl::Flush() {
   assert(!closed_);
   DmlTracing::Instance().LogExecutionContextFlush();
-  VLOG(1) << "DML EC IMPL: Begin Flush ("
-          << operations_recorded_in_current_command_list_ << " cmds)";
 
   if (operations_recorded_in_current_command_list_ == 0) {
     // Nothing to flush
@@ -296,10 +294,7 @@ StatusOr<DmlGpuEvent> DmlExecutionContextImpl::Flush() {
     return status_;
   }
 
-  auto event = GetCurrentCompletionEvent();
-  VLOG(1) << "DML EC IMPL: End Flush; completion fv = " << event.fence_value;
-
-  return event;
+  return GetCurrentCompletionEvent();
 }
 
 void DmlExecutionContextImpl::Close() {

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -438,8 +438,6 @@ DmlGpuEvent DmlExecutionContext::CopyBufferRegion(
   return event;
 }
 
-// TODO: this can be batched as well for small byte counts (typical). Larger
-// copies should flush the batch and execute synchronously.
 DmlGpuEvent DmlExecutionContext::FillBufferWithPattern(
     ID3D12Resource* dst, uint64_t dst_offset, uint64_t dst_size_in_bytes,
     absl::Span<const uint8_t> value) {

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -164,13 +164,13 @@ class DmlExecutionContext {
   // NOTE: the caller is responsible for keeping the initializer and
   // descriptor_heap alive until the returned GPU event has completed.
   DmlGpuEvent InitializeOperator(IDMLOperatorInitializer* initializer,
-                                 IDMLBindingTable* binding_table,
+                                 Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
                                  ID3D12DescriptorHeap* descriptor_heap);
 
   // NOTE: the caller is responsible for keeping the op and descriptor_heap
   // alive until the returned GPU event has completed.
   DmlGpuEvent ExecuteOperator(IDMLCompiledOperator* op,
-                              IDMLBindingTable* binding_table,
+                              Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
                               ID3D12DescriptorHeap* descriptor_heap);
 
   DmlGpuEvent ResourceBarrier(

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -41,11 +41,6 @@ class DmlExecutionContextImpl {
   DmlExecutionContextImpl(ID3D12Device* d3d12_device, IDMLDevice* dml_device,
                           ID3D12CommandQueue* queue, DmlAllocator* allocator);
 
-  // Waits for flushed work, discards unflushed work, and discards associated
-  // references to prevent circular references. Must be the last call on the
-  // object before destruction.
-  void Close();
-
   // Queues a CopyBufferRegion (see ID3D12GraphicsCommandList::CopyBufferRegion)
   // for execution. Transition barriers are automatically inserted to transition
   // the source and destination resources to COPY_SOURCE and COPY_DEST if
@@ -141,11 +136,6 @@ class DmlExecutionContext {
                       ID3D12CommandQueue* queue, DmlAllocator* allocator);
 
   ~DmlExecutionContext();
-
-  void Close() {
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
-    shared_state_->impl->Close();
-  }
 
   // NOTE: the caller is responsible for keeping the resources alive until the
   // returned GPU event has completed.

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -203,6 +203,7 @@ class DmlExecutionContext {
     absl::InlinedVector<std::function<void()>, default_batch_flush_size>
         batched_functions;
     bool exit_requested = false;
+    std::chrono::high_resolution_clock::time_point last_flush_time;
   };
 
   std::shared_ptr<SharedState> shared_state_;

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -140,169 +140,58 @@ class DmlExecutionContext {
 
   void Close() {
     std::unique_lock<std::mutex> lock(shared_state_->mutex);
-    VLOG(1) << "DML EC: Close";
     shared_state_->impl->Close();
   }
 
+  // NOTE: the caller is responsible for keeping the resources alive until the
+  // returned GPU event has completed.
   DmlGpuEvent CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
                                D3D12_RESOURCE_STATES dst_state,
                                ID3D12Resource* src_buffer, uint64_t src_offset,
                                D3D12_RESOURCE_STATES src_state,
-                               uint64_t byte_count) {
-    // std::unique_lock<std::mutex> lock(shared_state_->mutex);
-    // InvokeBatchedFunctions();
-    // shared_state_->impl->Flush();
-    // return shared_state_->impl->CopyBufferRegion(
-    //     dst_buffer, dst_offset, dst_state, src_buffer, src_offset, src_state,
-    //     byte_count);
+                               uint64_t byte_count);
 
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
-
-    auto event = shared_state_->impl->GetCurrentCompletionEvent();
-    ++event.fence_value;
-    VLOG(1) << "DML EC: CopyBufferRegion; completion fv = " << event.fence_value;
-
-    shared_state_->batched_functions.emplace_back(
-        [this, dst_buffer, dst_offset, dst_state, src_buffer, src_offset,
-         src_state, byte_count]() {
-           VLOG(1) << "DML EC BATCH: CopyBufferRegion";
-                    return shared_state_->impl->CopyBufferRegion(
-              dst_buffer, dst_offset, dst_state, src_buffer, src_offset,
-              src_state, byte_count);
-        });
-
-    shared_state_->new_function_enqueued.notify_all();
-
-    return event;
-  }
-
-  // TODO: this can be batched as well for small byte counts (typical). Larger
-  // copies should flush the batch and execute synchronously.
+  // NOTE: the caller is responsible for keeping the resources alive until the
+  // returned GPU event has completed.
   DmlGpuEvent FillBufferWithPattern(ID3D12Resource* dst, uint64_t dst_offset,
                                     uint64_t dst_size_in_bytes,
-                                    absl::Span<const uint8_t> value) {
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
-    VLOG(1) << "DML EC: Begin FillBufferWithPattern";
-    InvokeBatchedFunctions();
-    shared_state_->impl->Flush();
-    auto event = shared_state_->impl->FillBufferWithPattern(dst, dst_offset,
-                                                      dst_size_in_bytes, value);
-    VLOG(1) << "DML EC: End FillBufferWithPattern; completion fv = " << event.fence_value;
-    shared_state_->impl->Flush();
-    return event;
-  }
+                                    absl::Span<const uint8_t> value);
 
+  // NOTE: the caller is responsible for keeping the initializer and
+  // descriptor_heap alive until the returned GPU event has completed.
   DmlGpuEvent InitializeOperator(IDMLOperatorInitializer* initializer,
                                  IDMLBindingTable* binding_table,
-                                 ID3D12DescriptorHeap* descriptor_heap) {
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
-
-    auto event = shared_state_->impl->GetCurrentCompletionEvent();
-    ++event.fence_value;
-    VLOG(1) << "DML EC: InitializeOperator; completion fv = " << event.fence_value;
-
-    // The caller may not keep the binding table alive for longer than this
-    // function call, so take a reference and transfer ownership to the lambda.
-    Microsoft::WRL::ComPtr<IDMLBindingTable> binding_table_ref{binding_table};
-    shared_state_->batched_functions.emplace_back(
-        [this, initializer, binding_table = std::move(binding_table_ref),
-         descriptor_heap]() {
-           VLOG(1) << "DML EC BATCH: InitializeOperator";
-          shared_state_->impl->InitializeOperator(
-              initializer, binding_table.Get(), descriptor_heap);
-        });
-
-    shared_state_->new_function_enqueued.notify_all();
-
-    return event;
-  }
+                                 ID3D12DescriptorHeap* descriptor_heap);
 
   // NOTE: the caller is responsible for keeping the op and descriptor_heap
-  // alive until the returned GPU event has been signaled.
+  // alive until the returned GPU event has completed.
   DmlGpuEvent ExecuteOperator(IDMLCompiledOperator* op,
                               IDMLBindingTable* binding_table,
-                              ID3D12DescriptorHeap* descriptor_heap) {
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
-
-    auto event = shared_state_->impl->GetCurrentCompletionEvent();
-    ++event.fence_value;
-    VLOG(1) << "DML EC: ExecuteOperator; completion fv = " << event.fence_value;
-
-    // The caller may not keep the binding table alive for longer than this
-    // function call, so take a reference and transfer ownership to the lambda.
-    Microsoft::WRL::ComPtr<IDMLBindingTable> binding_table_ref{binding_table};
-    shared_state_->batched_functions.emplace_back(
-        [this, op, binding_table = std::move(binding_table_ref),
-         descriptor_heap]() {
-           VLOG(1) << "DML EC BATCH: ExecuteOperator";
-          shared_state_->impl->ExecuteOperator(op, binding_table.Get(),
-                                               descriptor_heap);
-        });
-
-    shared_state_->new_function_enqueued.notify_all();
-
-    return event;
-  }
+                              ID3D12DescriptorHeap* descriptor_heap);
 
   DmlGpuEvent ResourceBarrier(
-      absl::Span<const D3D12_RESOURCE_BARRIER> barriers) {
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
+      absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
 
-    auto event = shared_state_->impl->GetCurrentCompletionEvent();
-    ++event.fence_value;
-    VLOG(1) << "DML EC: ResourceBarrier; completion fv = " << event.fence_value;
-    // The caller may not keep the barriers span alive for longer than this
-    // function call, so make a copy and transfer ownership to the lambda.
-    absl::InlinedVector<D3D12_RESOURCE_BARRIER, 4> barriers_copy;
-    shared_state_->batched_functions.emplace_back(
-        [this, barriers = std::move(barriers_copy)]() {
-          VLOG(1) << "DML EC BATCH: ResourceBarrier";
-          shared_state_->impl->ResourceBarrier(barriers);
-        });
-
-    shared_state_->new_function_enqueued.notify_all();
-
-    return event;
-  }
-
-  StatusOr<DmlGpuEvent> Flush() {
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
-    VLOG(1) << "DML EC: Begin Flush; current fv = " << shared_state_->impl->GetCurrentCompletionEvent().fence_value;
-    InvokeBatchedFunctions();
-    auto event = shared_state_->impl->Flush();
-    VLOG(1) << "DML EC: End Flush; completion fv = " << event.ValueOrDie().fence_value;
-    return event;
-  }
+  StatusOr<DmlGpuEvent> Flush();
 
   Status GetCommandRecorderStatus() const {
     return shared_state_->impl->GetCommandRecorderStatus();
   }
 
-  DmlGpuEvent GetCurrentCompletionEvent() {
-    std::unique_lock<std::mutex> lock(shared_state_->mutex);
-    auto event = shared_state_->impl->GetCurrentCompletionEvent();
-    VLOG(1) << "DML EC: GetCurrentCompletionEvent; current fv = " << event.fence_value;
-
-    // If something has been batched but not submitted yet,
-    // it means that the *next* fence value is the one to signal completion.
-    if (!shared_state_->batched_functions.empty()) {
-      ++event.fence_value;
-      VLOG(1) << "DML EC: GetCurrentCompletionEvent; INCREMENT FV = " << event.fence_value;
-    }
-
-    return event;
-  }
+  DmlGpuEvent GetCurrentCompletionEvent();
 
   D3D12_COMMAND_LIST_TYPE GetCommandListTypeForQueue() const {
     return shared_state_->impl->GetCommandListTypeForQueue();
   }
 
  private:
+  static constexpr uint32_t batch_flush_size = 25;
+
   struct SharedState {
     std::mutex mutex;
     std::unique_ptr<DmlExecutionContextImpl> impl;
     std::condition_variable new_function_enqueued;
-    std::vector<std::function<void()>> batched_functions;
+    absl::InlinedVector<std::function<void()>, batch_flush_size> batched_functions;
     bool exit_requested = false;
   };
 
@@ -311,7 +200,7 @@ class DmlExecutionContext {
 
   static void ThreadProc(std::shared_ptr<SharedState> state);
 
-  void InvokeBatchedFunctions();
+  StatusOr<DmlGpuEvent> InvokeBatchedFunctionsAndExecute();
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -163,15 +163,17 @@ class DmlExecutionContext {
 
   // NOTE: the caller is responsible for keeping the initializer and
   // descriptor_heap alive until the returned GPU event has completed.
-  DmlGpuEvent InitializeOperator(IDMLOperatorInitializer* initializer,
-                                 Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
-                                 ID3D12DescriptorHeap* descriptor_heap);
+  DmlGpuEvent InitializeOperator(
+      IDMLOperatorInitializer* initializer,
+      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
+      ID3D12DescriptorHeap* descriptor_heap);
 
   // NOTE: the caller is responsible for keeping the op and descriptor_heap
   // alive until the returned GPU event has completed.
-  DmlGpuEvent ExecuteOperator(IDMLCompiledOperator* op,
-                              Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
-                              ID3D12DescriptorHeap* descriptor_heap);
+  DmlGpuEvent ExecuteOperator(
+      IDMLCompiledOperator* op,
+      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
+      ID3D12DescriptorHeap* descriptor_heap);
 
   DmlGpuEvent ResourceBarrier(
       absl::Span<const D3D12_RESOURCE_BARRIER> barriers);
@@ -194,10 +196,12 @@ class DmlExecutionContext {
 
  private:
   static constexpr uint32_t default_batch_flush_size = 100;
+  static constexpr uint32_t default_batch_flush_time_us = 1000;
 
   struct SharedState {
     std::mutex mutex;
-    uint32_t batch_flush_size_ = default_batch_flush_size;
+    uint32_t batch_flush_size = default_batch_flush_size;
+    uint32_t batch_flush_time_us = default_batch_flush_time_us;
     std::unique_ptr<DmlExecutionContextImpl> impl;
     std::condition_variable new_function_enqueued;
     absl::InlinedVector<std::function<void()>, default_batch_flush_size>

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -185,13 +185,14 @@ class DmlExecutionContext {
   }
 
  private:
-  static constexpr uint32_t batch_flush_size = 25;
+  static constexpr uint32_t default_batch_flush_size = 100;
 
   struct SharedState {
     std::mutex mutex;
+    uint32_t batch_flush_size_ = default_batch_flush_size;
     std::unique_ptr<DmlExecutionContextImpl> impl;
     std::condition_variable new_function_enqueued;
-    absl::InlinedVector<std::function<void()>, batch_flush_size> batched_functions;
+    absl::InlinedVector<std::function<void()>, default_batch_flush_size> batched_functions;
     bool exit_requested = false;
   };
 

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
@@ -76,7 +76,8 @@ void DmlKernelConstruction::EnqueueCallbackForGpuEvent(
 }
 
 DmlGpuEvent DmlKernelConstruction::BindAndInitializeOperator(
-    IDMLOperatorInitializer* initializer, IDMLBindingTable* binding_table,
+    IDMLOperatorInitializer* initializer,
+    Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
     ID3D12DescriptorHeap* heap_for_binding_table,
     _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
     _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding) {
@@ -95,7 +96,7 @@ DmlGpuEvent DmlKernelConstruction::BindAndInitializeOperator(
   }
 
   return device_->GetExecutionContext()->InitializeOperator(
-      initializer, binding_table, heap_for_binding_table);
+      initializer, std::move(binding_table), heap_for_binding_table);
 }
 
 DataType DmlKernelConstruction::GetInputDataType(uint32_t index) const {
@@ -201,7 +202,7 @@ void DmlKernelContext::EnqueueCallbackForGpuEvent(
 }
 
 DmlGpuEvent DmlKernelContext::BindAndExecuteOperator(
-    IDMLCompiledOperator* op, IDMLBindingTable* binding_table,
+    IDMLCompiledOperator* op, Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
     ID3D12DescriptorHeap* heap_for_binding_table,
     _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
     _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding,
@@ -250,7 +251,7 @@ DmlGpuEvent DmlKernelContext::BindAndExecuteOperator(
                              output_binding_descs.data());
 
   return device_->GetExecutionContext()->ExecuteOperator(
-      op, binding_table, heap_for_binding_table);
+      op, std::move(binding_table), heap_for_binding_table);
 }
 
 DmlGpuEvent DmlKernelContext::GetCurrentCompletionEvent() const {

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
@@ -286,10 +286,7 @@ DmlGpuEvent DmlKernelContext::ZeroBuffer(const D3D12BufferRegion& dst) const {
 }
 
 DmlGpuEvent DmlKernelContext::InsertUavBarrier() const {
-  D3D12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
-
-  return device_->GetExecutionContext()->ResourceBarrier(
-      absl::Span<D3D12_RESOURCE_BARRIER>(&barrier, 1));
+  return device_->GetExecutionContext()->UavBarrier();
 }
 
 DmlGpuEvent DmlKernelContext::FillBufferWithPattern(

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.h
@@ -67,7 +67,8 @@ class DmlKernelConstruction {
   // state when it completes. Note that we never supply any input bindings,
   // because we never set DML_TENSOR_FLAG_OWNED_BY_DML .
   DmlGpuEvent BindAndInitializeOperator(
-      IDMLOperatorInitializer* initializer, IDMLBindingTable* binding_table,
+      IDMLOperatorInitializer* initializer,
+      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
       ID3D12DescriptorHeap* heap_for_binding_table,
       _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
       _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding);
@@ -164,7 +165,8 @@ class DmlKernelContext {
   // Executes a DML operator. Note that this merely queues the execution; the
   // returned event will enter the signaled state when it completes.
   DmlGpuEvent BindAndExecuteOperator(
-      IDMLCompiledOperator* op, IDMLBindingTable* binding_table,
+      IDMLCompiledOperator* op,
+      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
       ID3D12DescriptorHeap* heap_for_binding_table,
       _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
       _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding,

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -34,7 +34,8 @@ DmlTracing::DmlTracing() {
   TraceLoggingRegister(g_providerHandle);
 
   tensorflow::int64 trace_level = 0;
-  tensorflow::Status s = tensorflow::ReadInt64FromEnvVar("TF_DIRECTML_TRACE_LEVEL", 0, &trace_level);
+  tensorflow::Status s = tensorflow::ReadInt64FromEnvVar(
+      "TF_DIRECTML_TRACE_LEVEL", trace_level_, &trace_level);
   if (s.ok()) {
     trace_level_ = static_cast<TraceLevel>(trace_level);
   }

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -19,6 +19,8 @@
 #endif
 
 #include "dml_tracing.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/util/env_var.h"
 
 TRACELOGGING_DECLARE_PROVIDER(g_providerHandle);
 
@@ -28,7 +30,15 @@ TRACELOGGING_DEFINE_PROVIDER(
     (0xe57b9ae, 0x5ce1, 0x4bef, 0x86, 0xbc, 0x24, 0x15, 0x2f, 0x6a, 0x95,
      0x60));
 
-DmlTracing::DmlTracing() { TraceLoggingRegister(g_providerHandle); }
+DmlTracing::DmlTracing() {
+  TraceLoggingRegister(g_providerHandle);
+
+  tensorflow::int64 trace_level = 0;
+  tensorflow::Status s = tensorflow::ReadInt64FromEnvVar("TF_DIRECTML_TRACE_LEVEL", 0, &trace_level);
+  if (s.ok()) {
+    trace_level_ = static_cast<TraceLevel>(trace_level);
+  }
+}
 
 DmlTracing::~DmlTracing() { TraceLoggingUnregister(g_providerHandle); }
 
@@ -38,30 +48,43 @@ DmlTracing::~DmlTracing() { TraceLoggingUnregister(g_providerHandle); }
 }
 
 void DmlTracing::LogSessionRunStart() {
-  TraceLoggingWrite(g_providerHandle, "SessionRun",
-                    TraceLoggingOpcode(EVENT_TRACE_TYPE_START));
+  if (trace_level_ >= LowFrequency) {
+    TraceLoggingWrite(g_providerHandle, "SessionRun",
+                      TraceLoggingOpcode(EVENT_TRACE_TYPE_START));
+  }
 }
 
 void DmlTracing::LogSessionRunEnd() {
-  TraceLoggingWrite(g_providerHandle, "SessionRun",
-                    TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP));
+  if (trace_level_ >= LowFrequency) {
+    TraceLoggingWrite(g_providerHandle, "SessionRun",
+                      TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP));
+  }
 }
 
 void DmlTracing::LogExecutionContextCopyBufferRegion() {
-  TraceLoggingWrite(g_providerHandle, "ExecutionContextCopyBufferRegion");
+  if (trace_level_ >= All) {
+    TraceLoggingWrite(g_providerHandle, "ExecutionContextCopyBufferRegion");
+  }
 }
 
 void DmlTracing::LogExecutionContextFillBufferWithPattern() {
-  TraceLoggingWrite(g_providerHandle, "ExecutionContextFillBufferWithPattern");
+  if (trace_level_ >= All) {
+    TraceLoggingWrite(g_providerHandle,
+                      "ExecutionContextFillBufferWithPattern");
+  }
 }
 
 void DmlTracing::LogExecutionContextFlush() {
-  TraceLoggingWrite(g_providerHandle, "ExecutionContextFlush");
+  if (trace_level_ >= All) {
+    TraceLoggingWrite(g_providerHandle, "ExecutionContextFlush");
+  }
 }
 
 void DmlTracing::LogKernelCompute(const std::string& op_type,
                                   const std::string& op_name) {
-  TraceLoggingWrite(g_providerHandle, "KernelCompute",
-                    TraceLoggingString(op_type.c_str(), "Type"),
-                    TraceLoggingString(op_name.c_str(), "Name"));
+  if (trace_level_ >= All) {
+    TraceLoggingWrite(g_providerHandle, "KernelCompute",
+                      TraceLoggingString(op_type.c_str(), "Type"),
+                      TraceLoggingString(op_name.c_str(), "Name"));
+  }
 }

--- a/tensorflow/core/common_runtime/dml/dml_tracing.h
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.h
@@ -9,6 +9,15 @@ class DmlTracing {
   DmlTracing();
   ~DmlTracing();
 
+  enum TraceLevel
+  {
+    None = 0,
+    LowFrequency = 1,
+    All = 10
+  };
+
+  TraceLevel trace_level_ = LowFrequency;
+
  public:
   static DmlTracing& Instance();
 

--- a/tensorflow/core/kernels/dml_ops_common.cc
+++ b/tensorflow/core/kernels/dml_ops_common.cc
@@ -274,7 +274,7 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   }
 
   auto init_gpu_event = ctx->BindAndInitializeOperator(
-      initializer.Get(), binding_table.Get(), descriptor_handles.heap,
+      initializer.Get(), std::move(binding_table), descriptor_handles.heap,
       temp_resource_binding ? &*temp_resource_binding : nullptr,
       GetPersistentResourceBinding());
 
@@ -347,7 +347,7 @@ StatusOr<DmlGpuEvent> DmlKernel::Compute(
   }
 
   DmlGpuEvent gpu_event = ctx->BindAndExecuteOperator(
-      compiled_op_.Get(), binding_table.Get(), descriptor_handles.heap,
+      compiled_op_.Get(), std::move(binding_table), descriptor_handles.heap,
       temp_resource_binding ? &*temp_resource_binding : nullptr,
       GetPersistentResourceBinding(), input_bindings, output_bindings);
 


### PR DESCRIPTION
This change builds on the previous refactoring changes to further eliminate lock contention in the DML execution context. Recall that the execution context (EC) is the primary mechanism for recording into a D3D command list and submitting it to the hardware. This results in ~45% performance improvement for heavily CPU bound models like Pixel-RNN.

DML kernels and devices may invoke EC methods in a free-threaded manner, but the current implementation simply holds a lock until the work is recorded. Once a fixed number of commands are recorded the EC flushes its current command list to the hardware queue. This approach works fine for most models, but in some extreme cases (e.g.  model with ~100k op executions per epoch) the lock contention starts to add significant overhead. We reduced some of this overhead in previous changes by moving binding logic outside the lock, but the recording work itself is still under the lock.

This change batches the calls to the EC itself (rather than command recorded in the command list) and relies on a background thread to flush the batched calls. Calls are double buffered so that the background thread can record a batch while kernels continue writing into another batch. As a consequence, the arguments passed the EC methods must be kept alive until the function is batch is flushed. This isn't a problem for most arguments, like D3D resources, which are already kept alive using GPU events and the event queue. Other types of args, like barrier structs, are simply copied and kept in the batch. We do not have any cases where the argument data is large enough to make the copies expensive.

A few other minor changes:
- The function batch may be flushed using either a fixed size capacity or if enough time has elapsed since the last flush. This isn't a perfect heuristic, but it seems to work well enough.
- High-frequency calls like op execution no longer emit tracing events by default, since it can add significant overhead when profiling. This behavior can be modified using the TF_DIRECTML_TRACE_LEVEL environment variable.
- Kernels transfer ownership of the binding table for init/exec rather than letting it destroy when the respective kernel context methods go out of scope: this is slightly more efficient than having the EC take a ref on the IUnknown. The binding tables must live until the EC function batch is flushed.