### PR TITLE
Add IDMLDevice::CompileOperator checks to adapter filtering

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -70,14 +70,22 @@ static bool IsUmaAdapter(const DmlAdapter& adapter) {
                                         : D3D_FEATURE_LEVEL_11_0;
 
   ComPtr<ID3D12Device> d3d12_device;
-  DML_CHECK_SUCCEEDED(D3D12CreateDevice(adapter.Impl()->Get(), feature_level,
-                                        IID_PPV_ARGS(&d3d12_device)));
+  HRESULT hr = D3D12CreateDevice(adapter.Impl()->Get(), feature_level,
+                                 IID_PPV_ARGS(&d3d12_device));
+
+  if (FAILED(hr)) {
+    return false;
+  }
 
   D3D12_FEATURE_DATA_ARCHITECTURE feature_data = {};
-  HRESULT hr = d3d12_device->CheckFeatureSupport(
-      D3D12_FEATURE_ARCHITECTURE, &feature_data, sizeof(feature_data));
+  hr = d3d12_device->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE,
+                                         &feature_data, sizeof(feature_data));
 
-  return SUCCEEDED(hr) && feature_data.CacheCoherentUMA;
+  if (FAILED(hr)) {
+    return false;
+  }
+
+  return feature_data.CacheCoherentUMA;
 }
 
 class DmlDeviceFactory : public DeviceFactory {

--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -73,11 +73,11 @@ static bool IsUmaAdapter(const DmlAdapter& adapter) {
   DML_CHECK_SUCCEEDED(D3D12CreateDevice(adapter.Impl()->Get(), feature_level,
                                         IID_PPV_ARGS(&d3d12_device)));
 
-  D3D12_FEATURE_DATA_ARCHITECTURE1 feature_data = {};
-  DML_CHECK_SUCCEEDED(d3d12_device->CheckFeatureSupport(
-      D3D12_FEATURE_ARCHITECTURE1, &feature_data, sizeof(feature_data)));
+  D3D12_FEATURE_DATA_ARCHITECTURE feature_data = {};
+  HRESULT hr = d3d12_device->CheckFeatureSupport(
+      D3D12_FEATURE_ARCHITECTURE, &feature_data, sizeof(feature_data));
 
-  return feature_data.CacheCoherentUMA;
+  return SUCCEEDED(hr) && feature_data.CacheCoherentUMA;
 }
 
 class DmlDeviceFactory : public DeviceFactory {

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -36,6 +36,9 @@ from tensorflow.python.ops import nn_grad  # pylint: disable=unused-import
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
+import os
+input(os.getpid())
+
 _ADD = lambda x, y: x + y
 _SUB = lambda x, y: x - y
 _MUL = lambda x, y: x * y

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -36,9 +36,6 @@ from tensorflow.python.ops import nn_grad  # pylint: disable=unused-import
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
-import os
-input(os.getpid())
-
 _ADD = lambda x, y: x + y
 _SUB = lambda x, y: x - y
 _MUL = lambda x, y: x * y


### PR DESCRIPTION
Adapter filtering right now has a gap where D3D12 device creation will be successful, but some APIs may be missing down the line and eventually make tfdml crash. This change attempts to correct this by making sure that we can at least compile a simple operator before certifying an adapter as DML-compatible.