### PR TITLE
Fix RandomUniformInt's DML validation

### DIFF
--- a/tensorflow/core/kernels/dml_random_ops.cc
+++ b/tensorflow/core/kernels/dml_random_ops.cc
@@ -325,7 +325,7 @@ class RandomUniformInitHelper : public InitializationHelper {
     // This init helper is shared for both "RandomUniform" (real types) and
     // "RandomUniformInt" (integral types). The latter has two extra host-memory
     // tensors for the min and max of the output range.
-    if (ctx->num_inputs() == 4) {
+    if (ctx->num_inputs() == 3) {
       const Tensor& minval = ctx->input(1);
       const Tensor& maxval = ctx->input(2);
       OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(minval.shape()),

--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -336,7 +336,6 @@ class RandomUniformTest(RandomOpTestCommon):
       self.assertLess(error.max(), 5 * std)
 
   # Check that minval = maxval is fine iff we're producing no numbers
-  @test_util.skip_dml # DML doesn't run validation logic on no-op kernels
   def testUniformIntsDegenerate(self):
     for dt in dtypes.int32, dtypes.int64:
       def sample(n):


### PR DESCRIPTION
DML actually does run validation for no-op kernels, but in this case we were never reaching it because the condition was wrong (RandomUniformInit has 3 inputs, not 4).