### PR TITLE
Address LSTM/RNN/GRU test issues

### DIFF
--- a/tensorflow/python/keras/layers/gru_v2_test.py
+++ b/tensorflow/python/keras/layers/gru_v2_test.py
@@ -348,6 +348,7 @@ class GRUV2Test(keras_parameterized.TestCase):
                 'return_sequences': True},
         input_shape=(num_samples, timesteps, embedding_dim))
 
+  @test_util.skip_dml # DML doesn't support float64 for most of the ops used in this test
   def test_float64_GRU(self):
     num_samples = 2
     timesteps = 3

--- a/tensorflow/python/keras/layers/gru_v2_test.py
+++ b/tensorflow/python/keras/layers/gru_v2_test.py
@@ -54,6 +54,11 @@ _rewrites.min_graph_nodes = -1
 _graph_options = config_pb2.GraphOptions(rewrite_options=_rewrites)
 _config = config_pb2.ConfigProto(graph_options=_graph_options)
 
+# DML doesn't implement every operator that used in these tests (e.g.
+# 'Qr'), so we need fallback to CPU kernels for unsupported ops to pass 
+# the _v1_session test case.
+if test_util.IsBuiltWithDML():
+  _config = None
 
 @keras_parameterized.run_all_keras_modes(config=_config)
 class GRUV2Test(keras_parameterized.TestCase):

--- a/tensorflow/python/keras/layers/gru_v2_test.py
+++ b/tensorflow/python/keras/layers/gru_v2_test.py
@@ -517,6 +517,11 @@ class GRUV2Test(keras_parameterized.TestCase):
     self.assertAllClose(out8, out7, atol=1e-5)
 
   def test_stateful_GRU_training(self):
+    # DML doesn't implement 'UnsortedSegmentSum', which will trigger colocation issues when
+    # running this test in an eager context.
+    if context.executing_eagerly() and test_util.gpu_device_type() == "DML":
+      self.skipTest('Test skipped on DML because UnsortedSegmentSum kernel is not implemented')
+
     # See b/123587692 for more context.
     vocab_size = 20
     embedding_dim = 10

--- a/tensorflow/python/keras/layers/lstm_v2_test.py
+++ b/tensorflow/python/keras/layers/lstm_v2_test.py
@@ -56,6 +56,11 @@ _rewrites.min_graph_nodes = -1
 _graph_options = config_pb2.GraphOptions(rewrite_options=_rewrites)
 _config = config_pb2.ConfigProto(graph_options=_graph_options)
 
+# DML doesn't implement every operator that used in these tests (e.g.
+# 'Qr'), so we need fallback to CPU kernels for unsupported ops to pass 
+# the _v1_session test case.
+if test_util.IsBuiltWithDML():
+  _config = None
 
 @keras_parameterized.run_all_keras_modes(config=_config)
 class LSTMV2Test(keras_parameterized.TestCase):

--- a/tensorflow/python/keras/layers/lstm_v2_test.py
+++ b/tensorflow/python/keras/layers/lstm_v2_test.py
@@ -694,6 +694,11 @@ class LSTMV2Test(keras_parameterized.TestCase):
     self.assertAllClose(out8, out7, atol=1e-5)
 
   def test_stateful_LSTM_training(self):
+    # DML doesn't implement 'UnsortedSegmentSum', which will trigger colocation issues when
+    # running this test in an eager context.
+    if context.executing_eagerly() and test_util.gpu_device_type() == "DML":
+      self.skipTest('Test skipped on DML because UnsortedSegmentSum kernel is not implemented')
+
     # See b/123587692 for more context.
     vocab_size = 20
     embedding_dim = 10

--- a/tensorflow/python/keras/layers/lstm_v2_test.py
+++ b/tensorflow/python/keras/layers/lstm_v2_test.py
@@ -540,23 +540,32 @@ class LSTMV2Test(keras_parameterized.TestCase):
       weights = cpu_model.get_weights()
     y_1 = cpu_model.predict(x_train)
 
-    with test_util.device(use_gpu=True):
+    # Note that CuDNN uses 'sigmoid' as activation, so the LSTM V2 uses
+    # 'sigmoid' as default. Construct the canonical LSTM with sigmoid to achieve
+    # the same output.
+    def run_y2y3():
       layer = rnn.LSTM(rnn_state_size)
       output = layer(inputs)
       gpu_model = keras.models.Model(inputs, output)
       gpu_model.set_weights(weights)
-    y_2 = gpu_model.predict(x_train)
+      y_2 = gpu_model.predict(x_train)
 
-    # Note that CuDNN uses 'sigmoid' as activation, so the LSTM V2 uses
-    # 'sigmoid' as default. Construct the canonical LSTM with sigmoid to achieve
-    # the same output.
-    with test_util.device(use_gpu=True):
       layer = rnn_v1.LSTM(rnn_state_size, recurrent_activation='sigmoid')
       output = layer(inputs)
       canonical_model = keras.models.Model(inputs, output)
       # Remove the extra cudnn bias since canonical lstm will not use it.
       canonical_model.set_weights(weights[:3])
-    y_3 = canonical_model.predict(x_train)
+      y_3 = canonical_model.predict(x_train)
+
+      return y_2, y_3
+
+    # DML doesn't implement UnsortedSegmentSum, so allow default device placement (i.e.
+    # prefer DML but fallback to CPU when necessary).
+    if test_util.gpu_device_type() == "DML":
+      y_2, y_3 = run_y2y3()
+    else:
+      with test_util.device(use_gpu=True):
+        y_2, y_3 = run_y2y3()
 
     self.assertAllClose(y_1, y_2)
     self.assertAllClose(y_2, y_3)
@@ -724,6 +733,11 @@ class LSTMV2Test(keras_parameterized.TestCase):
         input_shape=(num_samples, timesteps, embedding_dim))
 
   def test_bidirectional(self):
+    # DML doesn't implement 'UnsortedSegmentSum', which will trigger colocation issues when
+    # running this test in an eager context.
+    if context.executing_eagerly() and test_util.gpu_device_type() == "DML":
+      self.skipTest('Test skipped on DML because UnsortedSegmentSum kernel is not implemented')
+
     batch = 128
     timestep = 20
     vocab_size = 1000

--- a/tensorflow/python/keras/layers/lstm_v2_test.py
+++ b/tensorflow/python/keras/layers/lstm_v2_test.py
@@ -540,26 +540,24 @@ class LSTMV2Test(keras_parameterized.TestCase):
       weights = cpu_model.get_weights()
     y_1 = cpu_model.predict(x_train)
 
-    # Note that CuDNN uses 'sigmoid' as activation, so the LSTM V2 uses
-    # 'sigmoid' as default. Construct the canonical LSTM with sigmoid to achieve
-    # the same output.
     def run_y2y3():
       layer = rnn.LSTM(rnn_state_size)
       output = layer(inputs)
       gpu_model = keras.models.Model(inputs, output)
       gpu_model.set_weights(weights)
       y_2 = gpu_model.predict(x_train)
-
+      # Note that CuDNN uses 'sigmoid' as activation, so the LSTM V2 uses
+      # 'sigmoid' as default. Construct the canonical LSTM with sigmoid to achieve
+      # the same output.
       layer = rnn_v1.LSTM(rnn_state_size, recurrent_activation='sigmoid')
       output = layer(inputs)
       canonical_model = keras.models.Model(inputs, output)
       # Remove the extra cudnn bias since canonical lstm will not use it.
       canonical_model.set_weights(weights[:3])
       y_3 = canonical_model.predict(x_train)
-
       return y_2, y_3
 
-    # DML doesn't implement UnsortedSegmentSum, so allow default device placement (i.e.
+    # DML doesn't implement 'Qr', so allow default device placement (i.e.
     # prefer DML but fallback to CPU when necessary).
     if test_util.gpu_device_type() == "DML":
       y_2, y_3 = run_y2y3()

--- a/tensorflow/python/keras/layers/simplernn_test.py
+++ b/tensorflow/python/keras/layers/simplernn_test.py
@@ -43,6 +43,8 @@ class SimpleRNNLayerTest(keras_parameterized.TestCase):
         input_shape=(num_samples, timesteps, embedding_dim))
 
   def test_float64_SimpleRNN(self):
+    if test.is_built_with_rocm:
+      self.skipTest("Double type is yet not supported in DML")
     num_samples = 2
     timesteps = 3
     embedding_dim = 4

--- a/tensorflow/python/keras/layers/simplernn_test.py
+++ b/tensorflow/python/keras/layers/simplernn_test.py
@@ -43,7 +43,7 @@ class SimpleRNNLayerTest(keras_parameterized.TestCase):
         input_shape=(num_samples, timesteps, embedding_dim))
 
   def test_float64_SimpleRNN(self):
-    if test.is_built_with_rocm:
+    if test.is_built_with_dml():
       self.skipTest("Double type is yet not supported in DML")
     num_samples = 2
     timesteps = 3


### PR DESCRIPTION
Fixes some test methods in the LSTM/GRU/RNN test classes. These failures fall into three buckets:
1. UnsortedSegmentSum kernel isn't implemented in DML, so Keras' eager execution modes will hit colocation issues when placing random initializer on DML device. We don't want to unregister the random generator op obviously, so for now we skip these tests when run eagerly; they'll still be run in V1 session mode.
2. Qr kernel isn't implemented in DML and Keras' V1 session mode tests will try to force *all* ops on the same device. Fix is to allow fallback to CPU in these tests.
3. Some float64 tests are disabled because DML largely doesn't support float64.