### PR TITLE
Enable MaxPool3DGrad kernel

### DIFF
--- a/tensorflow/core/kernels/dml_pooling_ops.cc
+++ b/tensorflow/core/kernels/dml_pooling_ops.cc
@@ -486,7 +486,7 @@ class DmlMaxPoolGradKernel : public DmlKernel {
         ctx, init_helper, tensor_in_shape, 3);
 
     // TF doesn't use dilations, but DML needs default values of 1.
-    uint32_t dilations[] = {1, 1};
+    uint32_t dilations[] = {1, 1, 1};
 
     // Ignore the kernel size/stride tensors, because DML takes them as
     // attributes and not input tensors
@@ -568,13 +568,22 @@ using DmlMaxPoolKernel =
       Name("MaxPoolGrad").Device(DEVICE_DML).TypeConstraint<type>("T"), \
       DmlKernelWrapper<DmlMaxPoolGradKernel,                            \
                        GetOutputShapeAsInputShapeHelper>);              \
-  REGISTER_KERNEL_BUILDER(Name("MaxPoolGradV2")                         \
-                              .Device(DEVICE_DML)                       \
-                              .TypeConstraint<type>("T")                \
-                              .HostMemory("ksize")                      \
-                              .HostMemory("strides"),                   \
-                          DmlKernelWrapper<DmlMaxPoolGradKernel,        \
-                                           GetOutputShapeAsInputShapeHelper>);
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("MaxPoolGradV2")                                             \
+          .Device(DEVICE_DML)                                           \
+          .TypeConstraint<type>("T")                                    \
+          .HostMemory("ksize")                                          \
+          .HostMemory("strides"),                                       \
+      DmlKernelWrapper<DmlMaxPoolGradKernel,                            \
+                       GetOutputShapeAsInputShapeHelper>);              \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("MaxPool3DGrad")                                             \
+          .Device(DEVICE_DML)                                           \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<type>("TInput"),                              \
+      DmlKernelWrapper<DmlMaxPoolGradKernel,                            \
+                       GetOutputShapeAsInputShapeHelper>);              \
+
 TF_CALL_DML_FLOAT_TYPES(DML_REGISTER_KERNELS);
 #undef DML_REGISTER_KERNELS
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -89,7 +89,7 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     dml_repository(
         name = "dml_redist",
         package = "Microsoft.AI.DirectML.Preview",
-        version = "1.5.0-dev20210301",
+        version = "1.6.0-dev20210318",
         source = "https://api.nuget.org/v3/index.json",
         build_file = "//third_party/dml/redist:BUILD.bazel",
     )


### PR DESCRIPTION
- Enables MaxPool3DGrad kernel.
- Does *not* re-enable tests in pooling_ops_3d_test.py with "@test_util.skip_dml" because the test actually creates a gradient of MaxPool3D (MaxPool3DGrad) and then a gradient of a gradient (MaxPool3DGradGrad), which then fails as DML has no MaxPool3DGradGrad, yielding the misleading and bewildering error "(0) Invalid argument: Default MaxPooling3dGradGradOp only supportsNDHWC on CPU device type". I'm perplexed why we're not seeing the same error for AvgPool3D though, which also lacks a DML GradGrad operator.
- Do I need to create a private nuget of DirectML before enabling this, or will the nightly build select the proper DirectML.dll?