### PR TITLE
For identity reduce cases, forward input instead

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.h
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.h
@@ -58,10 +58,10 @@ class InitializationHelper {
     return false;
   }
 
-  virtual bool IsOutputForwardable(OpKernelContext* ctx,
-                                   absl::Span<const TensorShape> output_shapes,
-                                   int outputIndex, int& inputIndex) const {
-    return false;
+  virtual absl::optional<int> GetForwardableInputIndex(
+      OpKernelContext* ctx, absl::Span<const TensorShape> output_shapes,
+      int outputIndex) const {
+    return {};
   }
 
   virtual ~InitializationHelper() = default;

--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.h
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.h
@@ -58,9 +58,9 @@ class InitializationHelper {
     return false;
   }
 
-  virtual bool IsInputForwardable(OpKernelContext* ctx,
-                                  absl::Span<const TensorShape> output_shapes,
-                                  int& inputIndex) const {
+  virtual bool IsOutputForwardable(OpKernelContext* ctx,
+                                   absl::Span<const TensorShape> output_shapes,
+                                   int outputIndex, int& inputIndex) const {
     return false;
   }
 

--- a/tensorflow/core/common_runtime/dml/dml_operator_helper.h
+++ b/tensorflow/core/common_runtime/dml/dml_operator_helper.h
@@ -58,6 +58,12 @@ class InitializationHelper {
     return false;
   }
 
+  virtual bool IsInputForwardable(OpKernelContext* ctx,
+                                  absl::Span<const TensorShape> output_shapes,
+                                  int& inputIndex) const {
+    return false;
+  }
+
   virtual ~InitializationHelper() = default;
 };
 

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -103,6 +103,22 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
       return;
     }
 
+    int inputIndexToForward = -1;
+    if (shared_helper->IsInputForwardable(ctx, output_shapes,
+                                          inputIndexToForward)) {
+      // This should be set if true was returned
+      CHECK(inputIndexToForward != -1);
+      // We assume we are forwarding one input to one output for now.
+      CHECK(ctx->num_outputs() == 1);
+      constexpr int outputIndex = 0;
+      Tensor* output;
+      CHECK(ctx->forward_input_to_output_with_shape(
+          inputIndexToForward, outputIndex, output_shapes[outputIndex],
+          &output));
+
+      return;
+    }
+
     DmlKernelConstruction dml_construction(dml_device, ctx, node_def_.get(),
                                            output_shapes, shared_helper);
 

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -107,12 +107,12 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
     forwardIndices.reserve(ctx->num_outputs());
 
     for (int i = 0; i < ctx->num_outputs(); ++i) {
-      int inputIndexToForward = -1;
+      absl::optional<int> inputIndexToForward =
+          shared_helper->GetForwardableInputIndex(ctx, output_shapes, i);
       // If the input is considered forwardable for the op, and the shapes match
-      if (shared_helper->IsOutputForwardable(ctx, output_shapes, i, inputIndexToForward)) {
-        // This should be set if true was returned
-        CHECK(inputIndexToForward != -1);
-        forwardIndices.emplace_back(std::make_pair(inputIndexToForward, i));
+      if (inputIndexToForward) {
+        forwardIndices.emplace_back(
+            std::make_pair(inputIndexToForward.value(), i));
       } else {
         // If not all outputs are forwardable, we will forward nothing and
         // proceed with the kernel normally.

--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -282,6 +282,47 @@ class DmlReduceKernel : public DmlKernel {
       return;
     }
 
+    // This logic copied from the CPU implementation:
+    // tensorflow/core/kernels/reduction_ops_common.h(155)
+    bool is_identity =
+        !is_arg_function_ &&
+        (reduce_helper.ndims() == 0 ||
+         (reduce_helper.ndims() == 1 && !reduce_helper.reduce_first_axis()));
+
+    if (is_identity) {
+      // Since the reduce helper may have removed dimensions of size 1, we can't
+      // just take its shape as-is. We know that this is an identity scenario,
+      // so we can just collapse all dimensions into one and use the same tensor
+      // desc for both the input and the output.
+      TensorShape in_out_shape(
+          {1, 1, 1, ctx->GetInputTensorShape(0).num_elements()});
+
+      DmlTensorInfo in_out_tensor;
+      in_out_tensor.kernel_index = 0;
+      in_out_tensor.desc = DmlTensorDesc::Create(ctx->GetInputDataType(0),
+                                                 in_out_shape, in_out_shape);
+
+      DmlKernelTensors tensors;
+      tensors.inputs = {in_out_tensor};
+      tensors.outputs = {in_out_tensor};
+
+      auto input_descs = GetDmlTensorDescs(tensors.inputs);
+      auto scope = dml::Graph(ctx->GetDmlDevice(), out_policy);
+      auto result = dml::Identity(dml::InputTensor(scope, 0, input_descs[0]));
+
+      // TFDML #24881131
+      if (Is64BitSignedIntegerType(ctx->GetOutputDataType(0))) {
+        result = dml::ConvertInt32ToInt64(scope, result);
+      }
+
+      Microsoft::WRL::ComPtr<IDMLCompiledOperator> compiled_op =
+          scope.Compile(DML_EXECUTION_FLAG_NONE, {result});
+
+      Initialize(ctx, std::move(tensors), compiled_op.Get());
+
+      return;
+    }
+
     // Unlike other reduction operators, the behavior for arg functions when
     // there are no axes to reduce is to output 0's everywhere
     is_no_op_ =


### PR DESCRIPTION
This adds an extra step before kernel creation to check if an operation is a trivial identity. if so, the input can be forwarded to the output instead of performing a copy.

I'm sure there are more places where this could be used but for now it assumes 1 input will be forwarded to 1 output.