### PR TITLE
Make some local CLI tests run on CPU

### DIFF
--- a/tensorflow/python/debug/wrappers/local_cli_wrapper_test.py
+++ b/tensorflow/python/debug/wrappers/local_cli_wrapper_test.py
@@ -412,29 +412,32 @@ class LocalCLIDebugWrapperSessionTest(test_util.TensorFlowTestCase):
     self.assertEqual(1, len(wrapped_sess.observers["debug_dumps"]))
 
   def testDebuggingMakeCallableFromOptionsWithZeroFeedWorks(self):
-    variable_1 = variables.VariableV1(
-        10.5, dtype=dtypes.float32, name="variable_1")
-    a = math_ops.add(variable_1, variable_1, "callable_a")
-    math_ops.add(a, a, "callable_b")
-    self.sess.run(variable_1.initializer)
+    with test_util.device(use_gpu=False):
+      variable_1 = variables.VariableV1(
+          10.5, dtype=dtypes.float32, name="variable_1")
+      a = math_ops.add(variable_1, variable_1, "callable_a")
+      math_ops.add(a, a, "callable_b")
+      self.sess.run(variable_1.initializer)
 
-    wrapped_sess = LocalCLIDebuggerWrapperSessionForTest(
-        [["run"]] * 3, self.sess, dump_root=self._tmp_dir)
-    callable_options = config_pb2.CallableOptions()
-    callable_options.fetch.append("callable_b")
-    sess_callable = wrapped_sess._make_callable_from_options(callable_options)
+      wrapped_sess = LocalCLIDebuggerWrapperSessionForTest(
+          [["run"]] * 3, self.sess, dump_root=self._tmp_dir)
+      callable_options = config_pb2.CallableOptions()
+      callable_options.fetch.append("callable_b")
+      sess_callable = wrapped_sess._make_callable_from_options(callable_options)
 
-    for _ in range(2):
-      callable_output = sess_callable()
-      self.assertAllClose(np.array(42.0, dtype=np.float32), callable_output[0])
+      for _ in range(2):
+        callable_output = sess_callable()
+        self.assertAllClose(
+            np.array(42.0, dtype=np.float32), callable_output[0])
 
-    debug_dumps = wrapped_sess.observers["debug_dumps"]
-    self.assertEqual(2, len(debug_dumps))
-    for debug_dump in debug_dumps:
-      node_names = [datum.node_name for datum in debug_dump.dumped_tensor_data]
-      self.assertItemsEqual(
-          ["callable_a", "callable_b", "variable_1", "variable_1/read"],
-          node_names)
+      debug_dumps = wrapped_sess.observers["debug_dumps"]
+      self.assertEqual(2, len(debug_dumps))
+      for debug_dump in debug_dumps:
+        node_names = [
+            datum.node_name for datum in debug_dump.dumped_tensor_data]
+        self.assertItemsEqual(
+            ["callable_a", "callable_b", "variable_1", "variable_1/read"],
+            node_names)
 
   def testDebuggingMakeCallableFromOptionsWithOneFeedWorks(self):
     ph1 = array_ops.placeholder(dtypes.float32, name="callable_ph1")
@@ -491,34 +494,36 @@ class LocalCLIDebugWrapperSessionTest(test_util.TensorFlowTestCase):
       self.assertIn("callable_b", node_names)
 
   def testDebugMakeCallableFromOptionsWithCustomOptionsAndMetadataWorks(self):
-    variable_1 = variables.VariableV1(
-        10.5, dtype=dtypes.float32, name="variable_1")
-    a = math_ops.add(variable_1, variable_1, "callable_a")
-    math_ops.add(a, a, "callable_b")
-    self.sess.run(variable_1.initializer)
+    with test_util.device(use_gpu=False):
+      variable_1 = variables.VariableV1(
+          10.5, dtype=dtypes.float32, name="variable_1")
+      a = math_ops.add(variable_1, variable_1, "callable_a")
+      math_ops.add(a, a, "callable_b")
+      self.sess.run(variable_1.initializer)
 
-    wrapped_sess = LocalCLIDebuggerWrapperSessionForTest(
-        [["run"], ["run"]], self.sess, dump_root=self._tmp_dir)
-    callable_options = config_pb2.CallableOptions()
-    callable_options.fetch.append("callable_b")
-    callable_options.run_options.trace_level = config_pb2.RunOptions.FULL_TRACE
+      wrapped_sess = LocalCLIDebuggerWrapperSessionForTest(
+          [["run"], ["run"]], self.sess, dump_root=self._tmp_dir)
+      callable_options = config_pb2.CallableOptions()
+      callable_options.fetch.append("callable_b")
+      callable_options.run_options.trace_level = (
+          config_pb2.RunOptions.FULL_TRACE)
 
-    sess_callable = wrapped_sess._make_callable_from_options(callable_options)
+      sess_callable = wrapped_sess._make_callable_from_options(callable_options)
 
-    run_metadata = config_pb2.RunMetadata()
-    # Call the callable with a custom run_metadata.
-    callable_output = sess_callable(run_metadata=run_metadata)
-    # Verify that step_stats is populated in the custom run_metadata.
-    self.assertTrue(run_metadata.step_stats)
-    self.assertAllClose(np.array(42.0, dtype=np.float32), callable_output[0])
+      run_metadata = config_pb2.RunMetadata()
+      # Call the callable with a custom run_metadata.
+      callable_output = sess_callable(run_metadata=run_metadata)
+      # Verify that step_stats is populated in the custom run_metadata.
+      self.assertTrue(run_metadata.step_stats)
+      self.assertAllClose(np.array(42.0, dtype=np.float32), callable_output[0])
 
-    debug_dumps = wrapped_sess.observers["debug_dumps"]
-    self.assertEqual(1, len(debug_dumps))
-    debug_dump = debug_dumps[0]
-    node_names = [datum.node_name for datum in debug_dump.dumped_tensor_data]
-    self.assertItemsEqual(
-        ["callable_a", "callable_b", "variable_1", "variable_1/read"],
-        node_names)
+      debug_dumps = wrapped_sess.observers["debug_dumps"]
+      self.assertEqual(1, len(debug_dumps))
+      debug_dump = debug_dumps[0]
+      node_names = [datum.node_name for datum in debug_dump.dumped_tensor_data]
+      self.assertItemsEqual(
+          ["callable_a", "callable_b", "variable_1", "variable_1/read"],
+          node_names)
 
   def testRuntimeErrorShouldBeCaught(self):
     wrapped_sess = LocalCLIDebuggerWrapperSessionForTest(

--- a/third_party/dml/ci/run_tests_data.json
+++ b/third_party/dml/ci/run_tests_data.json
@@ -13,7 +13,8 @@
         "portpicker"
       ],
       "windowsPipDeps": [
-        "windows-curses"
+        "windows-curses",
+        "pyreadline"
       ],
       "isPythonTest": true
     },


### PR DESCRIPTION
These tests also fail on the vanilla TF 1.15 CUDA version, so they should only run on the CPU.