### PR TITLE
Reduce DML memory limit and allocate persistent resources outside arena

### DIFF
--- a/tensorflow/core/kernels/dml_ops_common.h
+++ b/tensorflow/core/kernels/dml_ops_common.h
@@ -181,8 +181,9 @@ class DmlKernel {
  private:
   Microsoft::WRL::ComPtr<IDMLCompiledOperator> compiled_op_;
 
-  DmlBuffer persistent_resource_;
+  Microsoft::WRL::ComPtr<ID3D12Resource> persistent_resource_;
   absl::optional<DML_BUFFER_BINDING> persistent_resource_binding_;
+  
   std::shared_ptr<const InitializationHelper> init_helper_;
 
   // The order and count of these descs match the DML operator, which might be


### PR DESCRIPTION
These changes are intended to align closer with the GPU device's heuristic, and to help avoid paging which could occur when DirectML operations use persistent memory, such as for indexing optimizations.
