### PR TITLE
Fix RandomUniform(Int) kernels when generating scalars

### DIFF
--- a/tensorflow/core/kernels/dml_random_ops.cc
+++ b/tensorflow/core/kernels/dml_random_ops.cc
@@ -464,6 +464,7 @@ class DmlRandomUniformKernel : public DmlKernel {
       Name("RandomUniform")               \
           .Device(DEVICE_DML)             \
           .HostMemory("shape")            \
+          .TypeConstraint<int32>("T")     \
           .TypeConstraint<type>("dtype"), \
       DmlPhiloxWrapper<DmlRandomUniformKernel, RandomUniformShapeHelper>);
 TF_CALL_DML_FLOAT_TYPES(DML_REGISTER_KERNEL);
@@ -476,6 +477,7 @@ TF_CALL_DML_FLOAT_TYPES(DML_REGISTER_KERNEL);
           .HostMemory("shape")           \
           .HostMemory("minval")          \
           .HostMemory("maxval")          \
+          .TypeConstraint<int32>("T")    \
           .TypeConstraint<type>("Tout"), \
       DmlPhiloxWrapper<DmlRandomUniformKernel, RandomUniformShapeHelper>);
 TF_CALL_int32(DML_REGISTER_KERNEL);

--- a/tensorflow/core/kernels/dml_random_ops.cc
+++ b/tensorflow/core/kernels/dml_random_ops.cc
@@ -350,6 +350,17 @@ class RandomUniformInitHelper : public InitializationHelper {
 
   const TensorShape& GetOutputShape() const { return output_shape_; }
 
+  bool IsNoOpKernel(
+      OpKernelContext* ctx,
+      absl::Span<const TensorShape> output_shapes) const override {
+    for (size_t i = 0; i < output_shapes.size(); ++i) {
+      if (output_shapes[i].num_elements() != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
  private:
   TensorShape output_shape_;
 };


### PR DESCRIPTION
DML incorrectly treated empty-shape tensors (scalars) as no-ops and filled the output with zero. This change also corrects the registrations to have a shape-data-type restriction that matches GPU kernels.