### PR TITLE
Increase tolerances for a few tests

### DIFF
--- a/tensorflow/python/keras/engine/base_layer_test.py
+++ b/tensorflow/python/keras/engine/base_layer_test.py
@@ -943,7 +943,10 @@ class AutographControlFlowTest(keras_parameterized.TestCase):
     train_loss = model.train_on_batch(np.ones((2, 3)), np.ones((2, 3)))
     self.assertEqual(train_loss, 0.)
     test_loss = model.test_on_batch(np.ones((2, 3)), np.ones((2, 3)))
-    self.assertEqual(test_loss, 1.)
+    if test.is_built_with_dml():
+      self.assertAlmostEqual(test_loss, 1., places=6)
+    else:
+      self.assertEqual(test_loss, 1.)
 
   def test_if_training_pattern_loss(self):
 

--- a/tensorflow/python/keras/engine/correctness_test.py
+++ b/tensorflow/python/keras/engine/correctness_test.py
@@ -137,7 +137,8 @@ class MultipleInputTest(keras_parameterized.TestCase):
 
     model = self._get_multiple_input_model(subclassed)
     loss = model.evaluate(x, y, batch_size=3)
-    self.assertAlmostEqual(loss, 2.)
+    places = 6 if test.is_built_with_dml() else None
+    self.assertAlmostEqual(loss, 2., places=places)
 
   @parameterized.named_parameters(('subclassed', True), ('functional', False))
   def test_multiple_input_predict(self, subclassed):

--- a/tensorflow/python/keras/layers/tensorflow_op_layer_test.py
+++ b/tensorflow/python/keras/layers/tensorflow_op_layer_test.py
@@ -284,13 +284,15 @@ class AutoLambdaTest(keras_parameterized.TestCase):
       grads = t.gradient(z, x)
       return grads
 
-    self.assertAllEqual(f(constant_op.constant(10.0, shape=(1, 1))),
-                        constant_op.constant(40.0, shape=(1, 1)))
+    assertFn = self.assertAllClose if test.is_built_with_dml() else self.assertAllEqual
+
+    assertFn(f(constant_op.constant(10.0, shape=(1, 1))),
+             constant_op.constant(40.0, shape=(1, 1)))
 
     f = def_function.function(f)
 
-    self.assertAllEqual(f(constant_op.constant(10.0, shape=(1, 1))),
-                        constant_op.constant(40.0, shape=(1, 1)))
+    assertFn(f(constant_op.constant(10.0, shape=(1, 1))),
+             constant_op.constant(40.0, shape=(1, 1)))
 
   def test_no_tracking(self):
     x = keras.backend.placeholder((10, 10))

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -292,7 +292,11 @@ class KerasMeanTest(keras_parameterized.TestCase):
     # restore to the same checkpoint mean object
     checkpoint.restore(save_path).assert_consumed().run_restore_ops()
     self.evaluate(m(300.))
-    self.assertEqual(200., self.evaluate(m.result()))
+
+    if test.is_built_with_dml():
+      self.assertAlmostEqual(200., self.evaluate(m.result()), delta=2e-5)
+    else:
+      self.assertEqual(200., self.evaluate(m.result()))
 
     # restore to a different checkpoint mean object
     restore_mean = metrics.Mean()
@@ -301,7 +305,11 @@ class KerasMeanTest(keras_parameterized.TestCase):
     restore_update = restore_mean(300.)
     status.assert_consumed().run_restore_ops()
     self.evaluate(restore_update)
-    self.assertEqual(200., self.evaluate(restore_mean.result()))
+
+    if test.is_built_with_dml():
+      self.assertAlmostEqual(200., self.evaluate(restore_mean.result()), delta=2e-5)
+    else:
+      self.assertEqual(200., self.evaluate(restore_mean.result()))
     self.assertEqual(3, self.evaluate(restore_mean.count))
 
   def test_multiple_instances(self):
@@ -494,7 +502,10 @@ class KerasAccuracyTest(test.TestCase):
     update_op = acc_obj.update_state(rt1, rt2)
     self.evaluate(update_op)
     result = self.evaluate(acc_obj.result())
-    self.assertEqual(result, 1)  # 2/2
+    if test.is_built_with_dml():
+      self.assertAlmostEqual(result, 1, places=6)  # 2/2
+    else:
+      self.assertEqual(result, 1)  # 2/2
 
     # check with sample_weight
     rt1 = ragged_factory_ops.constant([[0, 0, 1], [0, 1, 0]])

--- a/tensorflow/python/training/experimental/loss_scale_test.py
+++ b/tensorflow/python/training/experimental/loss_scale_test.py
@@ -154,7 +154,11 @@ class DynamicLossScaleTest(test.TestCase, parameterized.TestCase):
       else:
         self.evaluate(update_op)
       actual_outputs.append(self.evaluate(loss_scale()))
-    self.assertEqual(actual_outputs, expected_outputs)
+    if test.is_built_with_dml():
+      for i in range(len(inputs)):
+        self.assertAlmostEqual(actual_outputs[i], expected_outputs[i], delta=1e-6)
+    else:
+      self.assertEqual(actual_outputs, expected_outputs)
 
   @parameterized.named_parameters(*TESTCASES)
   @test_util.run_in_graph_and_eager_modes


### PR DESCRIPTION
Some DX adapters are slightly less precise when performing some calculations like divisions (e.g. 3/3 = 0.99999)