### PR TITLE
bngrad kernel and test fixes

### DIFF
--- a/tensorflow/core/kernels/dml_batch_norm_ops.cc
+++ b/tensorflow/core/kernels/dml_batch_norm_ops.cc
@@ -647,12 +647,7 @@ class DmlFusedBatchNormGradKernel : public DmlKernel {
 
     // FusedBatchNormGradV3 receives an additional (6th) input which we don't
     // use, so we explicitly only supply 5 indices here
-    if (is_training) {
-      params.kernel_input_indices = {0, 1, 2, 3, 4};
-    } else {
-      params.kernel_input_indices = {kX, kYBackprop, kReserveSpace1,
-                                     kReserveSpace2, kScale};
-    }
+    params.kernel_input_indices = {0, 1, 2, 3, 4};
 
     // Only the first 3 outputs are used, the remainder are placeholders
     params.kernel_output_indices = {0, 1, 2};

--- a/tensorflow/python/ops/nn_fused_batchnorm_test.py
+++ b/tensorflow/python/ops/nn_fused_batchnorm_test.py
@@ -44,12 +44,15 @@ class BatchNormalizationTest(test.TestCase):
     return math_ops.cast(y, x.dtype)
 
   def _inference_ref(self, x, scale, offset, mean, var, epsilon, data_format):
+    # the reference should be calculated in high precision
+    x_32 = math_ops.cast(x, np.float32);
+
     if data_format not in ['NHWC', 'NCHW']:
       raise ValueError('data_format must be NCHW or NHWC, '
                        'got %s.' % data_format)
     if data_format == 'NCHW':
-      x = array_ops.transpose(x, [0, 2, 3, 1])
-    y = self._batch_norm(x, mean, var, offset, scale, epsilon)
+      x_32 = array_ops.transpose(x_32, [0, 2, 3, 1])
+    y = self._batch_norm(x_32, mean, var, offset, scale, epsilon)
     if data_format == 'NCHW':
       y = array_ops.transpose(y, [0, 3, 1, 2])
     return self.evaluate(y)
@@ -90,18 +93,21 @@ class BatchNormalizationTest(test.TestCase):
     # An atol value of 1e-3 is too small for float16's, because some adjacent
     # float16 values that y_val can take are greater than 1e-3 apart, e.g.
     # 2.16602 and 2.16797.
-    atol = 2e-3 if x_dtype == np.float16 else 1e-3
+    atol = 4e-3 if x_dtype == np.float16 else 1e-3
     self.assertAllClose(y_ref, y_val, atol=atol)
 
   def _training_ref(self, x, scale, offset, epsilon, data_format):
     if data_format not in ['NHWC', 'NCHW']:
       raise ValueError('data_format must be NCHW or NHWC, '
                        'got %s.' % data_format)
+    # the reference should be calculated in high precision
+    x_32 = math_ops.cast(x, np.float32);
+
     if data_format == 'NCHW':
-      x = array_ops.transpose(x, [0, 2, 3, 1])
-    mean, var = nn_impl.moments(
-        math_ops.cast(x, scale.dtype), [0, 1, 2], keep_dims=False)
-    y = self._batch_norm(x, mean, var, offset, scale, epsilon)
+      x_32 = array_ops.transpose(x_32, [0, 2, 3, 1])
+
+    mean, var = nn_impl.moments(x_32, [0, 1, 2], keep_dims=False)
+    y = self._batch_norm(x_32, mean, var, offset, scale, epsilon)
     if data_format == 'NCHW':
       y = array_ops.transpose(y, [0, 3, 1, 2])
     return self.evaluate(y), self.evaluate(mean), self.evaluate(var)
@@ -132,7 +138,7 @@ class BatchNormalizationTest(test.TestCase):
       y_val, mean_val, var_val = self.evaluate([y, mean, var])
       y_ref, mean_ref, var_ref = self._training_ref(x, scale, offset, epsilon,
                                                     data_format)
-    y_atol = 2e-3 if x_dtype == np.float16 else 1e-3
+    y_atol = 4e-3 if x_dtype == np.float16 else 1e-3
     self.assertAllClose(y_ref, y_val, atol=y_atol)
     self.assertAllClose(mean_ref, mean_val, atol=1e-3)
     # This is for Bessel's correction. tf.nn.moments uses n, instead of n-1, as


### PR DESCRIPTION
the kernel had the wrong input indices for a graph operator (leftover from when it was not a graph operator)

I changed the tests to calculate the reference impl with 32 bit precision. 

One of the test tolerances is high (2e-2) because the is_training=true case results in some pretty low precision. That's because it's using many separate operations in the is_training=true kernel and losing precision.