### PR TITLE
Disables caching of random kernels

### DIFF
--- a/tensorflow/core/kernels/dml_random_ops.cc
+++ b/tensorflow/core/kernels/dml_random_ops.cc
@@ -294,7 +294,7 @@ TF_CALL_int32(DML_REGISTER_KERNEL);
 // ----------------------------------------------------------------------------
 
 template <typename TKernel, typename TShapeHelper,
-          DmlKernelCachePolicy cache_policy = DmlKernelCachePolicy::Default>
+          DmlKernelCachePolicy cache_policy = DmlKernelCachePolicy::Never>
 class DmlPhiloxWrapper
     : public DmlKernelWrapper<TKernel, TShapeHelper, cache_policy> {
  public:


### PR DESCRIPTION
Repeated invocations of the same instance of a RandomUniformInt/RandomUniform kernel should produce different results, but two distinct instances should not be shared.