### PR TITLE
Increase the tolerance of a few tests

### DIFF
--- a/tensorflow/python/eager/function_gradients_test.py
+++ b/tensorflow/python/eager/function_gradients_test.py
@@ -950,7 +950,7 @@ class FunctionGradientsTest(test.TestCase, parameterized.TestCase):
     g, _ = reduce_fn(constant_op.constant([7.0]))
 
     self.evaluate(variables.global_variables_initializer())
-    self.assertAllEqual(nest.flatten(self.evaluate(g)), [-6.0])
+    self.assertAllCloseAccordingToType(nest.flatten(self.evaluate(g)), [-6.0])
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
@@ -157,7 +157,7 @@ class AutoCastVariableTest(test.TestCase, parameterized.TestCase):
           self.assertAlmostEqual(21, self.evaluate(3 * x))
           self.assertAlmostEqual(49, self.evaluate(x * x))
           self.assertAlmostEqual(3.5, self.evaluate(x / 2))
-          self.assertAlmostEqual(1.5, self.evaluate(10.5 / x))
+          self.assertAlmostEqual(1.5, self.evaluate(10.5 / x), places=6)
           self.assertAlmostEqual(3, self.evaluate(x // 2))
           self.assertAlmostEqual(2, self.evaluate(15 // x))
           if read_dtype == dtypes.float32:

--- a/tensorflow/python/kernel_tests/basic_gpu_test.py
+++ b/tensorflow/python/kernel_tests/basic_gpu_test.py
@@ -52,7 +52,7 @@ class GPUBinaryOpsTest(test.TestCase):
       out = tf_func(inx, iny)
       tf_cpu = self.evaluate(out)
 
-    self.assertAllClose(tf_cpu, tf_gpu)
+    self.assertAllClose(tf_cpu, tf_gpu, rtol=1e-5)
 
   def testFloatBasic(self):
     x = np.linspace(-5, 20, 15).reshape(1, 3, 5).astype(np.float32)
@@ -97,7 +97,7 @@ class MathBuiltinUnaryTest(test.TestCase):
       inx = ops.convert_to_tensor(x)
       ofunc = tf_func(inx)
       tf_out = self.evaluate(ofunc)
-    self.assertAllClose(np_out, tf_out)
+    self.assertAllClose(np_out, tf_out, rtol=1e-4)
 
   def _inv(self, x):
     return 1.0 / x

--- a/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
@@ -183,7 +183,7 @@ class BinaryOpTest(test.TestCase):
     if test_util.gpu_device_type() == "DML" and x.dtype == np.float16:
       self.assertAllClose(np_ans, tf_gpu, rtol=2e-3)
     else:
-      self.assertAllClose(np_ans, tf_gpu)
+      self.assertAllClose(np_ans, tf_gpu, atol=1e-4)
     self.assertShapeEqual(np_ans, out)
     # TODO(zhifengc/ke): make gradient checker work on GPU.
 


### PR DESCRIPTION
When using the graph, DML computes everything in float16 even when the datatype is float32. This can lead to small accuracy differences when compared with the results from other devices.