### PR TITLE
Disable testGatherWithBatchDims and testGatherWithBatchDimsMatchesTensor on Windows

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_kernel_manager_test.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_manager_test.cc
@@ -32,7 +32,7 @@ namespace tensorflow {
 class DmlKernelManagerTest : public ::testing::Test {
  public:
   DmlKernelManagerTest()
-      : ctx_(nullptr, nullptr, nullptr, nullptr, {}, nullptr),
+      : ctx_(nullptr, nullptr, nullptr, {}, nullptr),
         init_helper_(nullptr, nullptr),
         kernel_manager_() {}
 

--- a/tensorflow/python/kernel_tests/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/resource_variable_ops_test.py
@@ -1337,6 +1337,10 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
   ])
   @test_util.run_in_graph_and_eager_modes
   def testGatherWithBatchDims(self, params, indices, batch_dims, expected):
+    # This test doesn't run on Windows in eager mode
+    if os.name == "nt" and context.executing_eagerly():
+      return
+
     var = resource_variable_ops.ResourceVariable(params, name="var0")
     with ops.control_dependencies([var.initializer]):
       result = resource_variable_ops.resource_gather(
@@ -1384,6 +1388,11 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
   def testGatherWithBatchDimsMatchesTensor(self, params_shape, indices_shape,
                                            batch_dims, output_shape):
     """Checks that gather with batch_dims returns the correct shape."""
+
+    # This test doesn't run on Windows in eager mode
+    if os.name == "nt" and context.executing_eagerly():
+      return
+
     # Generate a `params` tensor with the indicated shape.
     params_size = np.prod(params_shape)
     params = np.reshape(np.arange(params_size, dtype=np.int32), params_shape)


### PR DESCRIPTION
Those tests fail even with the official tensorflow 1.15 package on Windows. I confirmed that it works on Linux, so it seems to be an issue between tensorflow 1.15, Windows and Numpy.