### PR TITLE
Disable checkpoint tests and run util tests in float32

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -5739,6 +5739,9 @@ cuda_py_test(
         "//tensorflow/python/data/ops:dataset_ops",
     ],
     xla_enable_strict_auto_jit = True,
+    # Sporadic permissions issues on Windows related to moving/deleting temp dirs.
+    # This test is unrelated to DML usage.
+    tags = ["no_dml"],
 )
 
 tf_py_test(

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -5740,8 +5740,7 @@ cuda_py_test(
     ],
     xla_enable_strict_auto_jit = True,
     # Sporadic permissions issues on Windows related to moving/deleting temp dirs.
-    # This test is unrelated to DML usage.
-    tags = ["no_dml"],
+    tags = ["no_windows"],
 )
 
 tf_py_test(

--- a/tensorflow/python/keras/saving/saving_utils_test.py
+++ b/tensorflow/python/keras/saving/saving_utils_test.py
@@ -228,6 +228,11 @@ class TraceModelCallTest(keras_parameterized.TestCase):
     x = np.random.random((8, 5))
     y = np.random.random((8, 3))
 
+    # Numpy allocates float64 by default, which isn't supported by DML
+    if test.is_built_with_dml():
+      x = x.astype(np.float32)
+      y = y.astype(np.float32)
+
     train_step(x, y)
 
     fn = saving_utils.trace_model_call(model)


### PR DESCRIPTION
- Disables checkpoint tests (no interaction with DML backend) since they appear to have sporadic permission issues when renaming or deleting files in Windows. Not worth our time to run these in TFDML.
- Use float32 tensors in TraceModelCallTest to avoid op placement issues with numpy default FLOAT64 values