### PR TITLE
Fix race condition in kernel manager tests

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_kernel_manager_test.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_manager_test.cc
@@ -280,6 +280,7 @@ TEST_F(DmlKernelManagerTest, QueueReference) {
   // fence = 1
   // kernel1 should be released
   DML_CHECK_SUCCEEDED(fence->Signal(1));
+  DML_CHECK_SUCCEEDED(fence->SetEventOnCompletion(1, nullptr));
   kernel_manager_.ReleaseCompletedReferences();
   EXPECT_TRUE(kernel1_weak.expired());
   EXPECT_TRUE(!kernel2_weak.expired());
@@ -287,6 +288,7 @@ TEST_F(DmlKernelManagerTest, QueueReference) {
   // fence = 2
   // Both kernels should be released
   DML_CHECK_SUCCEEDED(fence->Signal(2));
+  DML_CHECK_SUCCEEDED(fence->SetEventOnCompletion(2, nullptr));
   kernel_manager_.ReleaseCompletedReferences();
   EXPECT_TRUE(kernel1_weak.expired());
   EXPECT_TRUE(kernel2_weak.expired());


### PR DESCRIPTION
ID3D12Fence::Signal() is not guaranteed to be completed once the function returns (it does on native Windows, but not WSL and Windows VMs).