### PR TITLE
Fix configure.py when using bazelisk on Windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -471,11 +471,12 @@ def check_bazel_version(min_version, max_version):
   Returns:
     The bazel version detected.
   """
-  if which('bazel') is None:
+  bazel_executable = which('bazel')
+  if bazel_executable is None:
     print('Cannot find bazel. Please install bazel.')
     sys.exit(0)
   curr_version = run_shell(
-      ['bazel', '--batch', '--bazelrc=/dev/null', 'version'])
+      [bazel_executable, '--batch', '--bazelrc=/dev/null', 'version'])
 
   for line in curr_version.split('\n'):
     if 'Build label: ' in line:


### PR DESCRIPTION
Bazelisk on Windows has `bazel.cmd` on the path instead of `bazel.exe`, which cannot be called simply with `bazel` when using `subprocess.run` with `shell=False`. Instead, we can simply use the full path obtained by the `which` command.