### PR TITLE
Run a few more reduction tests

### DIFF
--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1378,8 +1378,8 @@ class MeanTensorTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def test_unweighted(self):
-    # DML doesn't support double
-    if test_util.IsBuiltWithDML():
+    # DML doesn't support float64
+    if test_util.gpu_device_type() == 'DML':
       dtype = dtypes.float32
     else:
       dtype = dtypes.float64
@@ -1404,8 +1404,8 @@ class MeanTensorTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def test_weighted(self):
-    # DML doesn't support double
-    if test_util.IsBuiltWithDML():
+    # DML doesn't support float64
+    if test_util.gpu_device_type() == 'DML':
       dtype = dtypes.float32
     else:
       dtype = dtypes.float64
@@ -1461,7 +1461,14 @@ class MeanTensorTest(test.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def test_build_in_tf_function(self):
     """Ensure that variables are created correctly in a tf function."""
-    m = metrics.MeanTensor(dtype=dtypes.float64)
+
+    # DML doesn't support float64
+    if test_util.gpu_device_type() == 'DML':
+      dtype = dtypes.float32
+    else:
+      dtype = dtypes.float64
+
+    m = metrics.MeanTensor(dtype=dtype)
 
     @eager_function.defun
     def call_metric(x):

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1378,7 +1378,12 @@ class MeanTensorTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def test_unweighted(self):
-    m = metrics.MeanTensor(dtype=dtypes.float64)
+    # DML doesn't support double
+    if test_util.IsBuiltWithDML():
+      dtype = dtypes.float32
+    else:
+      dtype = dtypes.float64
+    m = metrics.MeanTensor(dtype=dtype)
 
     # check __call__()
     self.assertAllClose(self.evaluate(m([100, 40])), [100, 40])
@@ -1399,8 +1404,13 @@ class MeanTensorTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def test_weighted(self):
-    m = metrics.MeanTensor(dtype=dtypes.float64)
-    self.assertEqual(m.dtype, dtypes.float64)
+    # DML doesn't support double
+    if test_util.IsBuiltWithDML():
+      dtype = dtypes.float32
+    else:
+      dtype = dtypes.float64
+    m = metrics.MeanTensor(dtype=dtype)
+    self.assertEqual(m.dtype, dtype)
 
     # check scalar weight
     result_t = m([100, 30], sample_weight=0.5)
@@ -1428,7 +1438,7 @@ class MeanTensorTest(test.TestCase):
     self.assertAllClose(self.evaluate(m.count), [3, 1.4])
 
     # check weights expand
-    m = metrics.MeanTensor(dtype=dtypes.float64)
+    m = metrics.MeanTensor(dtype=dtype)
     self.evaluate(variables.variables_initializer(m.variables))
     result_t = m([[1], [5]], sample_weight=[1, 0.2])
     self.assertAllClose(self.evaluate(result_t), [[1], [5]])

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -75,8 +75,14 @@ class KerasSumTest(test.TestCase):
     self.assertEqual(self.evaluate(m.total), 0)
 
   def test_sum_with_sample_weight(self):
-    m = metrics.Sum(dtype=dtypes.float64)
-    self.assertEqual(m.dtype, dtypes.float64)
+    # DML doesn't support float64
+    if test_util.gpu_device_type() == 'DML':
+      dtype = dtypes.float32
+    else:
+      dtype = dtypes.float64
+
+    m = metrics.Sum(dtype=dtype)
+    self.assertEqual(m.dtype, dtype)
     self.evaluate(variables.variables_initializer(m.variables))
 
     # check scalar weight

--- a/tensorflow/python/kernel_tests/reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/reduction_ops_test.py
@@ -694,6 +694,7 @@ class MinReductionTest(test.TestCase):
         tf_v = self.evaluate(v)
       self.assertAllEqual(tf_v, 0)
 
+  @test_util.skip_dml # Re-enable after DML is upgraded to 1.7 #33412454
   @test_util.run_deprecated_v1
   def testInfinity(self):
     for dtype in [np.float32, np.float64]:
@@ -813,6 +814,7 @@ class MaxReductionTest(test.TestCase):
         tf_v = self.evaluate(v)
       self.assertAllEqual(tf_v, 0)
 
+  @test_util.skip_dml # Re-enable after DML is upgraded to 1.7 #33412454
   @test_util.run_deprecated_v1
   def testInfinity(self):
     for dtype in [np.float32, np.float64]:


### PR DESCRIPTION
A few of these were hitting colocation issues because of float64 use. Also temporarily disabling the infinity tests until DML 1.7 is added.