### PR TITLE
Fix bad strides for uint64 and int64 Invert

### DIFF
--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -965,6 +965,7 @@ class DmlBitwiseNotKernel : public DmlKernel {
     DCHECK(dtype == ctx->GetOutputDataType(0));
     if (Is64BitIntegerType(dtype)) {
       num_elements *= 2;
+      dtype = DT_UINT32;
     }
 
     std::array<uint32_t, 4> sizes = {1, 1, 1, num_elements};


### PR DESCRIPTION
We were doubling the number of elements, but since we didn't change the datatype the strides were still being doubled.