### PR TITLE
Disable a float64 gru test and add a new float32 gru test

### DIFF
--- a/tensorflow/python/keras/layers/gru_test.py
+++ b/tensorflow/python/keras/layers/gru_test.py
@@ -43,6 +43,21 @@ class GRULayerTest(keras_parameterized.TestCase):
                 'return_sequences': True},
         input_shape=(num_samples, timesteps, embedding_dim))
 
+  def test_float32_GRU(self):
+    num_samples = 2
+    timesteps = 3
+    embedding_dim = 4
+    units = 2
+    testing_utils.layer_test(
+        keras.layers.GRU,
+        kwargs={'units': units,
+                'return_sequences': True,
+                'dtype': 'float32'},
+        input_shape=(num_samples, timesteps, embedding_dim),
+        input_dtype='float32')
+
+  # DML doesn't support float64
+  @tf_test_util.skip_dml
   def test_float64_GRU(self):
     num_samples = 2
     timesteps = 3


### PR DESCRIPTION
Since we don't have extensive RNN operator coverage, I added a new float32 GRU test to compensate for the float64 one that we have to disable.