### PR TITLE
Cap the number of processes used in the tfdml test runner

### DIFF
--- a/third_party/dml/ci/tests/tfdml_test_runner.py
+++ b/third_party/dml/ci/tests/tfdml_test_runner.py
@@ -155,8 +155,9 @@ def _run_test(
 def main():
   args = _parse_args()
   absolute_binaries_path = os.path.join(sys.path[0], args.test_binaries_path)
+  processes_count = min(8, os.cpu_count())
 
-  with concurrent.futures.ThreadPoolExecutor(os.cpu_count()) as executor:
+  with concurrent.futures.ThreadPoolExecutor(processes_count) as executor:
     futures = []
 
     try:


### PR DESCRIPTION
Most of our Autopilot machines have 8 logical cores, but some have 16. It turns out that launching anything more than 8 processes simultaneously for the TF tests occupies too much ram and can lead to the WSL VM shutting down, so capping the number of processes to 8 seems to be a sensible "magic number" here.