### PR TITLE
Disable hanging test

### DIFF
--- a/tensorflow/python/autograph/operators/BUILD
+++ b/tensorflow/python/autograph/operators/BUILD
@@ -67,6 +67,7 @@ py_test(
     srcs_version = "PY2AND3",
     tags = [
         "no_gpu",  # b/127001953
+        "no_dml", # 32193733
     ],
     deps = [
         ":operators",

--- a/third_party/dml/ci/tests/tfdml_test_runner.py
+++ b/third_party/dml/ci/tests/tfdml_test_runner.py
@@ -30,11 +30,6 @@ def _parse_args():
       required=True)
 
   parser.add_argument(
-      "--test_timeout",
-      default=600,
-      help="max duration allowed for a single test (in seconds)")
-
-  parser.add_argument(
       "--log_device_placement",
       action="store_true")
 
@@ -58,8 +53,7 @@ def _run_test(
     log_device_placement,
     shard_index,
     total_shard_count,
-    test_framework,
-    test_timeout):
+    test_framework):
   """Runs a test executable in its own process."""
 
   # Insert the shard index in the name of the xml file
@@ -102,7 +96,6 @@ def _run_test(
             stderr=stderr,
             env=env_copy,
             stdin=subprocess.DEVNULL,
-            timeout=test_timeout,
             check=True)
       except KeyboardInterrupt: # pylint: disable=try-except-raise
         raise
@@ -205,8 +198,7 @@ def main():
                   log_device_placement,
                   shard_index,
                   shard_count,
-                  args.test_framework,
-                  args.test_timeout))
+                  args.test_framework))
 
       for future in futures:
         future.result()

--- a/third_party/dml/ci/tests/tfdml_test_runner.py
+++ b/third_party/dml/ci/tests/tfdml_test_runner.py
@@ -30,6 +30,11 @@ def _parse_args():
       required=True)
 
   parser.add_argument(
+      "--test_timeout",
+      default=600,
+      help="max duration allowed for a single test (in seconds)")
+
+  parser.add_argument(
       "--log_device_placement",
       action="store_true")
 
@@ -53,7 +58,8 @@ def _run_test(
     log_device_placement,
     shard_index,
     total_shard_count,
-    test_framework):
+    test_framework,
+    test_timeout):
   """Runs a test executable in its own process."""
 
   # Insert the shard index in the name of the xml file
@@ -96,6 +102,7 @@ def _run_test(
             stderr=stderr,
             env=env_copy,
             stdin=subprocess.DEVNULL,
+            timeout=test_timeout,
             check=True)
       except KeyboardInterrupt: # pylint: disable=try-except-raise
         raise
@@ -198,7 +205,8 @@ def main():
                   log_device_placement,
                   shard_index,
                   shard_count,
-                  args.test_framework))
+                  args.test_framework,
+                  args.test_timeout))
 
       for future in futures:
         future.result()


### PR DESCRIPTION
This single test is causing the entire test pass to timeout, so it's being disabled for now.