### PR TITLE
Make the DML RealDiv tests less prone to tolerance errors

### DIFF
--- a/tensorflow/core/kernels/dml_ops_simple_test.cc
+++ b/tensorflow/core/kernels/dml_ops_simple_test.cc
@@ -219,8 +219,8 @@ TEST(DmlKernelTests, Relu) {
 
 TEST(DmlKernelTests, RealDiv) {
   TensorShape shape({2, 2});
-  auto a_data = {2.0f, 7.0f, 6.0f, 12.0f};
-  auto b_data = {1.0f, 2.0f, 3.0f, 4.0f};
+  auto a_data = {2.0f, 7.0f, 12.0f, 32.0f};
+  auto b_data = {1.0f, 2.0f, 4.0f, 8.0f};
 
   {
     Tensor half_a(DT_HALF, shape);

--- a/tensorflow/core/kernels/dml_ops_simple_test.cc
+++ b/tensorflow/core/kernels/dml_ops_simple_test.cc
@@ -219,7 +219,7 @@ TEST(DmlKernelTests, Relu) {
 
 TEST(DmlKernelTests, RealDiv) {
   TensorShape shape({2, 2});
-  auto a_data = {2.0f, 7.0f, 9.0f, 50.0f};
+  auto a_data = {2.0f, 7.0f, 6.0f, 12.0f};
   auto b_data = {1.0f, 2.0f, 3.0f, 4.0f};
 
   {


### PR DESCRIPTION
The DML simple op tests aren't meant to test tolerances, so we can tweak the values to have more robust divisions for RealDiv.