### PR TITLE
PIX events & markers

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3690,6 +3690,7 @@ cc_library(
         "common_runtime/dml/dml_tensor_desc.cc",
         "common_runtime/dml/dml_upload_heap.cc",
         "common_runtime/dml/dml_util.cc",
+        "common_runtime/dml/dml_tracing.cc",
     ],
     hdrs = [
         "common_runtime/dml/dml_device_cache.h",
@@ -3718,6 +3719,7 @@ cc_library(
         "common_runtime/dml/dml_tensor_desc.h",
         "common_runtime/dml/dml_upload_heap.h",
         "common_runtime/dml/dml_util.h",
+        "common_runtime/dml/dml_tracing.h",
         "common_runtime/dml/dml_status.h",
         "common_runtime/device.h",
         "common_runtime/local_device.h",
@@ -3740,7 +3742,7 @@ cc_library(
         ":proto_text",
         ":stream_executor",
         "//tensorflow/stream_executor/platform:dso_loader",
-    ],
+    ] + if_windows(["@pix//:headers"]),
 )
 
 cc_library(
@@ -3776,7 +3778,6 @@ cc_library(
         "common_runtime/dml/dml_adapter.cc",
         "common_runtime/dml/dml_adapter_impl.cc",
         "common_runtime/dml/dml_error_handling.cc",
-        "common_runtime/dml/dml_tracing.cc",
     ],
     hdrs = [
         "common_runtime/dml/dml_common.h",
@@ -3784,7 +3785,6 @@ cc_library(
         "common_runtime/dml/dml_adapter.h",
         "common_runtime/dml/dml_adapter_impl.h",
         "common_runtime/dml/dml_adapter_heuristics.h",
-        "common_runtime/dml/dml_tracing.h",
     ],
     linkstatic = 1,
     deps = [

--- a/tensorflow/core/common_runtime/dml/dml_command_list.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_list.cc
@@ -165,6 +165,8 @@ void DmlCommandList::InitializeOperator(IDMLOperatorInitializer* initializer,
 void DmlCommandList::ExecuteOperator(IDMLCompiledOperator* op,
                                      IDMLBindingTable* binding_table,
                                      ID3D12DescriptorHeap* descriptor_heap) {
+  DmlTracing::Instance().LogExecuteOperatorStart(op, d3d_command_list_.Get());
+
   // Record the execution work.
   SetDescriptorHeap(descriptor_heap);
   recorder_->RecordDispatch(d3d_command_list_.Get(), op, binding_table);
@@ -174,6 +176,8 @@ void DmlCommandList::ExecuteOperator(IDMLCompiledOperator* op,
       CD3DX12_RESOURCE_BARRIER::UAV(nullptr),
       CD3DX12_RESOURCE_BARRIER::Aliasing(nullptr, nullptr)};
   d3d_command_list_->ResourceBarrier(ABSL_ARRAYSIZE(barriers), barriers);
+
+  DmlTracing::Instance().LogExecuteOperatorEnd(d3d_command_list_.Get());
 }
 
 void DmlCommandList::ResourceBarrier(

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -4,6 +4,59 @@
 #include <TraceLoggingProvider.h>
 #include <evntrace.h>
 // clang-format on
+
+#define USE_PIX
+#include "pix3.h"
+#include <d3d12.h>
+
+typedef HRESULT(WINAPI* PIXBeginEventOnCommandListFn)(
+    ID3D12GraphicsCommandList* commandList, UINT64 color, PCSTR formatString);
+typedef HRESULT(WINAPI* PIXEndEventOnCommandListFn)(
+    ID3D12GraphicsCommandList* commandList);
+typedef HRESULT(WINAPI* PIXSetMarkerOnCommandListFn)(
+    ID3D12GraphicsCommandList* commandList, UINT64 color, PCSTR formatString);
+
+static decltype(PIXGetThreadInfo)* g_pixGetThreadInfo = nullptr;
+static decltype(PIXEventsReplaceBlock)* g_pixEventsReplaceBlock = nullptr;
+static PIXBeginEventOnCommandListFn g_pixBeginEventOnCommandList = nullptr;
+static PIXEndEventOnCommandListFn g_pixEndEventOnCommandList = nullptr;
+static PIXSetMarkerOnCommandListFn g_pixSetMarkerOnCommandList = nullptr;
+
+void BeginEventOnCommandList(ID3D12GraphicsCommandList* command_list,
+                             UINT64 color, PCSTR format_string) {
+  if (g_pixBeginEventOnCommandList) {
+    g_pixBeginEventOnCommandList(command_list, color, format_string);
+  }
+}
+
+void EndEventOnCommandList(ID3D12GraphicsCommandList* command_list) {
+  if (g_pixEndEventOnCommandList) {
+    g_pixEndEventOnCommandList(command_list);
+  }
+}
+
+void SetMarkerOnCommandList(ID3D12GraphicsCommandList* command_list,
+                            UINT64 color, PCSTR format_string) {
+  if (g_pixSetMarkerOnCommandList) {
+    g_pixSetMarkerOnCommandList(command_list, color, format_string);
+  }
+}
+
+extern "C" PIXEventsThreadInfo* PIXGetThreadInfo() noexcept {
+  if (!g_pixGetThreadInfo) {
+    return nullptr;
+  }
+  return g_pixGetThreadInfo();
+}
+
+extern "C" UINT64 WINAPI PIXEventsReplaceBlock(PIXEventsThreadInfo* threadInfo,
+                                               bool getEarliestTime) noexcept {
+  if (!g_pixEventsReplaceBlock) {
+    return 0;
+  }
+  return g_pixEventsReplaceBlock(threadInfo, getEarliestTime);
+}
+
 #else
 // No-op macros for WSL
 #define TRACELOGGING_DECLARE_PROVIDER(...)
@@ -16,11 +69,21 @@
 #define TraceLoggingOpcode(...)
 #define EVENT_TRACE_TYPE_START
 #define EVENT_TRACE_TYPE_STOP
+
+#define PIXBeginEvent(...)
+#define PIXEndEvent(...)
+#define PIXSetMarker(...)
+#define PIX_COLOR(...)
+#define BeginEventOnCommandList(...)
+#define EndEventOnCommandList(...)
+#define SetMarkerOnCommandList(...)
 #endif
 
 #include "dml_tracing.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/util/env_var.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/stream_executor/platform/default/dso_loader.h"
 
 TRACELOGGING_DECLARE_PROVIDER(g_providerHandle);
 
@@ -39,6 +102,30 @@ DmlTracing::DmlTracing() {
   if (s.ok()) {
     trace_level_ = static_cast<TraceLevel>(trace_level);
   }
+
+#if _WIN32
+  if (trace_level_ > None) {
+    auto pix_handle_or =
+        stream_executor::internal::CachedDsoLoader::GetPixDsoHandle();
+    if (pix_handle_or.ok()) {
+      tensorflow::Env::Default()->GetSymbolFromLibrary(
+          pix_handle_or.ValueOrDie(), "PIXGetThreadInfo",
+          reinterpret_cast<void**>(&g_pixGetThreadInfo));
+      tensorflow::Env::Default()->GetSymbolFromLibrary(
+          pix_handle_or.ValueOrDie(), "PIXEventsReplaceBlock",
+          reinterpret_cast<void**>(&g_pixEventsReplaceBlock));
+      tensorflow::Env::Default()->GetSymbolFromLibrary(
+          pix_handle_or.ValueOrDie(), "PIXBeginEventOnCommandList",
+          reinterpret_cast<void**>(&g_pixBeginEventOnCommandList));
+      tensorflow::Env::Default()->GetSymbolFromLibrary(
+          pix_handle_or.ValueOrDie(), "PIXEndEventOnCommandList",
+          reinterpret_cast<void**>(&g_pixEndEventOnCommandList));
+      tensorflow::Env::Default()->GetSymbolFromLibrary(
+          pix_handle_or.ValueOrDie(), "PIXSetMarkerOnCommandList",
+          reinterpret_cast<void**>(&g_pixSetMarkerOnCommandList));
+    }
+  }
+#endif // _WIN32
 }
 
 DmlTracing::~DmlTracing() { TraceLoggingUnregister(g_providerHandle); }
@@ -52,6 +139,7 @@ void DmlTracing::LogSessionRunStart() {
   if (trace_level_ >= LowFrequency) {
     TraceLoggingWrite(g_providerHandle, "SessionRun",
                       TraceLoggingOpcode(EVENT_TRACE_TYPE_START));
+    PIXBeginEvent(PIX_COLOR(255, 0, 0), "SessionRun");
   }
 }
 
@@ -59,6 +147,7 @@ void DmlTracing::LogSessionRunEnd() {
   if (trace_level_ >= LowFrequency) {
     TraceLoggingWrite(g_providerHandle, "SessionRun",
                       TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP));
+    PIXEndEvent();
   }
 }
 
@@ -78,6 +167,7 @@ void DmlTracing::LogExecutionContextFillBufferWithPattern() {
 void DmlTracing::LogExecutionContextFlush() {
   if (trace_level_ >= All) {
     TraceLoggingWrite(g_providerHandle, "ExecutionContextFlush");
+    PIXSetMarker(0, "EC Flush");
   }
 }
 
@@ -87,5 +177,23 @@ void DmlTracing::LogKernelCompute(const std::string& op_type,
     TraceLoggingWrite(g_providerHandle, "KernelCompute",
                       TraceLoggingString(op_type.c_str(), "Type"),
                       TraceLoggingString(op_name.c_str(), "Name"));
+  }
+}
+
+void DmlTracing::LogExecuteOperatorStart(
+    IDMLCompiledOperator* op, ID3D12GraphicsCommandList* command_list) {
+  if (trace_level_ >= All) {
+    std::vector<char> chars(100);
+    UINT data_size = (UINT)(chars.size() * sizeof(char));
+    op->GetPrivateData(kPixEventNameId, &data_size, chars.data());
+    BeginEventOnCommandList(command_list, PIX_COLOR(128, 255, 128),
+                            chars.data());
+  }
+}
+
+void DmlTracing::LogExecuteOperatorEnd(
+    ID3D12GraphicsCommandList* command_list) {
+  if (trace_level_ >= All) {
+    EndEventOnCommandList(command_list);
   }
 }

--- a/tensorflow/core/common_runtime/dml/dml_tracing.cc
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.cc
@@ -182,13 +182,15 @@ void DmlTracing::LogKernelCompute(const std::string& op_type,
 
 void DmlTracing::LogExecuteOperatorStart(
     IDMLCompiledOperator* op, ID3D12GraphicsCommandList* command_list) {
+#if _WIN32
   if (trace_level_ >= All) {
-    std::vector<char> chars(100);
-    UINT data_size = (UINT)(chars.size() * sizeof(char));
-    op->GetPrivateData(kPixEventNameId, &data_size, chars.data());
+    std::vector<char> eventName(100);
+    UINT data_size = (UINT)(eventName.size() * sizeof(char));
+    op->GetPrivateData(kPixEventNameId, &data_size, eventName.data());
     BeginEventOnCommandList(command_list, PIX_COLOR(128, 255, 128),
-                            chars.data());
+                            eventName.data());
   }
+#endif
 }
 
 void DmlTracing::LogExecuteOperatorEnd(

--- a/tensorflow/core/common_runtime/dml/dml_tracing.h
+++ b/tensorflow/core/common_runtime/dml/dml_tracing.h
@@ -5,18 +5,20 @@
 // Helper for adding tracing events useful in ETW-based perf analysis
 // (GPUView/WPA). No telemetry.
 class DmlTracing {
+ public:
+  // GUID to associate a PIX event name with an IDMLObject (there is an existing
+  // SetName method, but no public GetName method).
+  constexpr static GUID kPixEventNameId = {0x191d7d5, 0x9fe1, 0x47cc, 0xb6,
+                                           0x46,      0xf6,   0x78,   0xb6,
+                                           0x33,      0x2f,   0x96};
+
+  enum TraceLevel { None = 0, LowFrequency = 1, All = 10 };
+
  private:
   DmlTracing();
   ~DmlTracing();
 
-  enum TraceLevel
-  {
-    None = 0,
-    LowFrequency = 1,
-    All = 10
-  };
-
-  TraceLevel trace_level_ = LowFrequency;
+  TraceLevel trace_level_ = None;
 
  public:
   static DmlTracing& Instance();
@@ -27,4 +29,9 @@ class DmlTracing {
   void LogExecutionContextFillBufferWithPattern();
   void LogExecutionContextFlush();
   void LogKernelCompute(const std::string& op_type, const std::string& op_name);
+
+  // GPU timeline
+  void LogExecuteOperatorStart(IDMLCompiledOperator* op,
+                               ID3D12GraphicsCommandList* command_list);
+  void LogExecuteOperatorEnd(ID3D12GraphicsCommandList* command_list);
 };

--- a/tensorflow/core/kernels/dml_ops_common.cc
+++ b/tensorflow/core/kernels/dml_ops_common.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/dml_ops_common.h"
 
+#include "tensorflow/core/common_runtime/dml/dml_tracing.h"
 #include "tensorflow/core/common_runtime/dml/dml_util.h"
 #include "tensorflow/core/lib/strings/numbers.h"
 
@@ -195,9 +196,12 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   // Set the name of this compiled op, for debugging purposes. We use the name
   // of the op (e.g. "Conv2D") rather than the name of the node because this
   // kernel may be shared across many nodes.
-  std::wstring op_type =
-      Utf8ToWideChar(ctx->GetOpKernelContext()->op_kernel().type_string());
+  std::string op_type_c = ctx->GetOpKernelContext()->op_kernel().type_string();
+  std::wstring op_type = Utf8ToWideChar(op_type_c);
   DML_CHECK_SUCCEEDED(compiled_op->SetName(op_type.c_str()));
+  DML_CHECK_SUCCEEDED(compiled_op->SetPrivateData(
+      DmlTracing::kPixEventNameId, static_cast<UINT>(op_type_c.size()),
+      op_type_c.c_str()));
 #endif
 
   compiled_op_ = compiled_op;

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -225,6 +225,10 @@ port::StatusOr<void*> GetDirectMLDebugDsoHandle() {
   return GetDirectMLLibraryHandle("directml.debug");
 }
 
+port::StatusOr<void*> GetPixDsoHandle() {
+  return GetDsoHandle("WinPixEventRuntime", "", GetModuleDirectory());
+}
+
 }  // namespace DsoLoader
 
 namespace CachedDsoLoader {
@@ -305,6 +309,11 @@ port::StatusOr<void*> GetDirectMLDsoHandle() {
 
 port::StatusOr<void*> GetDirectMLDebugDsoHandle() {
   static auto result = new auto(DsoLoader::GetDirectMLDebugDsoHandle());
+  return *result;
+}
+
+port::StatusOr<void*> GetPixDsoHandle() {
+  static auto result = new auto(DsoLoader::GetPixDsoHandle());
   return *result;
 }
 

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -29,6 +29,7 @@ limitations under the License.
 
 #if _WIN32
 #include <pathcch.h>
+
 #include "tensorflow/core/platform/windows/wide_char.h"
 #endif
 
@@ -226,7 +227,11 @@ port::StatusOr<void*> GetDirectMLDebugDsoHandle() {
 }
 
 port::StatusOr<void*> GetPixDsoHandle() {
+#if _WIN32
   return GetDsoHandle("WinPixEventRuntime", "", GetModuleDirectory());
+#else
+  return port::Status(port::error::UNIMPLEMENTED, "PIX events are not supported in WSL");
+#endif
 }
 
 }  // namespace DsoLoader

--- a/tensorflow/stream_executor/platform/default/dso_loader.h
+++ b/tensorflow/stream_executor/platform/default/dso_loader.h
@@ -53,6 +53,7 @@ port::StatusOr<void*> GetRocrandDsoHandle();
 port::StatusOr<void*> GetHipDsoHandle();
 port::StatusOr<void*> GetDirectMLDsoHandle();
 port::StatusOr<void*> GetDirectMLDebugDsoHandle();
+port::StatusOr<void*> GetPixDsoHandle();
 
 // The following method tries to dlopen all necessary GPU libraries for the GPU
 // platform TF is built with (CUDA or ROCm) only when these libraries should be
@@ -87,6 +88,7 @@ port::StatusOr<void*> GetRocrandDsoHandle();
 port::StatusOr<void*> GetHipDsoHandle();
 port::StatusOr<void*> GetDirectMLDsoHandle();
 port::StatusOr<void*> GetDirectMLDebugDsoHandle();
+port::StatusOr<void*> GetPixDsoHandle();
 }  // namespace CachedDsoLoader
 
 }  // namespace internal

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -242,7 +242,8 @@ sh_binary(
                    ":simple_console",
                ],
            }) + if_mkl_ml(["//third_party/mkl:intel_binary_blob"])
-           + if_dml(["@dml_redist//:pip_files"]),
+           + if_dml(["@dml_redist//:pip_files"])
+           + if_windows(["@pix//:pip_files"]),
 )
 
 # A genrule for generating a marker file for the pip package on Windows

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -66,6 +66,9 @@ function reorganize_includes() {
   # Select DML files are copied in the copy_dml_redist_files function; we should
   # never include the entire contents of the redistributable package.
   rm -rf external/dml_redist
+  if is_windows; then
+    rm -rf external/pix
+  fi
 
   popd
 }
@@ -112,6 +115,16 @@ function copy_dml_redist_files() {
   fi
   cp "${dml_redist_root}/LICENSE.txt" "${dml_redist_dir}/DirectML_LICENSE.txt"
   cp "${dml_redist_root}/ThirdPartyNotices.txt" "${dml_redist_dir}/DirectML_ThirdPartyNotices.txt"
+
+  # Copy PIX event runtime
+  if is_windows; then
+    pix_event_runtime_dll_path=$(awk '/^pix\/.*\/WinPixEventRuntime\.dll/ {print $2}' $runfiles_manifest_path)
+    pix_event_runtime_root=$(echo $pix_event_runtime_dll_path | sed 's/\/bin\/x64\/WinPixEventRuntime\.dll//')
+
+    cp "$pix_event_runtime_dll_path" "${dml_redist_dir}"
+    cp "$pix_event_runtime_root/license.txt" "${dml_redist_dir}/WinPixEventRuntime_LICENSE.txt"
+    cp "$pix_event_runtime_root/ThirdPartyNotices.txt" "${dml_redist_dir}/WinPixEventRuntime_ThirdPartyNotices.txt"
+  fi
 }
 
 function prepare_src() {

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -246,6 +246,7 @@ if os.name == 'nt':
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.pyd'
   matches.extend(['../' + x for x in find_files("DirectML.*.dll", "tensorflow_core/python")])
   matches.extend(['../' + x for x in find_files("DirectML_*.txt", "tensorflow_core/python")])
+  matches.extend(['../' + x for x in find_files("WinPixEventRuntime*", "tensorflow_core/python")])
 else:
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.so'
   matches.extend(['../' + x for x in find_files("libdirectml.*.so", "tensorflow_core")])

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -34,6 +34,7 @@ load("//third_party/kissfft:workspace.bzl", kissfft = "repo")
 load("//third_party/keras_applications_archive:workspace.bzl", keras_applications = "repo")
 load("//third_party/pasta:workspace.bzl", pasta = "repo")
 load("//third_party/dml/redist:workspace.bzl", "dml_repository")
+load("//third_party/pix:workspace.bzl", "pix_repository")
 
 def initialize_third_party():
     """ Load third party repositories.  See above load() statements. """
@@ -92,6 +93,14 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         version = "1.5.0-dev20210301",
         source = "https://api.nuget.org/v3/index.json",
         build_file = "//third_party/dml/redist:BUILD.bazel",
+    )
+
+    pix_repository(
+        name = "pix",
+        package = "WinPixEventRuntime",
+        version = "1.0.210209001",
+        source = "https://api.nuget.org/v3/index.json",
+        build_file = "//third_party/pix:BUILD.bazel",
     )
 
     # Point //external/local_config_arm_compiler to //external/arm_compiler

--- a/third_party/pix/BUILD.bazel
+++ b/third_party/pix/BUILD.bazel
@@ -1,0 +1,20 @@
+# Description:
+#   WinPixEventRuntime redistributable library
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "headers",
+    hdrs = glob(["WinPixEventRuntime/include/WinPixEventRuntime/*.h"]),
+    includes = ["WinPixEventRuntime/include/WinPixEventRuntime"],
+)
+
+filegroup(
+    name = "pip_files",
+    srcs = glob([
+        "WinPixEventRuntime/bin/x64/WinPixEventRuntime.dll", 
+        "WinPixEventRuntime/*.txt"]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/pix/workspace.bzl
+++ b/third_party/pix/workspace.bzl
@@ -1,0 +1,40 @@
+"""Loads the WinPixEventRuntime redistributable library"""
+
+def _pix_nuget_repository_impl(repository_ctx):
+  # Download NuGet CLI executable.
+  nuget_path = repository_ctx.path("nuget.exe")
+  repository_ctx.download(
+    url = "https://dist.nuget.org/win-x86-commandline/v5.7.0/nuget.exe", 
+    sha256 = "ae3bb02517b52a744833a4777e99d647cd80b29a62fd360e9aabaa34f09af59c",
+    output = nuget_path,
+    executable = True,
+  )
+
+  # Install the PIX NuGet package.
+  output_directory = repository_ctx.path("")
+  cmd = [
+    nuget_path,
+    "install",
+    "-Source", repository_ctx.attr.source,
+    "-Version", repository_ctx.attr.version,
+    "-OutputDirectory", output_directory,
+    "-ExcludeVersion",
+    repository_ctx.attr.package,
+  ]
+  result = repository_ctx.execute(cmd)
+  if result.return_code != 0:
+    fail("Downloading WinPixEventRuntime failed: %s (%s)" % (result.stderr, " ".join(cmd)))
+
+  # Overlay bazel BUILD file on top of the extracted NuGet.
+  build_file_path = repository_ctx.path(repository_ctx.attr.build_file)
+  repository_ctx.symlink(build_file_path, "BUILD")
+
+pix_repository = repository_rule(
+    implementation = _pix_nuget_repository_impl,
+    attrs = {
+      "source" : attr.string(mandatory=True),
+      "version" : attr.string(mandatory=True),
+      "package" : attr.string(mandatory=True),
+      "build_file" : attr.label(),
+    }
+)


### PR DESCRIPTION
Adds support for PIX events around session runs (CPU event) and operator execution (GPU events). These events make it much nicer to analyze models with PIX timing captures.

Note that CPU events are not part of WinPixEventRuntime's stable ABI, so this change also includes a copy of WinPixEventRuntime.dll in the TF wheels for Windows. PIX events are disabled by default and must be enabled by setting TF_DIRECTML_TRACE_LEVEL.