### PR TITLE
Fix data format ops logic and validation

### DIFF
--- a/tensorflow/core/kernels/data_format_ops.cc
+++ b/tensorflow/core/kernels/data_format_ops.cc
@@ -21,11 +21,11 @@ limitations under the License.
 
 #include <map>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/errors.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -144,17 +144,27 @@ class DataFormatVecPermuteOp : public OpKernel {
                 errors::InvalidArgument(
                     "input must be a vector or 2D tensor, but got shape ",
                     input.shape().DebugString()));
+
+    const int full_dim_count = src_format_.size();
+    const int spatial_dim_count = full_dim_count - 2;
+
     if (input.dims() == 1) {
-      OP_REQUIRES(
-          context, input.NumElements() == 4,
-          errors::InvalidArgument("1D input must be of size 4, but got shape ",
-                                  input.shape().DebugString()));
+      OP_REQUIRES(context,
+                  input.NumElements() == spatial_dim_count ||
+                      input.NumElements() == full_dim_count,
+                  errors::InvalidArgument("1D input must be of size ",
+                                          spatial_dim_count, " or ",
+                                          full_dim_count, ", but got shape ",
+                                          input.shape().DebugString()));
     } else if (input.dims() == 2) {
-      OP_REQUIRES(
-          context, input.dim_size(0) == 4,
-          errors::InvalidArgument(
-              "First dimension of 2D input must be of size 4, but got shape ",
-              input.shape().DebugString()));
+      OP_REQUIRES(context,
+                  input.dim_size(0) == spatial_dim_count ||
+                      input.dim_size(0) == full_dim_count,
+                  errors::InvalidArgument("First dimension of 2D input must be "
+                                          "of size ",
+                                          spatial_dim_count, " or ",
+                                          full_dim_count, ", but got shape ",
+                                          input.shape().DebugString()));
       OP_REQUIRES(
           context, input.dim_size(1) == 2,
           errors::InvalidArgument(
@@ -169,21 +179,34 @@ class DataFormatVecPermuteOp : public OpKernel {
     Eigen::DSizes<Eigen::DenseIndex, 8> dst_idx;
     string src_format_str = src_format_;
     string dst_format_str = dst_format_;
-    if (input.dim_size(0) == 2) {
+    if (input.dim_size(0) == spatial_dim_count) {
       // If the input is a vector of size 2, treat the two elements as spatial
       // dimensions.
-      auto keep_only_spatial_dimensions = [](string* format_str) -> void {
-        auto new_end = std::remove_if(
-            format_str->begin(), format_str->end(),
-            [](const char dim) { return dim != 'H' && dim != 'W'; });
+      auto keep_only_spatial_dimensions =
+          [spatial_dim_count](string* format_str) -> void {
+        auto new_end =
+            std::remove_if(format_str->begin(), format_str->end(),
+                           [spatial_dim_count](const char dim) {
+                             return dim != 'H' && dim != 'W' &&
+                                    (spatial_dim_count == 2 || dim != 'D');
+                           });
         format_str->erase(new_end, format_str->end());
       };
       keep_only_spatial_dimensions(&src_format_str);
       keep_only_spatial_dimensions(&dst_format_str);
-      OP_REQUIRES(context,
-                  src_format_str.size() == 2 && dst_format_str.size() == 2,
-                  errors::InvalidArgument(
-                      "Format specifier must contain H and W for 2D case"));
+
+      if (spatial_dim_count == 3) {
+        OP_REQUIRES(
+            context, src_format_str.size() == 3 && dst_format_str.size() == 3,
+            errors::InvalidArgument(
+                "Format specifier must contain D, H and W for 2D case"));
+      } else {
+        DCHECK(spatial_dim_count == 2);
+        OP_REQUIRES(context,
+                    src_format_str.size() == 2 && dst_format_str.size() == 2,
+                    errors::InvalidArgument(
+                        "Format specifier must contain H and W for 2D case"));
+      }
     }
     ComputeDstIndex(input.dims(), &dst_idx);
 

--- a/tensorflow/core/kernels/data_format_ops.cc
+++ b/tensorflow/core/kernels/data_format_ops.cc
@@ -176,7 +176,7 @@ class DataFormatVecPermuteOp : public OpKernel {
     OP_REQUIRES_OK(context,
                    context->allocate_output(0, input.shape(), &output));
     // Support 1D and 2D cases.
-    Eigen::DSizes<Eigen::DenseIndex, 8> dst_idx;
+    Eigen::DSizes<Eigen::DenseIndex, 10> dst_idx;
     string src_format_str = src_format_;
     string dst_format_str = dst_format_;
     if (input.dim_size(0) == spatial_dim_count) {
@@ -220,7 +220,7 @@ class DataFormatVecPermuteOp : public OpKernel {
   // Example: HWNC --> NHWC
   // 1D: dst = [1, 2, 0, 3],
   // 2D: dst = [2, 3, 4, 5, 0, 1, 6, 7]
-  void ComputeDstIndex(int num_dim, Eigen::DSizes<Eigen::DenseIndex, 8>* dst) {
+  void ComputeDstIndex(int num_dim, Eigen::DSizes<Eigen::DenseIndex, 10>* dst) {
     for (int i = 0; i < src_format_.size(); ++i) {
       for (int j = 0; j < dst_format_.size(); ++j) {
         if (dst_format_[j] != src_format_[i]) continue;
@@ -286,12 +286,12 @@ TF_CALL_int32(DECLARE_GPU_SPECS);
 TF_CALL_int64(DECLARE_GPU_SPECS);
 #undef DECLARE_GPU_SPEC
 
-#define DECLARE_GPU_SPEC(T)                                \
-  template <>                                              \
-  void DataFormatVecPermute<GPUDevice, T>::operator()(     \
-      const GPUDevice& d, typename TTypes<T>::ConstFlat x, \
-      typename TTypes<T>::Vec y,                           \
-      const Eigen::DSizes<Eigen::DenseIndex, 8>& dst_idx); \
+#define DECLARE_GPU_SPEC(T)                                 \
+  template <>                                               \
+  void DataFormatVecPermute<GPUDevice, T>::operator()(      \
+      const GPUDevice& d, typename TTypes<T>::ConstFlat x,  \
+      typename TTypes<T>::Vec y,                            \
+      const Eigen::DSizes<Eigen::DenseIndex, 10>& dst_idx); \
   extern template struct DataFormatVecPermute<GPUDevice, T>;
 #define DECLARE_GPU_SPECS(T) DECLARE_GPU_SPEC(T);
 TF_CALL_int32(DECLARE_GPU_SPECS);

--- a/tensorflow/core/kernels/data_format_ops.h
+++ b/tensorflow/core/kernels/data_format_ops.h
@@ -28,24 +28,50 @@ template <typename Device, typename T>
 struct DataFormatDimMap {
   void operator()(const Device& d, typename TTypes<T>::ConstFlat x,
                   typename TTypes<T>::Flat y, const TTypes<int>::Vec dst) {
-    auto zero = x.constant(0);
-    auto one = x.constant(1);
-    auto two = x.constant(2);
+    if (dst.size() == 4) {
+      auto zero = x.constant(0);
+      auto one = x.constant(1);
+      auto two = x.constant(2);
 
-    auto f_zero = x.constant(dst(0));
-    auto f_one = x.constant(dst(1));
-    auto f_two = x.constant(dst(2));
-    auto f_three = x.constant(dst(3));
+      auto f_zero = x.constant(dst(0));
+      auto f_one = x.constant(dst(1));
+      auto f_two = x.constant(dst(2));
+      auto f_three = x.constant(dst(3));
 
-    auto four = x.constant(4);
-    auto x_mod = (x + four) % 4;
+      auto four = x.constant(4);
+      auto x_mod = (x + four) % 4;
 
-    auto is_zero = (x_mod == zero);
-    auto is_one = (x_mod == one);
-    auto is_two = (x_mod == two);
+      auto is_zero = (x_mod == zero);
+      auto is_one = (x_mod == one);
+      auto is_two = (x_mod == two);
 
-    y.device(d) = is_zero.select(
-        f_zero, is_one.select(f_one, is_two.select(f_two, f_three)));
+      y.device(d) = is_zero.select(
+          f_zero, is_one.select(f_one, is_two.select(f_two, f_three)));
+    } else {
+      auto zero = x.constant(0);
+      auto one = x.constant(1);
+      auto two = x.constant(2);
+      auto three = x.constant(3);
+
+      auto f_zero = x.constant(dst(0));
+      auto f_one = x.constant(dst(1));
+      auto f_two = x.constant(dst(2));
+      auto f_three = x.constant(dst(3));
+      auto f_four = x.constant(dst(4));
+
+      auto five = x.constant(5);
+      auto x_mod = (x + five) % 5;
+
+      auto is_zero = (x_mod == zero);
+      auto is_one = (x_mod == one);
+      auto is_two = (x_mod == two);
+      auto is_three = (x_mod == three);
+
+      y.device(d) = is_zero.select(
+          f_zero,
+          is_one.select(
+              f_one, is_two.select(f_two, is_three.select(f_three, f_four))));
+    }
   }
 };
 

--- a/tensorflow/core/kernels/data_format_ops.h
+++ b/tensorflow/core/kernels/data_format_ops.h
@@ -77,7 +77,7 @@ struct DataFormatDimMap {
 
 template <typename T>
 struct VecPermute {
-  VecPermute(const Eigen::DSizes<Eigen::DenseIndex, 8>& dst) : dst_(dst) {}
+  VecPermute(const Eigen::DSizes<Eigen::DenseIndex, 10>& dst) : dst_(dst) {}
   Eigen::DSizes<Eigen::DenseIndex, 1> dimensions(
       typename TTypes<T>::ConstFlat input) const {
     Eigen::DSizes<Eigen::DenseIndex, 1> result;
@@ -93,7 +93,7 @@ struct VecPermute {
   }
 
  private:
-  Eigen::DSizes<Eigen::DenseIndex, 8> dst_;
+  Eigen::DSizes<Eigen::DenseIndex, 10> dst_;
 };
 
 // Functor used by DataFormatVecPermuteOp to do the computations.
@@ -101,7 +101,7 @@ template <typename Device, typename T>
 struct DataFormatVecPermute {
   void operator()(const Device& d, typename TTypes<T>::ConstFlat x,
                   typename TTypes<T>::Flat y,
-                  const Eigen::DSizes<Eigen::DenseIndex, 8>& dst) {
+                  const Eigen::DSizes<Eigen::DenseIndex, 10>& dst) {
     y.device(d) = x.customOp(VecPermute<T>(dst));
   }
 };

--- a/tensorflow/core/kernels/dml_data_format_vec_permute.cc
+++ b/tensorflow/core/kernels/dml_data_format_vec_permute.cc
@@ -31,22 +31,24 @@ static bool IsValidPermutation(const std::string& src, const std::string& dst) {
     return false;
   }
 
-  std::map<char, bool> characters;
+  std::array<bool, 256> characters{};
 
   // Every character in `src` must be present only once
   for (const auto c : src) {
-    if (characters[c]) {
+    const uint8_t char_index = static_cast<uint8_t>(c);
+    if (characters[char_index]) {
       return false;
     }
-    characters[c] = true;
+    characters[char_index] = true;
   }
 
   // Every character in `dst` must show up in `src` exactly once
   for (const auto c : dst) {
-    if (!characters[c]) {
+    const uint8_t char_index = static_cast<uint8_t>(c);
+    if (!characters[char_index]) {
       return false;
     }
-    characters[c] = false;
+    characters[char_index] = false;
   }
 
   // At this point, characters[] has been switched to true and false exactly

--- a/tensorflow/core/kernels/dml_data_format_vec_permute.cc
+++ b/tensorflow/core/kernels/dml_data_format_vec_permute.cc
@@ -22,30 +22,63 @@ limitations under the License.
 
 namespace tensorflow {
 
+// Ensure that `src` and `dst` define a valid permutation.
+// Ops defined in this file assume that user specifies a permutation via two
+// string attributes. This check validates that these attributes properly define
+// it to prevent security vulnerabilities.
+static bool IsValidPermutation(const std::string& src, const std::string& dst) {
+  if (src.size() != dst.size()) {
+    return false;
+  }
+
+  std::map<char, bool> characters;
+
+  // Every character in `src` must be present only once
+  for (const auto c : src) {
+    if (characters[c]) {
+      return false;
+    }
+    characters[c] = true;
+  }
+
+  // Every character in `dst` must show up in `src` exactly once
+  for (const auto c : dst) {
+    if (!characters[c]) {
+      return false;
+    }
+    characters[c] = false;
+  }
+
+  // At this point, characters[] has been switched to true and false exactly
+  // once for all character in `src` (and `dst`) so we have a valid permutation
+  return true;
+}
+
 class DmlDataFormatVecPermuteKernel : public OpKernel {
  public:
   explicit DmlDataFormatVecPermuteKernel(OpKernelConstruction* ctx)
       : OpKernel(ctx) {
     std::string src_format;
-    std::string dst_format;
-
     OP_REQUIRES_OK(ctx, ctx->GetAttr("src_format", &src_format));
+    OP_REQUIRES(ctx, src_format.size() == 4 || src_format.size() == 5,
+                errors::InvalidArgument(
+                    "Source format must be of length 4 or 5, received "
+                    "src_format = ",
+                    src_format));
+    std::string dst_format;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("dst_format", &dst_format));
+    OP_REQUIRES(ctx, dst_format.size() == 4 || dst_format.size() == 5,
+                errors::InvalidArgument("Destination format must be of length "
+                                        "4 or 5, received dst_format = ",
+                                        dst_format));
+    OP_REQUIRES(
+        ctx, IsValidPermutation(src_format, dst_format),
+        errors::InvalidArgument(
+            "Destination and source format must determine a permutation, got ",
+            src_format, " and ", dst_format));
 
-    // The CPU and CUDA implementions don't check the size of src_format or
-    // dst_format and just leave garbage data for the dimensions that are not
-    // included. We do the same thing here.
-    size_t src_format_length = std::min<size_t>(src_format.length(), 4u);
-    size_t dst_format_length = std::min<size_t>(dst_format.length(), 4u);
-
-    for (size_t dst_index = 0; dst_index < dst_format_length; ++dst_index) {
-      for (size_t src_index = 0; src_index < src_format_length; ++src_index) {
-        if (dst_format[dst_index] == src_format[src_index]) {
-          permutations_.push_back(src_index);
-          break;
-        }
-      }
-    }
+    src_format_ = src_format;
+    dst_format_ = dst_format;
   }
 
   void Compute(OpKernelContext* ctx) override {
@@ -57,22 +90,73 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
                     "input must be a vector or 2D tensor, but got shape ",
                     input_shape.DebugString()));
 
+    const int full_dim_count = src_format_.size();
+    const int spatial_dim_count = full_dim_count - 2;
+
     if (input_shape.dims() == 1) {
-      OP_REQUIRES(
-          ctx, input_shape.dim_size(0) == 4,
-          errors::InvalidArgument("1D input must be of size 4, but got shape ",
-                                  input_shape.DebugString()));
+      OP_REQUIRES(ctx,
+                  input.NumElements() == spatial_dim_count ||
+                      input.NumElements() == full_dim_count,
+                  errors::InvalidArgument("1D input must be of size ",
+                                          spatial_dim_count, " or ",
+                                          full_dim_count, ", but got shape ",
+                                          input.shape().DebugString()));
     } else if (input_shape.dims() == 2) {
-      OP_REQUIRES(
-          ctx, input_shape.dim_size(0) == 4,
-          errors::InvalidArgument(
-              "First dimension of 2D input must be of size 4, but got shape ",
-              input_shape.DebugString()));
+      OP_REQUIRES(ctx,
+                  input.dim_size(0) == spatial_dim_count ||
+                      input.dim_size(0) == full_dim_count,
+                  errors::InvalidArgument("First dimension of 2D input must be "
+                                          "of size ",
+                                          spatial_dim_count, " or ",
+                                          full_dim_count, ", but got shape ",
+                                          input.shape().DebugString()));
       OP_REQUIRES(
           ctx, input_shape.dim_size(1) == 2,
           errors::InvalidArgument(
               "Second dimension of 2D input must be of size 2, but got shape ",
               input_shape.DebugString()));
+    }
+    std::string src_format = src_format_;
+    std::string dst_format = dst_format_;
+
+    if (input.dim_size(0) == spatial_dim_count) {
+      // If the input is a vector of size 2, treat the two elements as spatial
+      // dimensions.
+      auto keep_only_spatial_dimensions =
+          [spatial_dim_count](std::string* format_str) -> void {
+        auto new_end =
+            std::remove_if(format_str->begin(), format_str->end(),
+                           [spatial_dim_count](const char dim) {
+                             return dim != 'H' && dim != 'W' &&
+                                    (spatial_dim_count == 2 || dim != 'D');
+                           });
+        format_str->erase(new_end, format_str->end());
+      };
+      keep_only_spatial_dimensions(&src_format);
+      keep_only_spatial_dimensions(&dst_format);
+
+      if (spatial_dim_count == 3) {
+        OP_REQUIRES(
+            ctx, src_format.size() == 3 && dst_format.size() == 3,
+            errors::InvalidArgument(
+                "Format specifier must contain D, H and W for 2D case"));
+      } else {
+        DCHECK(spatial_dim_count == 2);
+        OP_REQUIRES(ctx, src_format.size() == 2 && dst_format.size() == 2,
+                    errors::InvalidArgument(
+                        "Format specifier must contain H and W for 2D case"));
+      }
+    }
+
+    absl::InlinedVector<uint32_t, 5> permutations;
+
+    for (size_t dst_index = 0; dst_index < dst_format.length(); ++dst_index) {
+      for (size_t src_index = 0; src_index < src_format.length(); ++src_index) {
+        if (dst_format[dst_index] == src_format[src_index]) {
+          permutations.push_back(src_index);
+          break;
+        }
+      }
     }
 
     Tensor* output = nullptr;
@@ -100,10 +184,10 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
 
     const int perm_stride = DataTypeSize(input.dtype()) * input_shape.dims();
 
-    for (uint32_t i = 0; i < permutations_.size(); ++i) {
+    for (uint32_t i = 0; i < permutations.size(); ++i) {
       uint64_t dst_offset = output_buffer.Offset() + i * perm_stride;
       uint64_t src_offset =
-          input_buffer.Offset() + permutations_[i] * perm_stride;
+          input_buffer.Offset() + permutations[i] * perm_stride;
 
       execution_context->CopyBufferRegion(
           output_buffer.Resource(), dst_offset, D3D12_RESOURCE_STATE_COPY_DEST,
@@ -119,7 +203,8 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
   }
 
  private:
-  absl::InlinedVector<uint32_t, 4> permutations_;
+  std::string src_format_;
+  std::string dst_format_;
 };
 
 #define REGISTER_KERNEL(type)                             \

--- a/tensorflow/core/kernels/dml_ops_common.h
+++ b/tensorflow/core/kernels/dml_ops_common.h
@@ -214,17 +214,6 @@ template <typename T>
 struct TfTensorTypeTraits;
 
 template <>
-struct TfTensorTypeTraits<float> {
-  static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_FLOAT32;
-  static float FromFloat(float val) { return val; }
-  static DML_SCALAR_UNION ToDmlScalar(float val) {
-    DML_SCALAR_UNION scalar;
-    scalar.Float32 = val;
-    return scalar;
-  }
-};
-
-template <>
 struct TfTensorTypeTraits<Eigen::half> {
   static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_FLOAT16;
   static Eigen::half FromFloat(float val) {
@@ -238,11 +227,22 @@ struct TfTensorTypeTraits<Eigen::half> {
 };
 
 template <>
-struct TfTensorTypeTraits<uint32_t> {
-  static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_UINT32;
-  static DML_SCALAR_UNION ToDmlScalar(uint32_t val) {
+struct TfTensorTypeTraits<float> {
+  static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_FLOAT32;
+  static float FromFloat(float val) { return val; }
+  static DML_SCALAR_UNION ToDmlScalar(float val) {
     DML_SCALAR_UNION scalar;
-    scalar.UInt32 = val;
+    scalar.Float32 = val;
+    return scalar;
+  }
+};
+
+template <>
+struct TfTensorTypeTraits<uint8_t> {
+  static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_UINT8;
+  static DML_SCALAR_UNION ToDmlScalar(uint8_t val) {
+    DML_SCALAR_UNION scalar;
+    scalar.UInt8 = val;
     return scalar;
   }
 };
@@ -258,11 +258,31 @@ struct TfTensorTypeTraits<uint16_t> {
 };
 
 template <>
+struct TfTensorTypeTraits<uint32_t> {
+  static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_UINT32;
+  static DML_SCALAR_UNION ToDmlScalar(uint32_t val) {
+    DML_SCALAR_UNION scalar;
+    scalar.UInt32 = val;
+    return scalar;
+  }
+};
+
+template <>
 struct TfTensorTypeTraits<int32_t> {
   static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_INT32;
   static DML_SCALAR_UNION ToDmlScalar(int32_t val) {
     DML_SCALAR_UNION scalar;
     scalar.Int32 = val;
+    return scalar;
+  }
+};
+
+template <>
+struct TfTensorTypeTraits<int64_t> {
+  static constexpr DML_TENSOR_DATA_TYPE dml_type = DML_TENSOR_DATA_TYPE_INT64;
+  static DML_SCALAR_UNION ToDmlScalar(int64_t val) {
+    DML_SCALAR_UNION scalar;
+    scalar.Int64 = val;
     return scalar;
   }
 };

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -4301,7 +4301,6 @@ cuda_py_test(
         "@absl_py//absl/testing:parameterized",
         "//third_party/py/numpy",
     ],
-    tags = ["no_windows"],
     xla_enable_strict_auto_jit = True,
 )
 

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import math
+import os
 
 from absl.testing import parameterized
 import numpy as np
@@ -1121,6 +1122,8 @@ class MomentsTest(test_lib.TestCase):
     self.doOutputTest((10, 10, 10, 30), (0, 1, 2))
 
   def testOutput4DInput123(self):
+    if os.name == "nt":
+      self.skipTest("This test doesn't work on Windows")
     self.doOutputTest((10, 10, 10, 30), (1, 2, 3))
 
 

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -43,6 +43,8 @@ import tensorflow.python.ops.nn_grad  # pylint: disable=unused-import
 from tensorflow.python.ops.nn_impl import _compute_sampled_logits
 from tensorflow.python.platform import test as test_lib
 
+import os
+input(os.getpid())
 
 class ZeroFractionTest(test_lib.TestCase):
 
@@ -1174,6 +1176,33 @@ class DataFormatDimMapTest(test_lib.TestCase):
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, y_val_expected)
 
+  def testNDHWCtoNCDHW(self):
+    x_val = [1, -4, -3, -2]
+    y_val_expected = [2, 2, 3, 4]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_dim_map(x, src_format="NDHWC", dst_format="NCDHW")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, y_val_expected)
+
+  def testNDHWCtoDHWNC(self):
+    x_val = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4]
+    y_val_expected = [3, 0, 1, 2, 4, 3, 0, 1, 2, 4]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_dim_map(x, src_format="NDHWC", dst_format="DHWNC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, y_val_expected)
+
+  def testDNHWCtoWHDCN(self):
+    x_val = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4]
+    y_val_expected = [4, 2, 1, 0, 3, 4, 2, 1, 0, 3]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_dim_map(x, src_format="NDHWC", dst_format="WHDCN")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, y_val_expected)
+
   def testArbitraryASCII(self):
     x_val = [-4, -3, -2, -1, 0, 1, 2, 3]
     y_val_expected = [3, 2, 1, 0, 3, 2, 1, 0]
@@ -1234,6 +1263,66 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [7, 3, 4, 9])
 
+  def testNHWCToNCHW_Size2(self):
+    x_val = [4, 9]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(x)
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [4, 9])
+
+  def testNDHWCtoNCDHW(self):
+    x_val = [7, 4, 9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="NCDHW")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [7, 5, 4, 9, 3])
+
+  def testNDHWCtoNCDHW_Size3(self):
+    x_val = [4, 9, 3]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="NCDHW")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [4, 9, 3])
+
+  def testNHWCToWHCN(self):
+    x_val = [7, 4, 9, 3]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(x, src_format="NHWC", dst_format="WHCN")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [9, 4, 3, 7])
+
+  def testNHWCToWHCN_Size2(self):
+    x_val = [4, 9]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(x, src_format="NHWC", dst_format="WHCN")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [9, 4])
+
+  def testNDHWCToWHDCN(self):
+    x_val = [7, 4, 9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="WHDCN")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [3, 9, 4, 5, 7])
+
+  def testNDHWCToWHDCN_Size3(self):
+    x_val = [4, 9, 3]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="WHDCN")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [3, 9, 4])
+
   def testNCHWToNHWC(self):
     x_val = [7, 4, 9, 3]
     x = constant_op.constant(x_val)
@@ -1241,6 +1330,31 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
     with test_util.use_gpu():
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [7, 9, 3, 4])
+
+  def testNCHWToNHWC_Size2(self):
+    x_val = [9, 3]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(x, src_format="NCHW", dst_format="NHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [9, 3])
+
+  def testNCDHWToNDHWC(self):
+    x_val = [7, 4, 9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(x, src_format="NCDHW", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [7, 9, 3, 5, 4])
+
+  def testNCDHWToNDHWC_Size3(self):
+    x_val = [9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NCDHW", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [9, 3, 5])
 
   def testNHWCToHWNC(self):
     x_val = [7, 4, 9, 3]
@@ -1289,6 +1403,42 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
     with test_util.use_gpu():
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [[7, 4], [4, 5], [5, 1], [9, 3]])
+
+  def testNDHWCToNCDHW2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="NCDHW")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[7, 4], [8, 2], [9, 3], [4, 5], [5, 1]])
+
+  def testNDHWCToDHWNC2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="DHWNC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[9, 3], [4, 5], [5, 1], [7, 4], [8, 2]])
+
+  def testDHWNCToNDHWC2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="DHWNC", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[5, 1], [7, 4], [9, 3], [4, 5], [8, 2]])
+
+  def testNCDHWToNDHWC2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NCDHW", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[7, 4], [4, 5], [5, 1], [8, 2], [9, 3]])
 
   @test_util.disable_xla("XLA catches the error and rethrows as different one")
   def testInvalidLength(self):

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -43,8 +43,6 @@ import tensorflow.python.ops.nn_grad  # pylint: disable=unused-import
 from tensorflow.python.ops.nn_impl import _compute_sampled_logits
 from tensorflow.python.platform import test as test_lib
 
-import os
-input(os.getpid())
 
 class ZeroFractionTest(test_lib.TestCase):
 


### PR DESCRIPTION
A few things are going on in this PR:

1. Around 6 months ago, a cherry pick was made from the official TF2 master branch to the 1.15 branch in order to fix potential security issues where the src_format and dst_format attributes for data format ops were not validated. The problem is that this cherry-pick inadvertently also extended the validation from 4D to 5D without also porting the 5D implementation for DataFormatDimMap, thus breaking the CPU and CUDA implementations.
2. Even in TF2, the validation for DataFormatVecPermute is broken because it doesn't validate that the length of src_format and dst_format is equal to the size of the input.
3. In addition to fixing the DML implementations for these ops, this PR aims to also fix the CPU implementation and validation.