### PR TITLE
Add 8D support for BatchMatMul

### DIFF
--- a/tensorflow/core/kernels/dml_matmul_op.cc
+++ b/tensorflow/core/kernels/dml_matmul_op.cc
@@ -107,25 +107,25 @@ class BaseBatchMatMulInitHelper : public InitializationHelper {
                     "In[0] and In[1] must have compatible batch dimensions: ",
                     in0_shape.DebugString(), " vs. ", in1_shape.DebugString()));
 
-    auto d0 = in0_shape.dim_size(in0_shape.dims() - 2);
-    auto d1 = in0_shape.dim_size(in0_shape.dims() - 1);
-    auto d2 = in1_shape.dim_size(in1_shape.dims() - 2);
-    auto d3 = in1_shape.dim_size(in1_shape.dims() - 1);
+    auto in0_rows = in0_shape.dim_size(in0_shape.dims() - 2);
+    auto in0_cols = in0_shape.dim_size(in0_shape.dims() - 1);
+    auto in1_rows = in1_shape.dim_size(in1_shape.dims() - 2);
+    auto in1_cols = in1_shape.dim_size(in1_shape.dims() - 1);
 
     collapsed_in0_shape_ = BCast::ToShape(batches_bcast.x_reshape());
-    collapsed_in0_shape_.AddDim(d0);
-    collapsed_in0_shape_.AddDim(d1);
+    collapsed_in0_shape_.AddDim(in0_rows);
+    collapsed_in0_shape_.AddDim(in0_cols);
 
     collapsed_in1_shape_ = BCast::ToShape(batches_bcast.y_reshape());
-    collapsed_in1_shape_.AddDim(d2);
-    collapsed_in1_shape_.AddDim(d3);
+    collapsed_in1_shape_.AddDim(in1_rows);
+    collapsed_in1_shape_.AddDim(in1_cols);
 
-    if (attr->adj_x) std::swap(d0, d1);
-    if (attr->adj_y) std::swap(d2, d3);
+    if (attr->adj_x) std::swap(in0_rows, in0_cols);
+    if (attr->adj_y) std::swap(in1_rows, in1_cols);
 
     collapsed_output_shape_ = BCast::ToShape(batches_bcast.output_shape());
-    collapsed_output_shape_.AddDim(d0);
-    collapsed_output_shape_.AddDim(d3);
+    collapsed_output_shape_.AddDim(in0_rows);
+    collapsed_output_shape_.AddDim(in1_cols);
 
     OP_REQUIRES(ctx, collapsed_output_shape_.dims() <= 8,
                 errors::InvalidArgument(

--- a/tensorflow/core/kernels/dml_matmul_op.cc
+++ b/tensorflow/core/kernels/dml_matmul_op.cc
@@ -79,57 +79,86 @@ class BaseBatchMatMulInitHelper : public InitializationHelper {
     bool adj_y;
   };
 
-  BaseBatchMatMulInitHelper(OpKernelContext* ctx,
-                            std::shared_ptr<const Attributes> attr)
+  BaseBatchMatMulInitHelper(
+      OpKernelContext* ctx, std::shared_ptr<const Attributes> attr,
+      std::function<void(OpKernelContext*, const TensorShape&,
+                         const TensorShape&)>
+          ValidateInputTensors)
       : attr_(attr) {
-    const Tensor& in0 = ctx->input(0);
-    const Tensor& in1 = ctx->input(1);
+    const TensorShape& in0_shape = ctx->input(0).shape();
+    const TensorShape& in1_shape = ctx->input(1).shape();
+    ValidateInputTensors(ctx, in0_shape, in1_shape);
 
-    MatMulBCast bcast(in0.shape().dim_sizes(), in1.shape().dim_sizes());
-    OP_REQUIRES(
-        ctx, bcast.IsValid(),
-        errors::InvalidArgument(
-            "In[0] and In[1] must have compatible batch dimensions: ",
-            in0.shape().DebugString(), " vs. ", in1.shape().DebugString()));
+    TensorShape in0_batches_shape;
+    for (int i = 0; i < in0_shape.dims() - 2; ++i) {
+      in0_batches_shape.AddDim(in0_shape.dim_size(i));
+    }
 
-    auto batch_size = bcast.output_batch_size();
-    auto d0 = in0.dim_size(in0.dims() - 2);
-    auto d1 = in0.dim_size(in0.dims() - 1);
-    Tensor in0_reshaped;
-    OP_REQUIRES(
-        ctx,
-        in0_reshaped.CopyFrom(in0, TensorShape({bcast.x_batch_size(), d0, d1})),
-        errors::Internal("Failed to reshape In[0] from ",
-                         in0.shape().DebugString()));
-    auto d2 = in1.dim_size(in1.dims() - 2);
-    auto d3 = in1.dim_size(in1.dims() - 1);
-    Tensor in1_reshaped;
-    OP_REQUIRES(
-        ctx,
-        in1_reshaped.CopyFrom(in1, TensorShape({bcast.y_batch_size(), d2, d3})),
-        errors::Internal("Failed to reshape In[1] from ",
-                         in1.shape().DebugString()));
+    TensorShape in1_batches_shape;
+    for (int i = 0; i < in1_shape.dims() - 2; ++i) {
+      in1_batches_shape.AddDim(in1_shape.dim_size(i));
+    }
+
+    BCast batches_bcast(BCast::FromShape(in0_batches_shape),
+                        BCast::FromShape(in1_batches_shape));
+
+    OP_REQUIRES(ctx, batches_bcast.IsValid(),
+                errors::InvalidArgument(
+                    "In[0] and In[1] must have compatible batch dimensions: ",
+                    in0_shape.DebugString(), " vs. ", in1_shape.DebugString()));
+
+    auto d0 = in0_shape.dim_size(in0_shape.dims() - 2);
+    auto d1 = in0_shape.dim_size(in0_shape.dims() - 1);
+    auto d2 = in1_shape.dim_size(in1_shape.dims() - 2);
+    auto d3 = in1_shape.dim_size(in1_shape.dims() - 1);
+
+    collapsed_in0_shape_ = BCast::ToShape(batches_bcast.x_reshape());
+    collapsed_in0_shape_.AddDim(d0);
+    collapsed_in0_shape_.AddDim(d1);
+
+    collapsed_in1_shape_ = BCast::ToShape(batches_bcast.y_reshape());
+    collapsed_in1_shape_.AddDim(d2);
+    collapsed_in1_shape_.AddDim(d3);
+
     if (attr->adj_x) std::swap(d0, d1);
     if (attr->adj_y) std::swap(d2, d3);
+
+    collapsed_output_shape_ = BCast::ToShape(batches_bcast.output_shape());
+    collapsed_output_shape_.AddDim(d0);
+    collapsed_output_shape_.AddDim(d3);
+
+    OP_REQUIRES(ctx, collapsed_output_shape_.dims() <= 8,
+                errors::InvalidArgument(
+                    "DML doesn't support more than 8D for BroadcastTo after "
+                    "collapsing dimensions together, but the output has ",
+                    collapsed_output_shape_.dims(), " dimensions."));
+
     OP_REQUIRES(ctx, d1 == d2,
                 errors::InvalidArgument(
                     "In[0] mismatch In[1] shape: ", d1, " vs. ", d2, ": ",
-                    in0.shape().DebugString(), " ", in1.shape().DebugString(),
-                    " ", attr->adj_x, " ", attr->adj_y));
-
-    output_batch_shape_ = bcast.output_batch_shape();
+                    in0_shape.DebugString(), " ", in1_shape.DebugString(), " ",
+                    attr->adj_x, " ", attr->adj_y));
   }
 
-  const TensorShape& GetOutputBatchShape() const { return output_batch_shape_; }
+  const TensorShape& GetCollapsedIn0Shape() const {
+    return collapsed_in0_shape_;
+  }
+
+  const TensorShape& GetCollapsedIn1Shape() const {
+    return collapsed_in1_shape_;
+  }
+
+  const TensorShape& GetCollapsedOutputShape() const {
+    return collapsed_output_shape_;
+  }
+
   bool AdjX() const { return attr_->adj_x; }
   bool AdjY() const { return attr_->adj_y; }
 
- protected:
-  virtual void ValidateInputTensors(OpKernelContext* ctx, const Tensor& in0,
-                                    const Tensor& in1) = 0;
-
  private:
-  TensorShape output_batch_shape_;
+  TensorShape collapsed_in0_shape_;
+  TensorShape collapsed_in1_shape_;
+  TensorShape collapsed_output_shape_;
   const std::shared_ptr<const Attributes> attr_;
 };
 
@@ -138,27 +167,28 @@ class BatchMatMulInitHelper : public BaseBatchMatMulInitHelper {
   explicit BatchMatMulInitHelper(
       OpKernelContext* ctx,
       std::shared_ptr<const BaseBatchMatMulInitHelper::Attributes> attr)
-      : BaseBatchMatMulInitHelper(ctx, attr) {}
+      : BaseBatchMatMulInitHelper(ctx, attr, ValidateInputTensors) {}
 
  private:
-  void ValidateInputTensors(OpKernelContext* ctx, const Tensor& in0,
-                            const Tensor& in1) override {
+  static void ValidateInputTensors(OpKernelContext* ctx,
+                                   const TensorShape& in0_shape,
+                                   const TensorShape& in1_shape) {
     // Disallow broadcasting support. Ensure that all batch dimensions of the
     // input tensors match.
-    OP_REQUIRES(ctx, in0.dims() == in1.dims(),
+    OP_REQUIRES(ctx, in0_shape.dims() == in1_shape.dims(),
                 errors::InvalidArgument("In[0] and In[1] has different ndims: ",
-                                        in0.shape().DebugString(), " vs. ",
-                                        in1.shape().DebugString()));
-    const int ndims = in0.dims();
+                                        in0_shape.DebugString(), " vs. ",
+                                        in1_shape.DebugString()));
+    const int ndims = in0_shape.dims();
     OP_REQUIRES(
         ctx, ndims >= 2,
         errors::InvalidArgument("In[0] and In[1] ndims must be >= 2: ", ndims));
     for (int i = 0; i < ndims - 2; ++i) {
-      OP_REQUIRES(ctx, in0.dim_size(i) == in1.dim_size(i),
+      OP_REQUIRES(ctx, in0_shape.dim_size(i) == in1_shape.dim_size(i),
                   errors::InvalidArgument(
                       "In[0].dim(", i, ") and In[1].dim(", i,
-                      ") must be the same: ", in0.shape().DebugString(), " vs ",
-                      in1.shape().DebugString()));
+                      ") must be the same: ", in0_shape.DebugString(), " vs ",
+                      in1_shape.DebugString()));
     }
   }
 };
@@ -168,19 +198,20 @@ class BatchMatMulV2InitHelper : public BaseBatchMatMulInitHelper {
   explicit BatchMatMulV2InitHelper(
       OpKernelContext* ctx,
       std::shared_ptr<const BaseBatchMatMulInitHelper::Attributes> attr)
-      : BaseBatchMatMulInitHelper(ctx, attr) {}
+      : BaseBatchMatMulInitHelper(ctx, attr, ValidateInputTensors) {}
 
  private:
-  void ValidateInputTensors(OpKernelContext* ctx, const Tensor& in0,
-                            const Tensor& in1) override {
+  static void ValidateInputTensors(OpKernelContext* ctx,
+                                   const TensorShape& in0_shape,
+                                   const TensorShape& in1_shape) {
     // Enable broadcasting support. Validity of broadcasting is checked in
     // BaseBatchMatMulInitHelper.
-    OP_REQUIRES(
-        ctx, in0.dims() >= 2,
-        errors::InvalidArgument("In[0] ndims must be >= 2: ", in0.dims()));
-    OP_REQUIRES(
-        ctx, in1.dims() >= 2,
-        errors::InvalidArgument("In[1] ndims must be >= 2: ", in1.dims()));
+    OP_REQUIRES(ctx, in0_shape.dims() >= 2,
+                errors::InvalidArgument("In[0] ndims must be >= 2: ",
+                                        in0_shape.dims()));
+    OP_REQUIRES(ctx, in1_shape.dims() >= 2,
+                errors::InvalidArgument("In[1] ndims must be >= 2: ",
+                                        in1_shape.dims()));
   }
 };
 
@@ -203,36 +234,6 @@ class MatMulShapeHelper : public ShapeHelper {
   }
 };
 
-static std::vector<TensorShape> GetBatchMatMulOutputShapes(
-    OpKernelContext* ctx, const BaseBatchMatMulInitHelper* init_helper) {
-  const TensorShape& in0 = ctx->input(0).shape();
-  const TensorShape& in1 = ctx->input(1).shape();
-
-  int64 in0_rows = in0.dim_size(in0.dims() - 2);
-  int64 in0_cols = in0.dim_size(in0.dims() - 1);
-
-  int64 in1_rows = in1.dim_size(in1.dims() - 2);
-  int64 in1_cols = in1.dim_size(in1.dims() - 1);
-
-  if (init_helper->AdjX()) {
-    std::swap(in0_rows, in0_cols);
-  }
-
-  if (init_helper->AdjY()) {
-    std::swap(in1_rows, in1_cols);
-  }
-
-  // The matrices must have matching shapes; this should have been validated
-  // earlier
-  assert(in0_cols == in1_rows);
-
-  TensorShape output_shape = init_helper->GetOutputBatchShape();
-  output_shape.AddDim(in0_rows);
-  output_shape.AddDim(in1_cols);
-
-  return {output_shape};
-}
-
 template <typename TInitHelper>
 class BatchMatMulShapeHelper : public ShapeHelper {
  public:
@@ -241,7 +242,27 @@ class BatchMatMulShapeHelper : public ShapeHelper {
       const InitializationHelper* initialization_helper) const override {
     auto init_helper = static_cast<const TInitHelper*>(initialization_helper);
 
-    return GetBatchMatMulOutputShapes(ctx, init_helper);
+    const Tensor& in0 = ctx->input(0);
+    const Tensor& in1 = ctx->input(1);
+    auto in0_rows = in0.dim_size(in0.dims() - 2);
+    auto in0_cols = in0.dim_size(in0.dims() - 1);
+    auto in1_rows = in1.dim_size(in1.dims() - 2);
+    auto in1_cols = in1.dim_size(in1.dims() - 1);
+
+    if (init_helper->AdjX()) {
+      std::swap(in0_rows, in0_cols);
+    }
+
+    if (init_helper->AdjY()) {
+      std::swap(in1_rows, in1_cols);
+    }
+
+    MatMulBCast bcast(in0.shape().dim_sizes(), in1.shape().dim_sizes());
+    TensorShape output_shape = bcast.output_batch_shape();
+    output_shape.AddDim(in0_rows);
+    output_shape.AddDim(in1_cols);
+
+    return {output_shape};
   }
 };
 
@@ -312,12 +333,13 @@ class DmlBatchMatMulKernel : public DmlKernel {
 
     // Broadcast the batch dimensions of the input shapes if necessary by
     // setting the batch dimensions equal to the output's
-    TensorShape in0_shape;
-    TensorShape in1_shape;
+    TensorShape batches_shape;
     for (int i = 0; i < batch_dimension_count; ++i) {
-      in0_shape.AddDim(output_shape.dim_size(i));
-      in1_shape.AddDim(output_shape.dim_size(i));
+      batches_shape.AddDim(output_shape.dim_size(i));
     }
+
+    TensorShape in0_shape = batches_shape;
+    TensorShape in1_shape = batches_shape;
 
     // Add spatial dimensions for input shapes. Spatial dimensions are the
     // last two of the input shapes.
@@ -331,17 +353,46 @@ class DmlBatchMatMulKernel : public DmlKernel {
         in1_physical_shape.dim_size(in1_physical_shape.dims() - 1));
 
     DmlKernelParams params;
-    params.kernel_input_indices = {
-        0, 1,
-        absl::nullopt  // We don't use GEMM's 'C' tensor
-    };
+    params.kernel_input_indices = {0, 1};
 
     DmlKernelTensors tensors = GetTensorInfos(ctx, params);
     tensors.inputs[0]->desc = CreateTensorDescFromInput(ctx, 0, in0_shape);
     tensors.inputs[1]->desc = CreateTensorDescFromInput(ctx, 1, in1_shape);
 
     auto input_descs = GetDmlTensorDescs(tensors.inputs);
-    auto output_descs = GetDmlTensorDescs(tensors.outputs);
+    auto scope = dml::Graph(ctx->GetDmlDevice());
+    auto a_tensor = dml::InputTensor(scope, 0, input_descs[0]);
+    auto b_tensor = dml::InputTensor(scope, 1, input_descs[1]);
+
+    auto a_tensor_sizes = a_tensor.GetOutputDesc().sizes;
+    auto b_tensor_sizes = b_tensor.GetOutputDesc().sizes;
+
+    // DML doesn't support more than 4 dimensions for GEMM, so do the
+    // broadcasting manually by using identity beforehand
+    if (a_tensor_sizes.size() > kNchwDimensionCount) {
+      a_tensor = dml::Identity(a_tensor);
+      dml::TensorDimensions collapsed_sizes = {
+          static_cast<uint32_t>(batches_shape.num_elements()),
+          1,
+          a_tensor_sizes[a_tensor_sizes.size() - 2],
+          a_tensor_sizes[a_tensor_sizes.size() - 1],
+      };
+
+      a_tensor = dml::Reinterpret(a_tensor, collapsed_sizes, absl::nullopt);
+    }
+
+    if (b_tensor_sizes.size() > kNchwDimensionCount) {
+      b_tensor = dml::Identity(b_tensor);
+
+      dml::TensorDimensions collapsed_sizes = {
+          static_cast<uint32_t>(batches_shape.num_elements()),
+          1,
+          b_tensor_sizes[b_tensor_sizes.size() - 2],
+          b_tensor_sizes[b_tensor_sizes.size() - 1],
+      };
+
+      b_tensor = dml::Reinterpret(b_tensor, collapsed_sizes, absl::nullopt);
+    }
 
     // This kernel doesn't support complex types, so adjointed matrices are
     // equivalent to their transpose.
@@ -352,19 +403,15 @@ class DmlBatchMatMulKernel : public DmlKernel {
                                        ? DML_MATRIX_TRANSFORM_TRANSPOSE
                                        : DML_MATRIX_TRANSFORM_NONE;
 
-    DML_GEMM_OPERATOR_DESC gemm_desc = {};
-    gemm_desc.ATensor = &input_descs[0];
-    gemm_desc.BTensor = &input_descs[1];
-    gemm_desc.CTensor = nullptr;
-    gemm_desc.OutputTensor = &output_descs[0];
-    gemm_desc.TransA = trans_a;
-    gemm_desc.TransB = trans_b;
-    gemm_desc.Alpha = 1.0f;
-    gemm_desc.Beta = 0.0f;
-    gemm_desc.FusedActivation = nullptr;
+    constexpr float alpha = 1.0f;
+    constexpr float beta = 0.0f;
+    auto result = dml::Gemm(a_tensor, b_tensor, absl::nullopt, trans_a, trans_b,
+                            alpha, beta);
 
-    DML_OPERATOR_DESC op_desc = {DML_OPERATOR_GEMM, &gemm_desc};
-    Initialize(ctx, std::move(tensors), op_desc);
+    Microsoft::WRL::ComPtr<IDMLCompiledOperator> compiled_op =
+        scope.Compile(DML_EXECUTION_FLAG_NONE, {result});
+
+    Initialize(ctx, std::move(tensors), compiled_op.Get());
   }
 };
 

--- a/tensorflow/core/kernels/dml_matmul_op.cc
+++ b/tensorflow/core/kernels/dml_matmul_op.cc
@@ -133,11 +133,11 @@ class BaseBatchMatMulInitHelper : public InitializationHelper {
                     "collapsing dimensions together, but the output has ",
                     collapsed_output_shape_.dims(), " dimensions."));
 
-    OP_REQUIRES(ctx, d1 == d2,
+    OP_REQUIRES(ctx, in0_cols == in1_rows,
                 errors::InvalidArgument(
-                    "In[0] mismatch In[1] shape: ", d1, " vs. ", d2, ": ",
-                    in0_shape.DebugString(), " ", in1_shape.DebugString(), " ",
-                    attr->adj_x, " ", attr->adj_y));
+                    "In[0] mismatch In[1] shape: ", in0_cols, " vs. ", in1_rows,
+                    ": ", in0_shape.DebugString(), " ", in1_shape.DebugString(),
+                    " ", attr->adj_x, " ", attr->adj_y));
   }
 
   const TensorShape& GetCollapsedIn0Shape() const {

--- a/tensorflow/python/kernel_tests/batch_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/batch_matmul_op_test.py
@@ -111,9 +111,8 @@ class BatchMatmulOpTest(test.TestCase):
     CompareNonEmpty(self, [5, 1, 2, 3], [1, 7, 3, 5])
     CompareNonEmpty(self, [5, 2, 2, 3], [3, 5])
     CompareNonEmpty(self, [2, 3], [5, 2, 3, 5])
-    if test_util.gpu_device_type() != "DML": # DML only supports up to 4D
-      CompareNonEmpty(self, [4, 5, 1, 2, 3], [1, 1, 3, 5])
-      CompareNonEmpty(self, [1, 2, 1, 4, 2, 1, 3, 4], [3, 2, 1, 1, 1, 2, 4, 2])
+    CompareNonEmpty(self, [4, 5, 1, 2, 3], [1, 1, 3, 5])
+    CompareNonEmpty(self, [1, 2, 1, 4, 2, 1, 3, 4], [3, 2, 1, 1, 1, 2, 4, 2])
 
   def _testEmpty(self, dtype, adjoint_a, adjoint_b, use_static_shape):
 
@@ -207,9 +206,8 @@ def _GetBatchMatmulGradientWithBroadcastingTest(dtype, adjoint_a, adjoint_b):
       CheckGradients(self, [2, 3], [5, 3, 5])
       CheckGradients(self, [5, 2, 5], [5, 3])
       CheckGradients(self, [5, 2, 2, 3], [3, 5])
-      if test_util.gpu_device_type() != "DML": # DML only supports up to 4D
-        CheckGradients(self, [4, 5, 1, 2, 3], [1, 1, 3, 5])
-        CheckGradients(self, [1, 2, 1, 4, 2, 1, 3, 4], [3, 2, 1, 1, 1, 2, 4, 2])
+      CheckGradients(self, [4, 5, 1, 2, 3], [1, 1, 3, 5])
+      CheckGradients(self, [1, 2, 1, 4, 2, 1, 3, 4], [3, 2, 1, 1, 1, 2, 4, 2])
 
   return Test
 


### PR DESCRIPTION
DML's GEMM operator doesn't support more than 4D, but we can manually broadcast the batch dimensions using identity and collapse them together, therefore giving us 4D inputs instead of 8D.