### PR TITLE
Support tiled resources in primary DML allocator

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_buffer.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer.cc
@@ -42,8 +42,8 @@ DmlBuffer::~DmlBuffer() {
   }
 }
 
-ID3D12Resource* DmlBuffer::ResourceInFixedState() const {
-  return buffer_region_.ResourceInFixedState();
+ID3D12Resource* DmlBuffer::ResourceInUavState() const {
+  return buffer_region_.ResourceInUavState();
 }
 
 ID3D12Resource* DmlBuffer::ResourceInCopySrcState() const {

--- a/tensorflow/core/common_runtime/dml/dml_buffer.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer.cc
@@ -43,15 +43,15 @@ DmlBuffer::~DmlBuffer() {
 }
 
 ID3D12Resource* DmlBuffer::ResourceInFixedState() const {
-  return buffer_region_ ? buffer_region_.ResourceInFixedState() : nullptr;
+  return buffer_region_.ResourceInFixedState();
 }
 
 ID3D12Resource* DmlBuffer::ResourceInCopySrcState() const {
-  return buffer_region_ ? buffer_region_.ResourceInCopySrcState() : nullptr;
+  return buffer_region_.ResourceInCopySrcState();
 }
 
 ID3D12Resource* DmlBuffer::ResourceInCopyDstState() const {
-  return buffer_region_ ? buffer_region_.ResourceInCopyDstState() : nullptr;
+  return buffer_region_.ResourceInCopyDstState();
 }
 
 uint64_t DmlBuffer::Offset() const {

--- a/tensorflow/core/common_runtime/dml/dml_buffer.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer.cc
@@ -42,8 +42,16 @@ DmlBuffer::~DmlBuffer() {
   }
 }
 
-ID3D12Resource* DmlBuffer::Resource() const {
-  return buffer_region_ ? buffer_region_.Resource() : nullptr;
+ID3D12Resource* DmlBuffer::ResourceInFixedState() const {
+  return buffer_region_ ? buffer_region_.ResourceInFixedState() : nullptr;
+}
+
+ID3D12Resource* DmlBuffer::ResourceInCopySrcState() const {
+  return buffer_region_ ? buffer_region_.ResourceInCopySrcState() : nullptr;
+}
+
+ID3D12Resource* DmlBuffer::ResourceInCopyDstState() const {
+  return buffer_region_ ? buffer_region_.ResourceInCopyDstState() : nullptr;
 }
 
 uint64_t DmlBuffer::Offset() const {

--- a/tensorflow/core/common_runtime/dml/dml_buffer.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer.h
@@ -38,7 +38,7 @@ class DmlBuffer {
   DmlBuffer(DmlBuffer&&) = default;
   DmlBuffer& operator=(DmlBuffer&&) = default;
 
-  ID3D12Resource* ResourceInFixedState() const;
+  ID3D12Resource* ResourceInUavState() const;
   ID3D12Resource* ResourceInCopySrcState() const;
   ID3D12Resource* ResourceInCopyDstState() const;
   uint64_t Offset() const;

--- a/tensorflow/core/common_runtime/dml/dml_buffer.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer.h
@@ -25,8 +25,7 @@ class DmlAllocator;
 // Owns a D3D12 default heap buffer allocated using the DML device's
 // allocator. This is essentially a convenience wrapper over a device memory
 // allocation as well as the buffer region that spans it. When this object is
-// destructed, the device memory is freed to the allocator and the buffer region
-// is released.
+// destructed, the device memory is freed to the allocator.
 class DmlBuffer {
  public:
   DmlBuffer() = default;
@@ -39,9 +38,12 @@ class DmlBuffer {
   DmlBuffer(DmlBuffer&&) = default;
   DmlBuffer& operator=(DmlBuffer&&) = default;
 
-  ID3D12Resource* Resource() const;
+  ID3D12Resource* ResourceInFixedState() const;
+  ID3D12Resource* ResourceInCopySrcState() const;
+  ID3D12Resource* ResourceInCopyDstState() const;
   uint64_t Offset() const;
   uint64_t SizeInBytes() const;
+  const D3D12BufferRegion& Region() const { return buffer_region_; }
 
   DML_BUFFER_BINDING GetBufferBinding() const;
 

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -31,29 +31,35 @@ D3D12BufferRegion::D3D12BufferRegion(
       resource_(std::move(resource)),
       resource_copy_src_state_(std::move(resource_copy_src_state)),
       resource_copy_dst_state_(std::move(resource_copy_dst_state)) {
-  assert(resource_ != nullptr);
-  assert(size_in_bytes_ != 0);
+
+  CHECK(resource_ != nullptr);
+  CHECK(size_in_bytes_ != 0);
+
+  uint64_t buffer_size = resource->GetDesc().Width;
+  CHECK(offset_ < buffer_size);
+  CHECK(size_in_bytes_ <= buffer_size - offset);
+
   assert(resource_->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER);
-  assert(
-      !resource_copy_src_state ||
-      (resource_copy_src_state->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
-       resource_copy_src_state->GetDesc().Width == resource->GetDesc().Width));
-  assert(
-      !resource_copy_dst_state ||
-      (resource_copy_dst_state->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
-       resource_copy_dst_state->GetDesc().Width == resource->GetDesc().Width));
+  assert(!resource_copy_src_state ||
+         (resource_copy_src_state->GetDesc().Dimension ==
+              D3D12_RESOURCE_DIMENSION_BUFFER &&
+          resource_copy_src_state->GetDesc().Width == buffer_size));
+  assert(!resource_copy_dst_state ||
+         (resource_copy_dst_state->GetDesc().Dimension ==
+              D3D12_RESOURCE_DIMENSION_BUFFER &&
+          resource_copy_dst_state->GetDesc().Width == buffer_size));
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInFixedState() const {
-  return resource_ ? resource_.Get() : nullptr;
+  return resource_.Get();
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopySrcState() const {
-  return resource_copy_src_state_ ? resource_copy_src_state_.Get() : nullptr;
+  return resource_copy_src_state_.Get();
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopyDstState() const {
-  return resource_copy_dst_state_ ? resource_copy_dst_state_.Get() : nullptr;
+  return resource_copy_dst_state_.Get();
 }
 
 uint64_t D3D12BufferRegion::Offset() const { return resource_ ? offset_ : 0; }

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -31,7 +31,6 @@ D3D12BufferRegion::D3D12BufferRegion(
       resource_(std::move(resource)),
       resource_copy_src_state_(std::move(resource_copy_src_state)),
       resource_copy_dst_state_(std::move(resource_copy_dst_state)) {
-
   CHECK(resource_ != nullptr);
   CHECK(size_in_bytes_ != 0);
 

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -34,19 +34,19 @@ D3D12BufferRegion::D3D12BufferRegion(
   CHECK(resource_ != nullptr);
   CHECK(size_in_bytes_ != 0);
 
-  uint64_t buffer_size = resource->GetDesc().Width;
+  uint64_t buffer_size = resource_->GetDesc().Width;
   CHECK(offset_ < buffer_size);
   CHECK(size_in_bytes_ <= buffer_size - offset);
 
   assert(resource_->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER);
-  assert(!resource_copy_src_state ||
-         (resource_copy_src_state->GetDesc().Dimension ==
+  assert(!resource_copy_src_state_ ||
+         (resource_copy_src_state_->GetDesc().Dimension ==
               D3D12_RESOURCE_DIMENSION_BUFFER &&
-          resource_copy_src_state->GetDesc().Width == buffer_size));
-  assert(!resource_copy_dst_state ||
-         (resource_copy_dst_state->GetDesc().Dimension ==
+          resource_copy_src_state_->GetDesc().Width == buffer_size));
+  assert(!resource_copy_dst_state_ ||
+         (resource_copy_dst_state_->GetDesc().Dimension ==
               D3D12_RESOURCE_DIMENSION_BUFFER &&
-          resource_copy_dst_state->GetDesc().Width == buffer_size));
+          resource_copy_dst_state_->GetDesc().Width == buffer_size));
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInFixedState() const {

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -34,7 +34,14 @@ D3D12BufferRegion::D3D12BufferRegion(
   assert(resource_ != nullptr);
   assert(size_in_bytes_ != 0);
   assert(resource_->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER);
-  // TODO: if other resources provided they should match size
+  assert(
+      !resource_copy_src_state ||
+      (resource_copy_src_state->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
+       resource_copy_src_state->GetDesc().Width == resource->GetDesc().Width));
+  assert(
+      !resource_copy_dst_state ||
+      (resource_copy_dst_state->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
+       resource_copy_dst_state->GetDesc().Width == resource->GetDesc().Width));
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInFixedState() const {

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -33,10 +33,10 @@ D3D12BufferRegion::D3D12BufferRegion(
   // resource must be provided.
   first_valid_resource_ = resource_uav_state_.Get();
   if (!first_valid_resource_) {
-    first_valid_resource_ = resource_copy_src_state.Get();
+    first_valid_resource_ = resource_copy_src_state_.Get();
   }
   if (!first_valid_resource_) {
-    first_valid_resource_ = resource_copy_dst_state.Get();
+    first_valid_resource_ = resource_copy_dst_state_.Get();
   }
   CHECK(first_valid_resource_ != nullptr);
 

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -19,17 +19,18 @@ limitations under the License.
 
 namespace tensorflow {
 
-D3D12BufferRegion::D3D12BufferRegion(uint64_t offset, uint64_t size_in_bytes,
-                                     D3D12_RESOURCE_STATES resource_state,
-                                     ID3D12Resource* resource,
-                                     ID3D12Resource* resource_copy_src_state,
-                                     ID3D12Resource* resource_copy_dst_state)
+D3D12BufferRegion::D3D12BufferRegion(
+    uint64_t offset, uint64_t size_in_bytes,
+    D3D12_RESOURCE_STATES resource_state,
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource,
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state,
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state)
     : offset_(offset),
       size_in_bytes_(size_in_bytes),
-      resource_state_(resource_state),
+      resource_state_(std::move(resource_state)),
       resource_(resource),
-      resource_copy_src_state_(resource_copy_src_state),
-      resource_copy_dst_state_(resource_copy_dst_state) {
+      resource_copy_src_state_(std::move(resource_copy_src_state)),
+      resource_copy_dst_state_(std::move(resource_copy_dst_state)) {
   CHECK(resource_ != nullptr);
   CHECK(size_in_bytes_ != 0);
 
@@ -49,15 +50,15 @@ D3D12BufferRegion::D3D12BufferRegion(uint64_t offset, uint64_t size_in_bytes,
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInFixedState() const {
-  return resource_;
+  return resource_.Get();
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopySrcState() const {
-  return resource_copy_src_state_;
+  return resource_copy_src_state_.Get();
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopyDstState() const {
-  return resource_copy_dst_state_;
+  return resource_copy_dst_state_.Get();
 }
 
 uint64_t D3D12BufferRegion::Offset() const { return resource_ ? offset_ : 0; }
@@ -71,7 +72,7 @@ DML_BUFFER_BINDING D3D12BufferRegion::GetBufferBinding() const {
     return DML_BUFFER_BINDING{};
   }
 
-  return DML_BUFFER_BINDING{resource_, offset_, size_in_bytes_};
+  return DML_BUFFER_BINDING{resource_.Get(), offset_, size_in_bytes_};
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -19,18 +19,17 @@ limitations under the License.
 
 namespace tensorflow {
 
-D3D12BufferRegion::D3D12BufferRegion(
-    uint64_t offset, uint64_t size_in_bytes,
-    D3D12_RESOURCE_STATES resource_state,
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource,
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state,
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state)
+D3D12BufferRegion::D3D12BufferRegion(uint64_t offset, uint64_t size_in_bytes,
+                                     D3D12_RESOURCE_STATES resource_state,
+                                     ID3D12Resource* resource,
+                                     ID3D12Resource* resource_copy_src_state,
+                                     ID3D12Resource* resource_copy_dst_state)
     : offset_(offset),
       size_in_bytes_(size_in_bytes),
       resource_state_(resource_state),
-      resource_(std::move(resource)),
-      resource_copy_src_state_(std::move(resource_copy_src_state)),
-      resource_copy_dst_state_(std::move(resource_copy_dst_state)) {
+      resource_(resource),
+      resource_copy_src_state_(resource_copy_src_state),
+      resource_copy_dst_state_(resource_copy_dst_state) {
   CHECK(resource_ != nullptr);
   CHECK(size_in_bytes_ != 0);
 
@@ -50,15 +49,15 @@ D3D12BufferRegion::D3D12BufferRegion(
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInFixedState() const {
-  return resource_.Get();
+  return resource_;
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopySrcState() const {
-  return resource_copy_src_state_.Get();
+  return resource_copy_src_state_;
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopyDstState() const {
-  return resource_copy_dst_state_.Get();
+  return resource_copy_dst_state_;
 }
 
 uint64_t D3D12BufferRegion::Offset() const { return resource_ ? offset_ : 0; }
@@ -72,7 +71,7 @@ DML_BUFFER_BINDING D3D12BufferRegion::GetBufferBinding() const {
     return DML_BUFFER_BINDING{};
   }
 
-  return DML_BUFFER_BINDING{resource_.Get(), offset_, size_in_bytes_};
+  return DML_BUFFER_BINDING{resource_, offset_, size_in_bytes_};
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -65,6 +65,27 @@ D3D12BufferRegion::D3D12BufferRegion(
           resource_copy_dst_state_->GetDesc().Width == buffer_size));
 }
 
+D3D12BufferRegion::D3D12BufferRegion(D3D12BufferRegion&& that)
+{
+  std::swap(this->resource_uav_state_, that.resource_uav_state_);
+  std::swap(this->resource_copy_src_state_, that.resource_copy_src_state_);
+  std::swap(this->resource_copy_dst_state_, that.resource_copy_dst_state_);
+  std::swap(this->offset_, that.offset_);
+  std::swap(this->size_in_bytes_, that.size_in_bytes_);
+  std::swap(this->first_valid_resource_, that.first_valid_resource_);
+}
+
+D3D12BufferRegion& D3D12BufferRegion::operator=(D3D12BufferRegion&& that)
+{
+  std::swap(this->resource_uav_state_, that.resource_uav_state_);
+  std::swap(this->resource_copy_src_state_, that.resource_copy_src_state_);
+  std::swap(this->resource_copy_dst_state_, that.resource_copy_dst_state_);
+  std::swap(this->offset_, that.offset_);
+  std::swap(this->size_in_bytes_, that.size_in_bytes_);
+  std::swap(this->first_valid_resource_, that.first_valid_resource_);
+  return *this;
+}
+
 ID3D12Resource* D3D12BufferRegion::ResourceInUavState() const {
   return resource_uav_state_.Get();
 }

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -27,8 +27,8 @@ D3D12BufferRegion::D3D12BufferRegion(
     Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state)
     : offset_(offset),
       size_in_bytes_(size_in_bytes),
-      resource_state_(std::move(resource_state)),
-      resource_(resource),
+      resource_state_(resource_state),
+      resource_(std::move(resource)),
       resource_copy_src_state_(std::move(resource_copy_src_state)),
       resource_copy_dst_state_(std::move(resource_copy_dst_state)) {
   CHECK(resource_ != nullptr);

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.cc
@@ -19,24 +19,23 @@ limitations under the License.
 
 namespace tensorflow {
 
-D3D12BufferRegion::D3D12BufferRegion(
-    uint64_t offset, uint64_t size_in_bytes,
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource_uav_state,
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state,
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state)
+D3D12BufferRegion::D3D12BufferRegion(uint64_t offset, uint64_t size_in_bytes,
+                                     ID3D12Resource* resource_uav_state,
+                                     ID3D12Resource* resource_copy_src_state,
+                                     ID3D12Resource* resource_copy_dst_state)
     : offset_(offset),
       size_in_bytes_(size_in_bytes),
-      resource_uav_state_(std::move(resource_uav_state)),
-      resource_copy_src_state_(std::move(resource_copy_src_state)),
-      resource_copy_dst_state_(std::move(resource_copy_dst_state)) {
+      resource_uav_state_(resource_uav_state),
+      resource_copy_src_state_(resource_copy_src_state),
+      resource_copy_dst_state_(resource_copy_dst_state) {
   // Get a raw pointer to the first non-null resource passed in. At least one
   // resource must be provided.
-  first_valid_resource_ = resource_uav_state_.Get();
+  first_valid_resource_ = resource_uav_state_;
   if (!first_valid_resource_) {
-    first_valid_resource_ = resource_copy_src_state_.Get();
+    first_valid_resource_ = resource_copy_src_state_;
   }
   if (!first_valid_resource_) {
-    first_valid_resource_ = resource_copy_dst_state_.Get();
+    first_valid_resource_ = resource_copy_dst_state_;
   }
   CHECK(first_valid_resource_ != nullptr);
 
@@ -65,8 +64,7 @@ D3D12BufferRegion::D3D12BufferRegion(
           resource_copy_dst_state_->GetDesc().Width == buffer_size));
 }
 
-D3D12BufferRegion::D3D12BufferRegion(D3D12BufferRegion&& that)
-{
+D3D12BufferRegion::D3D12BufferRegion(D3D12BufferRegion&& that) {
   std::swap(this->resource_uav_state_, that.resource_uav_state_);
   std::swap(this->resource_copy_src_state_, that.resource_copy_src_state_);
   std::swap(this->resource_copy_dst_state_, that.resource_copy_dst_state_);
@@ -75,8 +73,7 @@ D3D12BufferRegion::D3D12BufferRegion(D3D12BufferRegion&& that)
   std::swap(this->first_valid_resource_, that.first_valid_resource_);
 }
 
-D3D12BufferRegion& D3D12BufferRegion::operator=(D3D12BufferRegion&& that)
-{
+D3D12BufferRegion& D3D12BufferRegion::operator=(D3D12BufferRegion&& that) {
   std::swap(this->resource_uav_state_, that.resource_uav_state_);
   std::swap(this->resource_copy_src_state_, that.resource_copy_src_state_);
   std::swap(this->resource_copy_dst_state_, that.resource_copy_dst_state_);
@@ -87,15 +84,15 @@ D3D12BufferRegion& D3D12BufferRegion::operator=(D3D12BufferRegion&& that)
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInUavState() const {
-  return resource_uav_state_.Get();
+  return resource_uav_state_;
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopySrcState() const {
-  return resource_copy_src_state_.Get();
+  return resource_copy_src_state_;
 }
 
 ID3D12Resource* D3D12BufferRegion::ResourceInCopyDstState() const {
-  return resource_copy_dst_state_.Get();
+  return resource_copy_dst_state_;
 }
 
 uint64_t D3D12BufferRegion::Offset() const {
@@ -111,7 +108,7 @@ DML_BUFFER_BINDING D3D12BufferRegion::GetBufferBinding() const {
     return DML_BUFFER_BINDING{};
   }
 
-  return DML_BUFFER_BINDING{resource_uav_state_.Get(), offset_, size_in_bytes_};
+  return DML_BUFFER_BINDING{resource_uav_state_, offset_, size_in_bytes_};
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -31,11 +31,10 @@ class D3D12BufferRegion {
   // References a region of a buffer. The respective ID3D12Resource objects must
   // be in the appropriate states. Each resource is optional, but if more than
   // one are provided they must map to the same region of memory.
-  D3D12BufferRegion(
-      uint64_t offset, uint64_t size_in_bytes,
-      Microsoft::WRL::ComPtr<ID3D12Resource> resource_uav_state,
-      Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state,
-      Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state);
+  D3D12BufferRegion(uint64_t offset, uint64_t size_in_bytes,
+                    ID3D12Resource* resource_uav_state,
+                    ID3D12Resource* resource_copy_src_state,
+                    ID3D12Resource* resource_copy_dst_state);
 
   // Move-only
   D3D12BufferRegion(const D3D12BufferRegion&) = delete;
@@ -75,9 +74,9 @@ class D3D12BufferRegion {
   }
 
  private:
-  Microsoft::WRL::ComPtr<ID3D12Resource> resource_uav_state_;
-  Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state_;
-  Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state_;
+  ID3D12Resource* resource_uav_state_ = nullptr;
+  ID3D12Resource* resource_copy_src_state_ = nullptr;
+  ID3D12Resource* resource_copy_dst_state_ = nullptr;
   uint64_t offset_ = 0;
   uint64_t size_in_bytes_ = 0;
 

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -53,12 +53,17 @@ class D3D12BufferRegion {
 
   explicit operator bool() const { return resource_ != nullptr; }
 
-  // Creates a subregion at an offset from the start of this region. If no size is provided
-  // the region runs to the end of the current region.
-  inline D3D12BufferRegion Subregion(uint64_t offset, uint64_t size_in_bytes = 0) const {
-    CHECK(offset < size_in_bytes_); // start of subregion must be within current region
-    size_in_bytes = size_in_bytes == 0 ? size_in_bytes_ - offset : size_in_bytes;
-    CHECK(size_in_bytes <= size_in_bytes_ - offset); // end of subregion must be within current region
+  // Creates a subregion at an offset from the start of this region. If no size
+  // is provided the region runs to the end of the current region.
+  inline D3D12BufferRegion Subregion(uint64_t offset,
+                                     uint64_t size_in_bytes = 0) const {
+    // start of subregion must be within current region
+    CHECK(offset < size_in_bytes_);
+    size_in_bytes =
+        size_in_bytes == 0 ? size_in_bytes_ - offset : size_in_bytes;
+    // end of subregion must be within current region
+    CHECK(size_in_bytes <= size_in_bytes_ - offset);
+
     return D3D12BufferRegion(offset_ + offset, size_in_bytes, resource_state_,
                              resource_, resource_copy_src_state_,
                              resource_copy_dst_state_);

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -29,12 +29,11 @@ class D3D12BufferRegion {
   D3D12BufferRegion() = default;
 
   // References a region of a resource that remains in a fixed state.
-  D3D12BufferRegion(
-      uint64_t offset, uint64_t size_in_bytes,
-      D3D12_RESOURCE_STATES resource_state,
-      Microsoft::WRL::ComPtr<ID3D12Resource> resource,
-      Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state = nullptr,
-      Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state = nullptr);
+  D3D12BufferRegion(uint64_t offset, uint64_t size_in_bytes,
+                    D3D12_RESOURCE_STATES resource_state,
+                    ID3D12Resource* resource,
+                    ID3D12Resource* resource_copy_src_state = nullptr,
+                    ID3D12Resource* resource_copy_dst_state = nullptr);
 
   // Move-only
   D3D12BufferRegion(const D3D12BufferRegion&) = delete;
@@ -70,9 +69,9 @@ class D3D12BufferRegion {
   }
 
  private:
-  Microsoft::WRL::ComPtr<ID3D12Resource> resource_;
-  Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state_;
-  Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state_;
+  ID3D12Resource* resource_;
+  ID3D12Resource* resource_copy_src_state_;
+  ID3D12Resource* resource_copy_dst_state_;
   uint64_t offset_ = 0;
   uint64_t size_in_bytes_ = 0;
   D3D12_RESOURCE_STATES resource_state_ = D3D12_RESOURCE_STATE_COMMON;

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -56,7 +56,7 @@ class D3D12BufferRegion {
 
   DML_BUFFER_BINDING GetBufferBinding() const;
 
-  explicit operator bool() const { return first_valid_resource_ != nullptr; }
+  explicit operator bool() const { return resource_uav_state_ != nullptr; }
 
   // Creates a subregion at an offset from the start of this region. If no size
   // is provided the region runs to the end of the current region.

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -69,9 +69,9 @@ class D3D12BufferRegion {
   }
 
  private:
-  ID3D12Resource* resource_;
-  ID3D12Resource* resource_copy_src_state_;
-  ID3D12Resource* resource_copy_dst_state_;
+  ID3D12Resource* resource_ = nullptr;
+  ID3D12Resource* resource_copy_src_state_ = nullptr;
+  ID3D12Resource* resource_copy_dst_state_ = nullptr;
   uint64_t offset_ = 0;
   uint64_t size_in_bytes_ = 0;
   D3D12_RESOURCE_STATES resource_state_ = D3D12_RESOURCE_STATE_COMMON;

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -47,7 +47,7 @@ class D3D12BufferRegion {
   ID3D12Resource* ResourceInCopyDstState() const;
   uint64_t Offset() const;
   uint64_t SizeInBytes() const;
-  D3D12_RESOURCE_STATES ResourceState() const;
+  D3D12_RESOURCE_STATES ResourceState() const { return resource_state_; }
 
   DML_BUFFER_BINDING GetBufferBinding() const;
 

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -29,11 +29,12 @@ class D3D12BufferRegion {
   D3D12BufferRegion() = default;
 
   // References a region of a resource that remains in a fixed state.
-  D3D12BufferRegion(uint64_t offset, uint64_t size_in_bytes,
-                    D3D12_RESOURCE_STATES resource_state,
-                    ID3D12Resource* resource,
-                    ID3D12Resource* resource_copy_src_state = nullptr,
-                    ID3D12Resource* resource_copy_dst_state = nullptr);
+  D3D12BufferRegion(
+      uint64_t offset, uint64_t size_in_bytes,
+      D3D12_RESOURCE_STATES resource_state,
+      Microsoft::WRL::ComPtr<ID3D12Resource> resource,
+      Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state = nullptr,
+      Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state = nullptr);
 
   // Move-only
   D3D12BufferRegion(const D3D12BufferRegion&) = delete;
@@ -69,9 +70,9 @@ class D3D12BufferRegion {
   }
 
  private:
-  ID3D12Resource* resource_ = nullptr;
-  ID3D12Resource* resource_copy_src_state_ = nullptr;
-  ID3D12Resource* resource_copy_dst_state_ = nullptr;
+  Microsoft::WRL::ComPtr<ID3D12Resource> resource_;
+  Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state_;
+  Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state_;
   uint64_t offset_ = 0;
   uint64_t size_in_bytes_ = 0;
   D3D12_RESOURCE_STATES resource_state_ = D3D12_RESOURCE_STATE_COMMON;

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -40,8 +40,8 @@ class D3D12BufferRegion {
   // Move-only
   D3D12BufferRegion(const D3D12BufferRegion&) = delete;
   D3D12BufferRegion& operator=(const D3D12BufferRegion&) = delete;
-  D3D12BufferRegion(D3D12BufferRegion&&) = default;
-  D3D12BufferRegion& operator=(D3D12BufferRegion&&) = default;
+  D3D12BufferRegion(D3D12BufferRegion&&);
+  D3D12BufferRegion& operator=(D3D12BufferRegion&&);
 
   ID3D12Resource* ResourceInUavState() const;
 
@@ -56,7 +56,7 @@ class D3D12BufferRegion {
 
   DML_BUFFER_BINDING GetBufferBinding() const;
 
-  explicit operator bool() const { return resource_uav_state_ != nullptr; }
+  explicit operator bool() const { return first_valid_resource_ != nullptr; }
 
   // Creates a subregion at an offset from the start of this region. If no size
   // is provided the region runs to the end of the current region.

--- a/tensorflow/core/common_runtime/dml/dml_buffer_region.h
+++ b/tensorflow/core/common_runtime/dml/dml_buffer_region.h
@@ -56,7 +56,9 @@ class D3D12BufferRegion {
   // Creates a subregion at an offset from the start of this region. If no size is provided
   // the region runs to the end of the current region.
   inline D3D12BufferRegion Subregion(uint64_t offset, uint64_t size_in_bytes = 0) const {
+    CHECK(offset < size_in_bytes_); // start of subregion must be within current region
     size_in_bytes = size_in_bytes == 0 ? size_in_bytes_ - offset : size_in_bytes;
+    CHECK(size_in_bytes <= size_in_bytes_ - offset); // end of subregion must be within current region
     return D3D12BufferRegion(offset_ + offset, size_in_bytes, resource_state_,
                              resource_, resource_copy_src_state_,
                              resource_copy_dst_state_);

--- a/tensorflow/core/common_runtime/dml/dml_device.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device.cc
@@ -44,9 +44,7 @@ DmlDevice::DmlDevice(const DmlDeviceState* state, const SessionOptions& options,
   device_context_ = new DMLDeviceContext(
       state_->execution_context.get(), state_->event_queue.get(),
       state_->upload_heap.get(), state_->readback_heap.get(),
-      state_->dml_allocator.get(),
-      state_->descriptor_allocator.get()
-      );
+      state_->dml_allocator.get(), state_->descriptor_allocator.get());
   set_dml_device_context(device_context_);
 }
 

--- a/tensorflow/core/common_runtime/dml/dml_device.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device.cc
@@ -43,7 +43,10 @@ DmlDevice::DmlDevice(const DmlDeviceState* state, const SessionOptions& options,
 
   device_context_ = new DMLDeviceContext(
       state_->execution_context.get(), state_->event_queue.get(),
-      state_->upload_heap.get(), state_->readback_heap.get());
+      state_->upload_heap.get(), state_->readback_heap.get(),
+      state_->dml_allocator.get(),
+      state_->descriptor_allocator.get()
+      );
   set_dml_device_context(device_context_);
 }
 

--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -64,7 +64,8 @@ void DMLDeviceContext::CopyTensorInSameDevice(const Tensor* input_tensor,
   D3D12BufferRegion src = CreateBufferForTensor(*input_tensor);
   D3D12BufferRegion dst = CreateBufferForTensor(*output_tensor);
 
-  (void)execution_context_->CopyBufferRegion(dst, src.Subregion(0, total_bytes));
+  (void)execution_context_->CopyBufferRegion(dst,
+                                             src.Subregion(0, total_bytes));
 
   // Immediately signal completion even though we haven't actually kicked off
   // the GPU, or waited for it to complete. This is because from the framework's
@@ -195,8 +196,8 @@ DmlGpuEvent DMLDeviceContext::BindAndExecuteOperator(
   binding_table->BindOutputs(static_cast<UINT>(output_binding_descs.size()),
                              output_binding_descs.data());
 
-  return execution_context_->ExecuteOperator(
-      op, std::move(binding_table), heap_for_binding_table);
+  return execution_context_->ExecuteOperator(op, std::move(binding_table),
+                                             heap_for_binding_table);
 }
 
 DmlGpuEvent DMLDeviceContext::InsertUavBarrier() const {
@@ -243,13 +244,11 @@ DescriptorAllocation DMLDeviceContext::AllocateDescriptors(
 
 DmlGpuEvent DMLDeviceContext::CopyBufferToBuffer(
     const D3D12BufferRegion& dst, const D3D12BufferRegion& src) const {
-  return execution_context_->CopyBufferRegion(
-      dst, src);
+  return execution_context_->CopyBufferRegion(dst, src);
 }
 
 StatusOr<DmlGpuEvent> DMLDeviceContext::CopyHostToBuffer(
-    const D3D12BufferRegion& dst,
-    absl::Span<const uint8_t> src) const {
+    const D3D12BufferRegion& dst, absl::Span<const uint8_t> src) const {
   return upload_heap_->BeginUploadToGpu(dst, src);
 }
 
@@ -262,8 +261,7 @@ DmlGpuEvent DMLDeviceContext::ZeroBuffer(const D3D12BufferRegion& dst) const {
 // Fills dst region with a repeating byte pattern.
 DmlGpuEvent DMLDeviceContext::FillBufferWithPattern(
     const D3D12BufferRegion& dst, absl::Span<const uint8_t> value) const {
-  return execution_context_->FillBufferWithPattern(
-      dst, value);
+  return execution_context_->FillBufferWithPattern(dst, value);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -35,7 +35,7 @@ void DMLDeviceContext::CopyCPUTensorToDevice(const Tensor* cpu_tensor,
 
   const void* src_data = DMAHelper::base(cpu_tensor);
 
-  D3D12BufferRegion dst = CreateBufferForTensor(*device_tensor);
+  D3D12BufferRegion dst = GetBufferForTensor(*device_tensor);
 
   auto byte_span = absl::Span<const uint8_t>(
       static_cast<const uint8_t*>(src_data), total_bytes);
@@ -61,8 +61,8 @@ void DMLDeviceContext::CopyTensorInSameDevice(const Tensor* input_tensor,
     return;
   }
 
-  D3D12BufferRegion src = CreateBufferForTensor(*input_tensor);
-  D3D12BufferRegion dst = CreateBufferForTensor(*output_tensor);
+  D3D12BufferRegion src = GetBufferForTensor(*input_tensor);
+  D3D12BufferRegion dst = GetBufferForTensor(*output_tensor);
 
   (void)execution_context_->CopyBufferRegion(dst,
                                              src.Subregion(0, total_bytes));
@@ -85,7 +85,7 @@ void DMLDeviceContext::CopyDeviceTensorToCPU(const Tensor* device_tensor,
     return;
   }
 
-  D3D12BufferRegion src = CreateBufferForTensor(*device_tensor);
+  D3D12BufferRegion src = GetBufferForTensor(*device_tensor);
 
   void* dst_data = DMAHelper::base(cpu_tensor);
 
@@ -217,7 +217,7 @@ DmlBuffer DMLDeviceContext::AllocateDefaultBuffer(uint64_t num_bytes) const {
   return DmlBuffer(allocator_, num_bytes);
 }
 
-D3D12BufferRegion DMLDeviceContext::CreateBufferForTensor(
+D3D12BufferRegion DMLDeviceContext::GetBufferForTensor(
     const Tensor& tensor) const {
   const void* p = tensor.tensor_data().data();
 

--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -121,7 +121,6 @@ void DMLDeviceContext::CopyDeviceTensorToCPU(const Tensor* device_tensor,
   event_queue_->Enqueue(status_or_event.ConsumeValueOrDie(), callback);
 }
 
-// TODO: consider moving this code into EC outside of lock
 DmlGpuEvent DMLDeviceContext::BindAndInitializeOperator(
     IDMLOperatorInitializer* initializer,
     Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
@@ -146,7 +145,6 @@ DmlGpuEvent DMLDeviceContext::BindAndInitializeOperator(
       initializer, std::move(binding_table), heap_for_binding_table);
 }
 
-// TODO: consider moving this code into EC outside of lock
 DmlGpuEvent DMLDeviceContext::BindAndExecuteOperator(
     IDMLCompiledOperator* op,
     Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,

--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -221,12 +221,8 @@ D3D12BufferRegion DMLDeviceContext::GetBufferForTensor(
     const Tensor& tensor) const {
   const void* p = tensor.tensor_data().data();
 
-  // Important: we must use AllocatedBytes() here and not TotalBytes() because
-  // AllocatedBytes includes the necessary padding and alignment, whereas
-  // TotalBytes is exactly equal to the number of elements multiplied by the
-  // element size.
-  uint64_t size_in_bytes = tensor.AllocatedBytes();
-
+  // DirectML allocators copy by TotalBytes (not AllocatedBytes) and ignore alignment.
+  uint64_t size_in_bytes = tensor.TotalBytes();
   auto region = allocator_->CreateBufferRegion(p, size_in_bytes);
 
   // DML always requires at least 4 byte alignment in all cases, so both the

--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -221,8 +221,12 @@ D3D12BufferRegion DMLDeviceContext::GetBufferForTensor(
     const Tensor& tensor) const {
   const void* p = tensor.tensor_data().data();
 
-  // DirectML allocators copy by TotalBytes (not AllocatedBytes) and ignore alignment.
-  uint64_t size_in_bytes = tensor.TotalBytes();
+  // Important: we must use AllocatedBytes() here and not TotalBytes() because
+  // AllocatedBytes includes the necessary padding and alignment, whereas
+  // TotalBytes is exactly equal to the number of elements multiplied by the
+  // element size.
+  uint64_t size_in_bytes = tensor.AllocatedBytes();
+
   auto region = allocator_->CreateBufferRegion(p, size_in_bytes);
 
   // DML always requires at least 4 byte alignment in all cases, so both the

--- a/tensorflow/core/common_runtime/dml/dml_device_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.h
@@ -107,7 +107,7 @@ class DMLDeviceContext : public DeviceContext {
   DmlBuffer AllocateDefaultBuffer(uint64_t num_bytes) const;
 
   // Retrives the D3D12 default heap buffer backing the specified tensor.
-  D3D12BufferRegion CreateBufferForTensor(const Tensor& tensor) const;
+  D3D12BufferRegion GetBufferForTensor(const Tensor& tensor) const;
 
   // Allocates a range of D3D12 descriptors at least size_in_descriptors large.
   // When the returned object is destructed, the descriptors are freed back to

--- a/tensorflow/core/common_runtime/dml/dml_device_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.h
@@ -46,7 +46,7 @@ class DMLDeviceContext : public DeviceContext {
         event_queue_(event_queue),
         upload_heap_(upload_heap),
         readback_heap_(readback_heap),
-        allocator_(allocator), 
+        allocator_(allocator),
         descriptor_allocator_(descriptor_allocator) {}
 
   // --------------------------------

--- a/tensorflow/core/common_runtime/dml/dml_device_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.h
@@ -15,6 +15,9 @@ limitations under the License.
 
 #pragma once
 
+#include "dml_buffer.h"
+#include "dml_buffer_region.h"
+#include "dml_descriptor_bfc_allocator.h"
 #include "dml_event_queue.h"
 #include "dml_execution_context.h"
 #include "dml_readback_heap.h"
@@ -31,15 +34,24 @@ class DMLDeviceContext : public DeviceContext {
   DmlEventQueue* event_queue_;
   DmlUploadHeap* upload_heap_;
   DmlReadbackHeap* readback_heap_;
+  DmlAllocator* allocator_;
+  DmlDescriptorAllocator* descriptor_allocator_;
 
  public:
   DMLDeviceContext(DmlExecutionContext* execution_context,
                    DmlEventQueue* event_queue, DmlUploadHeap* upload_heap,
-                   DmlReadbackHeap* readback_heap)
+                   DmlReadbackHeap* readback_heap, DmlAllocator* allocator,
+                   DmlDescriptorAllocator* descriptor_allocator)
       : execution_context_(execution_context),
         event_queue_(event_queue),
         upload_heap_(upload_heap),
-        readback_heap_(readback_heap) {}
+        readback_heap_(readback_heap),
+        allocator_(allocator), 
+        descriptor_allocator_(descriptor_allocator) {}
+
+  // --------------------------------
+  // TF::DeviceContext Overrides
+  // --------------------------------
 
   void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                              Tensor* device_tensor, StatusCallback done,
@@ -52,6 +64,87 @@ class DMLDeviceContext : public DeviceContext {
   void CopyDeviceTensorToCPU(const Tensor* device_tensor, StringPiece edge_name,
                              Device* device, Tensor* cpu_tensor,
                              StatusCallback done) override;
+
+  // --------------------------------
+  // Allocation & Execution Helpers
+  // --------------------------------
+
+  // Initializes a given DML operator on the GPU. Note that this merely
+  // queues the initialization; the returned event will enter the signaled
+  // state when it completes. Note that we never supply any input bindings,
+  // because we never set DML_TENSOR_FLAG_OWNED_BY_DML .
+  DmlGpuEvent BindAndInitializeOperator(
+      IDMLOperatorInitializer* initializer,
+      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
+      ID3D12DescriptorHeap* heap_for_binding_table,
+      _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
+      _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding);
+
+  // Executes a DML operator. Note that this merely queues the execution; the
+  // returned event will enter the signaled state when it completes.
+  DmlGpuEvent BindAndExecuteOperator(
+      IDMLCompiledOperator* op,
+      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
+      ID3D12DescriptorHeap* heap_for_binding_table,
+      _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
+      _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding,
+      absl::Span<const absl::optional<DML_BUFFER_BINDING>> input_bindings,
+      absl::Span<const absl::optional<DML_BUFFER_BINDING>> output_bindings);
+
+  DmlGpuEvent InsertUavBarrier() const;
+
+  DmlGpuEvent GetCurrentCompletionEvent() const;
+
+  // Enqueues a callback to fire when the given GpuEvent enters the signaled
+  // state. Note that the callback may be invoked on an arbitrary thread, so it
+  // must be thread-safe.
+  void EnqueueCallbackForGpuEvent(DmlGpuEvent gpu_event,
+                                  std::function<void()> callback) const;
+
+  // Allocates a D3D12 default heap buffer which is at least num_bytes large.
+  // When the returned object is destructed, the memory is freed back to the
+  // pool.
+  DmlBuffer AllocateDefaultBuffer(uint64_t num_bytes) const;
+
+  // Retrives the D3D12 default heap buffer backing the specified tensor.
+  D3D12BufferRegion CreateBufferForTensor(const Tensor& tensor) const;
+
+  // Allocates a range of D3D12 descriptors at least size_in_descriptors large.
+  // When the returned object is destructed, the descriptors are freed back to
+  // the pool.
+  DescriptorAllocation AllocateDescriptors(size_t size_in_descriptors) const;
+
+  // Copies src to dst (dst needs to be at least as big as src).
+  DmlGpuEvent CopyBufferToBuffer(const D3D12BufferRegion& dst,
+                                 const D3D12BufferRegion& src) const;
+
+  // Copies src (host memory) to dst (dst needs to be at least as big as src).
+  StatusOr<DmlGpuEvent> CopyHostToBuffer(const D3D12BufferRegion& dst,
+                                         absl::Span<const uint8_t> src) const;
+
+  // Fills dst region with zeroes.
+  DmlGpuEvent ZeroBuffer(const D3D12BufferRegion& dst) const;
+
+  // Fills dst region with a repeating byte pattern.
+  DmlGpuEvent FillBufferWithPattern(const D3D12BufferRegion& dst,
+                                    absl::Span<const uint8_t> value) const;
+
+  // Fills dst region with a repeat value.
+  template <typename T>
+  DmlGpuEvent FillBufferWithValue(const D3D12BufferRegion& dst, T value) const {
+    static_assert(
+        sizeof(value) <= 16,
+        "FillBufferWithValue doesn't accept values bigger than 16 bytes.");
+
+    static_assert(
+        std::is_trivially_copyable<T>::value,
+        "FillBufferWithValue only accepts values that are trivially copyable.");
+
+    auto value_bytes = absl::Span<const uint8_t>(
+        reinterpret_cast<const uint8_t*>(&value), sizeof(value));
+
+    return FillBufferWithPattern(dst, value_bytes);
+  }
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -160,12 +160,9 @@ class DmlDeviceFactory : public DeviceFactory {
       const auto& adapter = device_cache.GetAdapter(i);
 
       tensorflow::GPUOptions adapter_gpu_options = gpu_options;
-      const bool is_uma_adapter = IsUmaAdapter(adapter);
-      if (is_uma_adapter) {
-        // For adapters with unified memory architecture (UMA), which use system
-        // memory, allocate memory as needed rather than all of it upfront.
-        adapter_gpu_options.set_allow_growth(true);
-      }
+
+      // Allocate memory as needed rather than consuming all of it upfront.
+      adapter_gpu_options.set_allow_growth(true);
 
       if (virtual_devices.empty() ||
           virtual_devices.Get(i).memory_limit_mb_size() == 0) {
@@ -175,7 +172,7 @@ class DmlDeviceFactory : public DeviceFactory {
           // limit as a fraction of TOTAL GPU memory
           uint64_t total_gpu_memory = adapter.GetTotalDedicatedMemory();
 
-          if (is_uma_adapter) {
+          if (IsUmaAdapter(adapter)) {
             // For adapters with unified memory architecture (UMA), add shared
             // memory to the total GPU memory
             total_gpu_memory += adapter.GetTotalSharedMemory();

--- a/tensorflow/core/common_runtime/dml/dml_device_state.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_state.cc
@@ -115,7 +115,8 @@ namespace tensorflow {
   (void)command_queue->QueryInterface(IID_PPV_ARGS(&sharing_contract));
 
   auto heap_allocator = absl::make_unique<D3D12HeapAllocator>(
-      d3d_device.Get(), CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+      d3d_device.Get(), command_queue.Get(),
+      CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
       D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS,
       D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
       D3D12_RESOURCE_STATE_UNORDERED_ACCESS);

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -113,9 +113,9 @@ DmlGpuEvent DmlExecutionContext::CopyBufferRegion(
     const D3D12BufferRegion& dst, const D3D12BufferRegion& src) {
   CHECK(src.SizeInBytes() <= dst.SizeInBytes());
   CHECK(dst.SizeInBytes() + dst.Offset() <=
-         dst.ResourceInFixedState()->GetDesc().Width);
+        dst.ResourceInFixedState()->GetDesc().Width);
   CHECK(src.SizeInBytes() + src.Offset() <=
-         src.ResourceInFixedState()->GetDesc().Width);
+        src.ResourceInFixedState()->GetDesc().Width);
 
   // Most D3D12BufferRegions have the same logical resource in three states:
   // UAV, COPY_SRC, and COPY_DST. Resources allocated through upload & readback

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.cc
@@ -111,10 +111,10 @@ DmlGpuEvent DmlExecutionContext::CopyBufferRegionRaw(
 
 DmlGpuEvent DmlExecutionContext::CopyBufferRegion(
     const D3D12BufferRegion& dst, const D3D12BufferRegion& src) {
-  DCHECK(src.SizeInBytes() <= dst.SizeInBytes());
-  DCHECK(dst.SizeInBytes() + dst.Offset() <=
+  CHECK(src.SizeInBytes() <= dst.SizeInBytes());
+  CHECK(dst.SizeInBytes() + dst.Offset() <=
          dst.ResourceInFixedState()->GetDesc().Width);
-  DCHECK(src.SizeInBytes() + src.Offset() <=
+  CHECK(src.SizeInBytes() + src.Offset() <=
          src.ResourceInFixedState()->GetDesc().Width);
 
   // Most D3D12BufferRegions have the same logical resource in three states:

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -70,8 +70,7 @@ class DmlExecutionContext {
 
   inline DmlGpuEvent FillBufferWithPattern(const D3D12BufferRegion& dst,
                                            absl::Span<const uint8_t> value) {
-    DCHECK(dst.ResourceState() == D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-    return FillBufferWithPatternRaw(dst.ResourceInFixedState(), dst.Offset(),
+    return FillBufferWithPatternRaw(dst.ResourceInUavState(), dst.Offset(),
                                     dst.SizeInBytes(), value);
   }
 

--- a/tensorflow/core/common_runtime/dml/dml_execution_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_execution_context.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <thread>
 #include <vector>
 
+#include "dml_buffer_region.h"
 #include "dml_command_allocator_ring.h"
 #include "dml_command_list.h"
 #include "dml_command_queue.h"
@@ -48,19 +49,31 @@ class DmlExecutionContext {
 
   // NOTE: the caller is responsible for keeping the dst_buffer/src_buffer
   // resources alive until the returned GPU event has completed.
-  DmlGpuEvent CopyBufferRegion(ID3D12Resource* dst_buffer, uint64_t dst_offset,
-                               D3D12_RESOURCE_STATES dst_state,
-                               ID3D12Resource* src_buffer, uint64_t src_offset,
-                               D3D12_RESOURCE_STATES src_state,
-                               uint64_t byte_count);
+  DmlGpuEvent CopyBufferRegionRaw(ID3D12Resource* dst_buffer,
+                                  uint64_t dst_offset,
+                                  D3D12_RESOURCE_STATES dst_state,
+                                  ID3D12Resource* src_buffer,
+                                  uint64_t src_offset,
+                                  D3D12_RESOURCE_STATES src_state,
+                                  uint64_t byte_count);
+
+  DmlGpuEvent CopyBufferRegion(const D3D12BufferRegion& dst,
+                               const D3D12BufferRegion& src);
 
   // NOTE: the caller is responsible for keeping the dst resource alive until
   // the returned GPU event has completed. A copy of the value span will be
   // made, so the pointed-to value is safe to release immediately after calling
   // this method.
-  DmlGpuEvent FillBufferWithPattern(ID3D12Resource* dst, uint64_t dst_offset,
-                                    uint64_t dst_size_in_bytes,
-                                    absl::Span<const uint8_t> value);
+  DmlGpuEvent FillBufferWithPatternRaw(ID3D12Resource* dst, uint64_t dst_offset,
+                                       uint64_t dst_size_in_bytes,
+                                       absl::Span<const uint8_t> value);
+
+  inline DmlGpuEvent FillBufferWithPattern(const D3D12BufferRegion& dst,
+                                           absl::Span<const uint8_t> value) {
+    DCHECK(dst.ResourceState() == D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    return FillBufferWithPatternRaw(dst.ResourceInFixedState(), dst.Offset(),
+                                    dst.SizeInBytes(), value);
+  }
 
   // NOTE: the caller is responsible for keeping the initializer and
   // descriptor_heap alive until the returned GPU event has completed. This

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
@@ -306,9 +306,10 @@ D3D12BufferRegion D3D12HeapAllocator::CreateBufferRegion(
 
   Allocation* allocation = &it->second;
 
-  return D3D12BufferRegion(
-      tagged_ptr.offset, size_in_bytes, allocation->resource_uav_state,
-      allocation->resource_copy_src_state, allocation->resource_copy_dst_state);
+  return D3D12BufferRegion(tagged_ptr.offset, size_in_bytes,
+                           allocation->resource_uav_state.Get(),
+                           allocation->resource_copy_src_state.Get(),
+                           allocation->resource_copy_dst_state.Get());
 }
 
 absl::optional<uint32_t> D3D12HeapAllocator::TryReserveAllocationID() {

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
@@ -303,9 +303,8 @@ D3D12BufferRegion D3D12HeapAllocator::CreateBufferRegion(
   Allocation* allocation = &it->second;
 
   return D3D12BufferRegion(
-      tagged_ptr.offset, size_in_bytes, initial_state_,
-      allocation->resource, allocation->resource_copy_src_state,
-      allocation->resource_copy_dst_state);
+      tagged_ptr.offset, size_in_bytes, initial_state_, allocation->resource,
+      allocation->resource_copy_src_state, allocation->resource_copy_dst_state);
 }
 
 absl::optional<uint32_t> D3D12HeapAllocator::TryReserveAllocationID() {

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
@@ -17,40 +17,232 @@ limitations under the License.
 
 #include "dml_util.h"
 #include "tensorflow/core/lib/strings/numbers.h"
-
+#include "tensorflow/core/util/env_var.h"
 namespace tensorflow {
 
+static bool GetTilingEnabled(ID3D12Device* device) {
+  bool force_placed_resources = false;
+  const char* force_placed_resources_string =
+      std::getenv("TF_DIRECTML_FORCE_PLACED_RESOURCES");
+  if (force_placed_resources_string != nullptr) {
+    if (strcmp("false", force_placed_resources_string) == 0) {
+      force_placed_resources = false;
+    } else if (strcmp("true", force_placed_resources_string) == 0) {
+      force_placed_resources = true;
+    } else {
+      LOG(ERROR) << "The TF_DIRECTML_FORCE_PLACED_RESOURCES environment "
+                    "variable is set "
+                    "but could"
+                 << " not be parsed: \"" << force_placed_resources_string
+                 << "\". Valid"
+                 << " values are \"true\" or \"false\". Using default value of "
+                    "\"false\".";
+    }
+  }
+
+  if (!force_placed_resources) {
+    D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
+    if (SUCCEEDED(device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS,
+                                              &options, sizeof(options)))) {
+      return options.TiledResourcesTier >= D3D12_TILED_RESOURCES_TIER_1;
+    }
+  }
+
+  return false;
+}
+
+static uint64_t GetMaxHeapSizeInTiles() {
+  int64 override_value = 0;
+  Status s =
+      ReadInt64FromEnvVar("TF_DIRECTML_MAX_HEAP_TILES", 0, &override_value);
+  if (s.ok() && override_value > 0) {
+    return static_cast<uint64_t>(override_value);
+  }
+
+  return D3D12HeapAllocator::kDefaultMaxHeapSizeInTiles;
+}
+
 D3D12HeapAllocator::D3D12HeapAllocator(ID3D12Device* device,
+                                       ID3D12CommandQueue* queue,
                                        const D3D12_HEAP_PROPERTIES& heap_props,
                                        D3D12_HEAP_FLAGS heap_flags,
                                        D3D12_RESOURCE_FLAGS resource_flags,
                                        D3D12_RESOURCE_STATES initial_state)
     : device_(device),
+      queue_(queue),
       heap_properties_(heap_props),
       heap_flags_(heap_flags),
       resource_flags_(resource_flags),
-      initial_state_(initial_state) {}
+      initial_state_(initial_state),
+      tiling_enabled_(GetTilingEnabled(device)),
+      max_heap_size_in_tiles_(GetMaxHeapSizeInTiles()) {
+  VLOG(1) << "Tiling enabled = " << tiling_enabled_;
+  VLOG(1) << "Max heap size in tiles = " << max_heap_size_in_tiles_;
+}
+
+absl::optional<D3D12HeapAllocator::Allocation>
+D3D12HeapAllocator::TryCreateTiledAllocation(uint64_t size_in_bytes) {
+  Allocation allocation = {};
+
+  // Initialize the pool with a single reserved resource. The resource may be
+  // larger than the requested size to ensure a whole number of tiles.
+  const uint64_t resource_size_in_tiles =
+      1 + (size_in_bytes - 1) / D3D12_TILED_RESOURCE_TILE_SIZE_IN_BYTES;
+  const uint64_t resource_size_in_bytes =
+      resource_size_in_tiles * D3D12_TILED_RESOURCE_TILE_SIZE_IN_BYTES;
+  auto resource_desc =
+      CD3DX12_RESOURCE_DESC::Buffer(resource_size_in_bytes, resource_flags_);
+
+  ID3D12Resource** resources[] = {&allocation.resource,
+                                  &allocation.resource_copy_src_state,
+                                  &allocation.resource_copy_dst_state};
+
+  D3D12_RESOURCE_STATES states[] = {initial_state_,
+                                    D3D12_RESOURCE_STATE_COPY_SOURCE,
+                                    D3D12_RESOURCE_STATE_COPY_DEST};
+
+  for (int i = 0; i < ARRAYSIZE(resources); i++) {
+    HRESULT create_resource_hr = device_->CreateReservedResource(
+        &resource_desc, states[i], nullptr, IID_PPV_ARGS(resources[i]));
+
+    if (dml_util::HrIsOutOfMemory(create_resource_hr)) {
+      LOG(WARNING) << "DML allocator out of memory!";
+      return absl::nullopt;
+    }
+    DML_CHECK_SUCCEEDED(create_resource_hr);
+  }
+
+  // Reserve enough heaps to store all tiles in the resource.
+  const uint64_t heap_count =
+      1 + (resource_size_in_tiles - 1) / max_heap_size_in_tiles_;
+  allocation.heaps.resize(heap_count);
+
+  // Create heaps and map them to the primary reserved resource.
+  D3D12_TILED_RESOURCE_COORDINATE resource_region_start_coordinates = {};
+  uint64_t unmapped_resource_tiles = resource_size_in_tiles;
+  for (uint64_t i = 0; i < heap_count; i++) {
+    // Create heap. The last heap of the allocation may have fewer tiles to
+    // avoid wasting space.
+    uint64_t heap_size_in_tiles =
+        std::min<uint64_t>(unmapped_resource_tiles, max_heap_size_in_tiles_);
+    uint64_t heap_size_in_bytes =
+        heap_size_in_tiles * D3D12_TILED_RESOURCE_TILE_SIZE_IN_BYTES;
+    auto heap_desc =
+        CD3DX12_HEAP_DESC(heap_size_in_bytes, heap_properties_, 0, heap_flags_);
+
+    HRESULT create_heap_hr =
+        device_->CreateHeap(&heap_desc, IID_PPV_ARGS(&allocation.heaps[i]));
+    if (dml_util::HrIsOutOfMemory(create_heap_hr)) {
+      LOG(WARNING) << "DML allocator out of memory!";
+      return absl::nullopt;
+    }
+    DML_CHECK_SUCCEEDED(create_heap_hr);
+
+    // Source region in the resource to map.
+    D3D12_TILE_REGION_SIZE resource_region_size = {};
+    resource_region_size.NumTiles = heap_size_in_tiles;
+
+    // Target range in the current heap to map.
+    const D3D12_TILE_RANGE_FLAGS tile_range_flags = D3D12_TILE_RANGE_FLAG_NONE;
+    const UINT heap_range_start_offset = 0;
+    const UINT heap_range_tile_count = heap_size_in_tiles;
+
+    constexpr UINT numResourceRegions = 1;
+    constexpr UINT numHeapRanges = 1;
+    queue_->UpdateTileMappings(allocation.resource.Get(), numResourceRegions,
+                               &resource_region_start_coordinates,
+                               &resource_region_size, allocation.heaps[i].Get(),
+                               numHeapRanges, &tile_range_flags,
+                               &heap_range_start_offset, &heap_range_tile_count,
+                               D3D12_TILE_MAPPING_FLAG_NONE);
+
+    resource_region_start_coordinates.X += heap_size_in_tiles;
+    unmapped_resource_tiles -= heap_size_in_tiles;
+  }
+
+  assert(unmapped_resource_tiles == 0);
+
+  // Copy tile mappings from the primary resource.
+  {
+    D3D12_TILED_RESOURCE_COORDINATE resource_start_coordinate = {};
+    D3D12_TILE_REGION_SIZE resource_region_size = {};
+    resource_region_size.NumTiles = resource_size_in_tiles;
+
+    queue_->CopyTileMappings(
+        allocation.resource_copy_src_state.Get(),  // dstResource
+        &resource_start_coordinate,                // dstCoordinate
+        allocation.resource.Get(),                 // srcResource
+        &resource_start_coordinate,                // srcCoordinate
+        &resource_region_size,                     // copy size
+        D3D12_TILE_MAPPING_FLAG_NONE);
+
+    queue_->CopyTileMappings(
+        allocation.resource_copy_dst_state.Get(),  // dstResource
+        &resource_start_coordinate,                // dstCoordinate
+        allocation.resource.Get(),                 // srcResource
+        &resource_start_coordinate,                // srcCoordinate
+        &resource_region_size,                     // copy size
+        D3D12_TILE_MAPPING_FLAG_NONE);
+  }
+
+  return allocation;
+}
+
+absl::optional<D3D12HeapAllocator::Allocation>
+D3D12HeapAllocator::TryCreateUntiledAllocation(uint64_t size_in_bytes) {
+  Allocation allocation = {};
+
+  // Create the allocation's sole heap.
+  allocation.heaps.resize(1);
+  D3D12_HEAP_DESC heap_desc =
+      CD3DX12_HEAP_DESC(size_in_bytes, heap_properties_, 0, heap_flags_);
+  HRESULT create_heap_hr =
+      device_->CreateHeap(&heap_desc, IID_PPV_ARGS(&allocation.heaps.front()));
+  if (dml_util::HrIsOutOfMemory(create_heap_hr)) {
+    LOG(WARNING) << "DML allocator out of memory!";
+    return absl::nullopt;
+  }
+  DML_CHECK_SUCCEEDED(create_heap_hr);
+
+  // Initialize the pool with a single placed resource.
+  D3D12_RESOURCE_DESC resource_desc =
+      CD3DX12_RESOURCE_DESC::Buffer(size_in_bytes, resource_flags_);
+
+  ID3D12Resource** resources[] = {&allocation.resource,
+                                  &allocation.resource_copy_src_state,
+                                  &allocation.resource_copy_dst_state};
+  D3D12_RESOURCE_STATES states[] = {initial_state_,
+                                    D3D12_RESOURCE_STATE_COPY_SOURCE,
+                                    D3D12_RESOURCE_STATE_COPY_DEST};
+
+  for (int i = 0; i < ARRAYSIZE(resources); i++) {
+    HRESULT create_resource_hr = device_->CreatePlacedResource(
+        allocation.heaps.front().Get(), 0, &resource_desc, states[i], nullptr,
+        IID_PPV_ARGS(resources[i]));
+    if (dml_util::HrIsOutOfMemory(create_resource_hr)) {
+      LOG(WARNING) << "DML allocator out of memory!";
+      return absl::nullopt;
+    }
+    DML_CHECK_SUCCEEDED(create_resource_hr);
+  }
+
+  return allocation;
+}
 
 void* D3D12HeapAllocator::Alloc(uint64_t size_in_bytes) {
   if (size_in_bytes == 0) {
     return nullptr;
   }
 
-  // The heap properties and flags are constant, and the D3D12 device is
-  // thread-safe so we don't need to hold the lock over the call to CreateHeap
-  D3D12_HEAP_DESC heap_desc =
-      CD3DX12_HEAP_DESC(size_in_bytes, heap_properties_, 0, heap_flags_);
+  // The D3D12 device is thread-safe so we don't need to hold the lock while
+  // creating an allocation.
+  absl::optional<Allocation> allocation =
+      tiling_enabled_ ? TryCreateTiledAllocation(size_in_bytes)
+                      : TryCreateUntiledAllocation(size_in_bytes);
 
-  Microsoft::WRL::ComPtr<ID3D12Heap> heap;
-  HRESULT hr = device_->CreateHeap(&heap_desc, IID_PPV_ARGS(&heap));
-
-  // Return early since we don't have enough memory to allocate the buffer
-  if (dml_util::HrIsOutOfMemory(hr)) {
-    LOG(WARNING) << "DML allocator out of memory!";
+  if (!allocation) {
     return nullptr;
   }
-
-  DML_CHECK_SUCCEEDED(hr);
 
   // We need to access (mutable) state after this point, so we need to lock
   std::unique_lock<std::mutex> lock(mutex_);
@@ -64,10 +256,7 @@ void* D3D12HeapAllocator::Alloc(uint64_t size_in_bytes) {
   VLOG(3) << "D3D12HeapAllocator: allocating id=" << *id << ", "
           << strings::HumanReadableNumBytes(size_in_bytes);
 
-  Allocation allocation = {};
-  allocation.heap = std::move(heap);
-
-  allocations_by_id_.emplace(*id, std::move(allocation));
+  allocations_by_id_.emplace(*id, std::move(*allocation));
 
   lock.unlock();
 
@@ -87,7 +276,6 @@ void D3D12HeapAllocator::Free(void* ptr, uint64_t size_in_bytes) {
   auto it = allocations_by_id_.find(tagged_ptr.allocation_id);
 
   CHECK(it != allocations_by_id_.end()) << "Invalid pointer";
-  DCHECK(it->second.heap->GetDesc().SizeInBytes == size_in_bytes);
 
   VLOG(3) << "D3D12HeapAllocator: freeing id=" << tagged_ptr.allocation_id
           << ", " << strings::HumanReadableNumBytes(size_in_bytes);
@@ -113,45 +301,10 @@ D3D12BufferRegion D3D12HeapAllocator::CreateBufferRegion(
 
   Allocation* allocation = &it->second;
 
-  // Retrieve a placed resource that spans the allocation's heap
-  Microsoft::WRL::ComPtr<ID3D12Resource> buffer;
-  if (!allocation->placed_resource_pool.empty()) {
-    // If there are spare resources in the pool, return one of those
-
-    buffer = std::move(allocation->placed_resource_pool.back());
-    allocation->placed_resource_pool.pop_back();
-  } else {
-    // No resources left in the pool; need to create one from scratch
-
-    D3D12_RESOURCE_DESC resource_desc = CD3DX12_RESOURCE_DESC::Buffer(
-        allocation->heap->GetDesc().SizeInBytes, resource_flags_);
-
-    DML_CHECK_SUCCEEDED(device_->CreatePlacedResource(
-        allocation->heap.Get(), 0, &resource_desc, initial_state_, nullptr,
-        IID_PPV_ARGS(&buffer)));
-  }
-
-  return D3D12BufferRegion(this, tagged_ptr.allocation_id, std::move(buffer),
-                           tagged_ptr.offset, size_in_bytes);
-}
-
-void D3D12HeapAllocator::ReleasePlacedResource(
-    uint32_t allocation_id, Microsoft::WRL::ComPtr<ID3D12Resource> resource) {
-  assert(resource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER);
-
-  std::unique_lock<std::mutex> lock(mutex_);
-
-  auto it = allocations_by_id_.find(allocation_id);
-  CHECK(it != allocations_by_id_.end());
-
-  Allocation* allocation = &it->second;
-
-  // If the sizes don't match, then it means this resource didn't come from this
-  // allocator...
-  assert(allocation->heap->GetDesc().SizeInBytes == resource->GetDesc().Width);
-
-  // Return the resource to the pool
-  allocation->placed_resource_pool.push_back(std::move(resource));
+  return D3D12BufferRegion(
+      tagged_ptr.offset, size_in_bytes, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+      allocation->resource, allocation->resource_copy_src_state,
+      allocation->resource_copy_dst_state);
 }
 
 absl::optional<uint32_t> D3D12HeapAllocator::TryReserveAllocationID() {

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
@@ -307,9 +307,9 @@ D3D12BufferRegion D3D12HeapAllocator::CreateBufferRegion(
   Allocation* allocation = &it->second;
 
   return D3D12BufferRegion(tagged_ptr.offset, size_in_bytes, initial_state_,
-                           allocation->resource.Get(),
-                           allocation->resource_copy_src_state.Get(),
-                           allocation->resource_copy_dst_state.Get());
+                           allocation->resource,
+                           allocation->resource_copy_src_state,
+                           allocation->resource_copy_dst_state);
 }
 
 absl::optional<uint32_t> D3D12HeapAllocator::TryReserveAllocationID() {

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
@@ -101,7 +101,7 @@ D3D12HeapAllocator::TryCreateTiledAllocation(uint64_t size_in_bytes) {
                                     D3D12_RESOURCE_STATE_COPY_SOURCE,
                                     D3D12_RESOURCE_STATE_COPY_DEST};
 
-  for (int i = 0; i < ARRAYSIZE(resources); i++) {
+  for (int i = 0; i < ABSL_ARRAYSIZE(resources); i++) {
     HRESULT create_resource_hr = device_->CreateReservedResource(
         &resource_desc, states[i], nullptr, IID_PPV_ARGS(resources[i]));
 
@@ -216,7 +216,7 @@ D3D12HeapAllocator::TryCreateUntiledAllocation(uint64_t size_in_bytes) {
                                     D3D12_RESOURCE_STATE_COPY_SOURCE,
                                     D3D12_RESOURCE_STATE_COPY_DEST};
 
-  for (int i = 0; i < ARRAYSIZE(resources); i++) {
+  for (int i = 0; i < ABSL_ARRAYSIZE(resources); i++) {
     HRESULT create_resource_hr = device_->CreatePlacedResource(
         allocation.heaps.front().Get(), 0, &resource_desc, states[i], nullptr,
         IID_PPV_ARGS(resources[i]));

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.cc
@@ -84,8 +84,8 @@ absl::optional<D3D12HeapAllocator::Allocation>
 D3D12HeapAllocator::TryCreateTiledAllocation(uint64_t size_in_bytes) {
   Allocation allocation = {};
 
-  // Initialize the pool with a single reserved resource. The resource may be
-  // larger than the requested size to ensure a whole number of tiles.
+  // The allocation may be larger than the requested size to ensure a whole
+  // number of tiles.
   const uint64_t resource_size_in_tiles =
       1 + (size_in_bytes - 1) / D3D12_TILED_RESOURCE_TILE_SIZE_IN_BYTES;
   const uint64_t resource_size_in_bytes =
@@ -192,7 +192,8 @@ absl::optional<D3D12HeapAllocator::Allocation>
 D3D12HeapAllocator::TryCreateUntiledAllocation(uint64_t size_in_bytes) {
   Allocation allocation = {};
 
-  // Create the allocation's sole heap.
+  // Create the allocation's sole heap. The allocation may be larger than the
+  // requested size to ensure a whole number of tiles.
   allocation.heaps.resize(1);
   D3D12_HEAP_DESC heap_desc =
       CD3DX12_HEAP_DESC(size_in_bytes, heap_properties_, 0, heap_flags_);
@@ -204,7 +205,7 @@ D3D12HeapAllocator::TryCreateUntiledAllocation(uint64_t size_in_bytes) {
   }
   DML_CHECK_SUCCEEDED(create_heap_hr);
 
-  // Initialize the pool with a single placed resource.
+  // Create large placed resource that spans the heap.
   D3D12_RESOURCE_DESC resource_desc =
       CD3DX12_RESOURCE_DESC::Buffer(size_in_bytes, resource_flags_);
 
@@ -302,7 +303,7 @@ D3D12BufferRegion D3D12HeapAllocator::CreateBufferRegion(
   Allocation* allocation = &it->second;
 
   return D3D12BufferRegion(
-      tagged_ptr.offset, size_in_bytes, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+      tagged_ptr.offset, size_in_bytes, initial_state_,
       allocation->resource, allocation->resource_copy_src_state,
       allocation->resource_copy_dst_state);
 }

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.h
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.h
@@ -115,7 +115,7 @@ class D3D12HeapAllocator {
     // resources; all three are wrapped by the buffer regions returned from this
     // allocator, and the appropriate resource will be used automatically when
     // performing buffer copies.
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource;
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource_uav_state;
     Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state;
     Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state;
   };

--- a/tensorflow/core/common_runtime/dml/dml_heap_allocator.h
+++ b/tensorflow/core/common_runtime/dml/dml_heap_allocator.h
@@ -21,8 +21,37 @@ limitations under the License.
 
 namespace tensorflow {
 
+// An allocator that makes logically contiguous allocations backed by D3D heaps.
+//
+// Heaps must fit entirely in either local or non-local memory. Larger heaps
+// have a greater chance of getting demoted into non-local memory, which can be
+// disastrous for performance. This problem is compounded by the fact that heaps
+// may be demoted even if overall local memory usage is within the process'
+// budget. Heaps are not necessarily mappable to discontiguous regions of
+// physical memory, which means physical memory fragmentation *may* make it
+// extremely difficult to accommodate larger heaps.
+//
+// On D3D hardware that supports tiled resource tier 1+ this class implements
+// large allocations through tiling. Each allocation is backed by however many
+// small heaps are necessary to cover the requested allocation size. Buffer
+// regions retrieved through this allocator are reserved resources that span the
+// full collection of heaps assigned to an individual allocation. Tile mappings
+// are static.
+//
+// On hardware that doesn't support tiled resources each allocation is backed by
+// a single heap. Buffer regions retrieved through this allocator are placed
+// resources that span the full heap assigned to an individual allocation. In
+// this case it is better make more but smaller allocations (resulting in
+// smaller heaps); this fallback path is only retained as a last resort for
+// older hardware.
 class D3D12HeapAllocator {
  public:
+  // Maximum size of a heap (in tiles) when allocations are tiled. Each tile is
+  // 64KB. A default size of 512 tiles (32MB) does a good job of handling local
+  // video memory fragmentation without requiring lots of heaps. This value can
+  // be overridden using the TF_DIRECTML_MAX_HEAP_TILES environment variable.
+  static constexpr uint64_t kDefaultMaxHeapSizeInTiles = 512;
+
   // The largest single allocation supported by this allocator. We use 4GB minus
   // a MB to avoid edge cases in hw/drivers that aren't expecting such large
   // allocations. This value can be overridden using the
@@ -30,31 +59,36 @@ class D3D12HeapAllocator {
   static constexpr uint64_t kDefaultMaxAllocationSizeInBytes =
       (1ull << 32) - (1ull << 20);
 
-  D3D12HeapAllocator(ID3D12Device* device,
+  D3D12HeapAllocator(ID3D12Device* device, ID3D12CommandQueue* queue,
                      const D3D12_HEAP_PROPERTIES& heap_props,
                      D3D12_HEAP_FLAGS heap_flags,
                      D3D12_RESOURCE_FLAGS resource_flags,
                      D3D12_RESOURCE_STATES initial_state);
 
-  // Creates a D3D12 placed resource buffer over the given memory range. The
-  // physical D3D12 resource may be larger than thet requested size, so callers
-  // must ensure to use the offset/size returned in the D3D12BufferRegion else
-  // risk out of bounds access. Note that in practice the ID3D12Resource is
-  // cached, so this call typically has a lower cost than a call to
-  // ID3D12Device::CreatePlacedResource.
+  // Creates a reserved or placed resource buffer over the given memory range.
+  // The physical D3D12 resource may be larger than the requested size, so
+  // callers must ensure to use the offset/size returned in the
+  // D3D12BufferRegion else risk out of bounds access. Note that in practice the
+  // ID3D12Resource is cached, so this call typically has a lower cost than a
+  // call to ID3D12Device::CreatePlacedResource or CreateReservedResource.
   D3D12BufferRegion CreateBufferRegion(const void* ptr, uint64_t size_in_bytes);
 
   void* Alloc(uint64_t size_in_bytes);
   void Free(void* ptr, uint64_t size_in_bytes);
 
+  bool TilingEnabled() const { return tiling_enabled_; };
+
  private:
   std::mutex mutex_;
 
   Microsoft::WRL::ComPtr<ID3D12Device> device_;
+  Microsoft::WRL::ComPtr<ID3D12CommandQueue> queue_;
   const D3D12_HEAP_PROPERTIES heap_properties_;
   const D3D12_HEAP_FLAGS heap_flags_;
   const D3D12_RESOURCE_FLAGS resource_flags_;
   const D3D12_RESOURCE_STATES initial_state_;
+  bool tiling_enabled_;
+  uint64_t max_heap_size_in_tiles_;
 
   // The largest allocation ID we've returned so far (or 0 if we've never done
   // so). Note that our allocation IDs start at 1 (not 0) to ensure that it
@@ -68,23 +102,25 @@ class D3D12HeapAllocator {
   std::vector<uint32_t> free_allocation_ids_;
 
   struct Allocation {
-    Microsoft::WRL::ComPtr<ID3D12Heap> heap;
+    // Heaps backing the memory for the allocation. If tiling is supported an
+    // allocation may comprise multiple heaps. If tiling is not supported an
+    // allocation will only have a single heap.
+    std::vector<Microsoft::WRL::ComPtr<ID3D12Heap>> heaps;
 
-    // A pool of placed resource buffers created over this allocation's heap.
-    // Each placed resource is identical, and covers the entire extent of its
-    // parent heap. When a caller wants to access a region of memory in this
-    // allocation's heap, one of these resources will be popped out of this
-    // vector (or if empty, a new one created) and returned. Once the caller is
-    // done with the resource, it is added back to the pool for re-use.
-    std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>> placed_resource_pool;
+    // Resources created over this allocation's heaps. All three resources are
+    // identical aside from being fixed in a single resource state: UAV,
+    // COPY_SRC, and COPY_DST respectively. The purpose of duplicate resources
+    // is to enable overlapping resources in different states for copying data.
+    // Most callers will not (and should not) interact directly with these
+    // resources; all three are wrapped by the buffer regions returned from this
+    // allocator, and the appropriate resource will be used automatically when
+    // performing buffer copies.
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource;
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_src_state;
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource_copy_dst_state;
   };
 
   absl::flat_hash_map<uint32_t, Allocation> allocations_by_id_;
-
-  // Releases a placed resource back to an allocation's pool. Called by
-  // D3D12BufferRegion when it gets destructed.
-  void ReleasePlacedResource(uint32_t allocation_id,
-                             Microsoft::WRL::ComPtr<ID3D12Resource> resource);
 
   // Retrieves a free allocation ID, or nullopt if no more IDs are available.
   absl::optional<uint32_t> TryReserveAllocationID();
@@ -113,6 +149,9 @@ class D3D12HeapAllocator {
 
   static void* PackPointer(uint32_t allocation_id, uint64_t offset);
   static TaggedPointer UnpackPointer(const void* ptr);
+
+  absl::optional<Allocation> TryCreateTiledAllocation(uint64_t size_in_bytes);
+  absl::optional<Allocation> TryCreateUntiledAllocation(uint64_t size_in_bytes);
 
   friend class D3D12BufferRegion;
 };

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.h
@@ -20,8 +20,8 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/dml/dml_buffer_region.h"
 #include "tensorflow/core/common_runtime/dml/dml_common.h"
 #include "tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.h"
-#include "tensorflow/core/common_runtime/dml/dml_gpu_event.h"
 #include "tensorflow/core/common_runtime/dml/dml_device_context.h"
+#include "tensorflow/core/common_runtime/dml/dml_gpu_event.h"
 #include "tensorflow/core/framework/op_kernel.h"
 
 namespace tensorflow {

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/dml/dml_common.h"
 #include "tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.h"
 #include "tensorflow/core/common_runtime/dml/dml_gpu_event.h"
+#include "tensorflow/core/common_runtime/dml/dml_device_context.h"
 #include "tensorflow/core/framework/op_kernel.h"
 
 namespace tensorflow {
@@ -40,37 +41,8 @@ class DmlKernelConstruction {
   IDMLDevice* GetDmlDevice() const;
   ID3D12Device* GetD3D12Device() const;
   OpKernelContext* GetOpKernelContext() const;
+  DMLDeviceContext* GetDmlDeviceContext() const;
   std::shared_ptr<const InitializationHelper> GetInitializationHelper() const;
-
-  // Allocates a D3D12 default heap buffer which is at least num_bytes large.
-  // When the returned object is destructed, the memory is freed back to the
-  // pool.
-  DmlBuffer AllocateDefaultBuffer(uint64_t num_bytes) const;
-
-  // Retrives the D3D12 default heap buffer backing the specified tensor.
-  D3D12BufferRegion CreateBufferForTensor(const Tensor& tensor) const;
-
-  // Allocates a range of D3D12 descriptors at least size_in_descriptors large.
-  // When the returned object is destructed, the descriptors are freed back to
-  // the pool.
-  DescriptorAllocation AllocateDescriptors(size_t size_in_descriptors) const;
-
-  // Enqueues a callback to fire when the given GpuEvent enters the signaled
-  // state. Note that the callback may be invoked on an arbitrary thread, so it
-  // must be thread-safe.
-  void EnqueueCallbackForGpuEvent(DmlGpuEvent gpu_event,
-                                  std::function<void()> callback) const;
-
-  // Initializes a given DML operator on the GPU. Note that this merely
-  // queues the initialization; the returned event will enter the signaled
-  // state when it completes. Note that we never supply any input bindings,
-  // because we never set DML_TENSOR_FLAG_OWNED_BY_DML .
-  DmlGpuEvent BindAndInitializeOperator(
-      IDMLOperatorInitializer* initializer,
-      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
-      ID3D12DescriptorHeap* heap_for_binding_table,
-      _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
-      _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding);
 
   // Input tensors
   uint32_t GetInputCount() const { return op_ctx_->num_inputs(); }
@@ -135,83 +107,12 @@ class DmlKernelContext {
   IDMLDevice* GetDmlDevice() const;
   ID3D12Device* GetD3D12Device() const;
   OpKernelContext* GetOpKernelContext() const;
+  DMLDeviceContext* GetDmlDeviceContext() const;
 
   template <typename T>
   const T* GetInitializationHelper() const {
     return static_cast<const T*>(init_helper_);
   }
-
-  // Allocates a D3D12 default heap buffer which is at least num_bytes large.
-  // When the returned object is destructed, the memory is freed back to the
-  // pool.
-  DmlBuffer AllocateDefaultBuffer(uint64_t num_bytes) const;
-
-  // Retrives the D3D12 default heap buffer backing the specified tensor.
-  D3D12BufferRegion CreateBufferForTensor(const Tensor& tensor) const;
-
-  // Allocates a range of D3D12 descriptors at least size_in_descriptors large.
-  // When the returned object is destructed, the descriptors are freed back to
-  // the pool.
-  DescriptorAllocation AllocateDescriptors(size_t size_in_descriptors) const;
-
-  // Enqueues a callback to fire when the given GpuEvent enters the signaled
-  // state. Note that the callback may be invoked on an arbitrary thread, so it
-  // must be thread-safe.
-  void EnqueueCallbackForGpuEvent(DmlGpuEvent gpu_event,
-                                  std::function<void()> callback) const;
-
-  // Executes a DML operator. Note that this merely queues the execution; the
-  // returned event will enter the signaled state when it completes.
-  DmlGpuEvent BindAndExecuteOperator(
-      IDMLCompiledOperator* op,
-      Microsoft::WRL::ComPtr<IDMLBindingTable>&& binding_table,
-      ID3D12DescriptorHeap* heap_for_binding_table,
-      _In_opt_ const DML_BUFFER_BINDING* temporary_resource_binding,
-      _In_opt_ const DML_BUFFER_BINDING* persistent_resource_binding,
-      absl::Span<const absl::optional<DML_BUFFER_BINDING>> input_bindings,
-      absl::Span<const absl::optional<DML_BUFFER_BINDING>> output_bindings);
-
-  // Copies src to dst (dst needs to be at at least as big as src)
-  DmlGpuEvent CopyBufferToBuffer(ID3D12Resource* dst, uint64_t dst_offset,
-                                 ID3D12Resource* src, uint64_t src_offset,
-                                 uint64 size_in_bytes) const;
-
-  // Copies src (host memory) to dst (dst needs to be at least as big as src).
-  StatusOr<DmlGpuEvent> CopyHostToBuffer(ID3D12Resource* dst,
-                                         uint64_t dst_offset,
-                                         absl::Span<const uint8_t> src) const;
-
-  // Sets a region of the destination buffer to zero.
-  DmlGpuEvent ZeroBuffer(ID3D12Resource* dst, uint64_t offset,
-                         uint64_t size_in_bytes) const;
-  DmlGpuEvent ZeroBuffer(const D3D12BufferRegion& dst) const;
-
-  template <typename T>
-  DmlGpuEvent FillBufferWithValue(ID3D12Resource* dst, uint64_t offset,
-                                  uint64_t size_in_bytes, T value) const {
-    static_assert(
-        sizeof(value) <= 16,
-        "FillBufferWithValue doesn't accept values bigger than 16 bytes.");
-
-    static_assert(
-        std::is_trivially_copyable<T>::value,
-        "FillBufferWithValue only accepts values that are trivially copyable.");
-
-    auto value_bytes = absl::Span<const uint8_t>(
-        reinterpret_cast<const uint8_t*>(&value), sizeof(value));
-
-    return FillBufferWithPattern(dst, offset, size_in_bytes, value_bytes);
-  }
-
-  template <typename T>
-  DmlGpuEvent FillBufferWithValue(const D3D12BufferRegion& dst, T value) const {
-    return FillBufferWithValue(dst.Resource(), dst.Offset(), dst.SizeInBytes(),
-                               value);
-  }
-
-  DmlGpuEvent InsertUavBarrier() const;
-
-  DmlGpuEvent GetCurrentCompletionEvent() const;
 
   Tensor GetInputTensor(int index) const {
     return op_ctx_->input_is_ref(index) ? op_ctx_->mutable_input(index, false)
@@ -223,10 +124,6 @@ class DmlKernelContext {
   uint32_t GetOutputCount() const { return op_ctx_->num_outputs(); }
 
  private:
-  DmlGpuEvent FillBufferWithPattern(ID3D12Resource* dst, uint64_t offset,
-                                    uint64_t size_in_bytes,
-                                    absl::Span<const uint8_t> pattern) const;
-
   const DmlDevice* device_;
   OpKernelContext* op_ctx_;
   const InitializationHelper* init_helper_;

--- a/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
@@ -65,8 +65,8 @@ StatusOr<DmlGpuEvent> DmlReadbackHeap::ReadbackFromGpu(
   // Copy from the source resource into the readback heap. `gpu_done_event` is
   // the event that will be signaled when the copy to the readback heap
   // completes on the GPU.
-  DmlGpuEvent gpu_done_event =
-      execution_context_->CopyBufferRegion(readback_resource, src.Subregion(0, dst.size()));
+  DmlGpuEvent gpu_done_event = execution_context_->CopyBufferRegion(
+      readback_resource, src.Subregion(0, dst.size()));
 
   // Get the event which will become signaled once the readback into `dst` has
   // fully completed on the CPU.

--- a/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_readback_heap.cc
@@ -58,9 +58,13 @@ StatusOr<DmlGpuEvent> DmlReadbackHeap::ReadbackFromGpu(
 
   ID3D12Resource* readback_heap = chunk->resource.Get();
 
-  auto readback_resource =
-      D3D12BufferRegion(offset_in_chunk, dst.size(),
-                        D3D12_RESOURCE_STATE_COPY_DEST, chunk->resource.Get());
+  // Allocations from the readback pool are only ever used as copy destinations.
+  auto readback_resource = D3D12BufferRegion(offset_in_chunk,       // offset
+                                             dst.size(),            // size,
+                                             nullptr,               // uav state
+                                             nullptr,               // copy src
+                                             chunk->resource.Get()  // copy dst
+  );
 
   // Copy from the source resource into the readback heap. `gpu_done_event` is
   // the event that will be signaled when the copy to the readback heap

--- a/tensorflow/core/common_runtime/dml/dml_readback_heap.h
+++ b/tensorflow/core/common_runtime/dml/dml_readback_heap.h
@@ -34,9 +34,7 @@ class DmlReadbackHeap : public DmlPooledHeap {
   // event becomes signaled. Both the dst buffer and src resource must stay
   // alive until the copy is complete.
   StatusOr<DmlGpuEvent> ReadbackFromGpu(absl::Span<uint8_t> dst,
-                                        ID3D12Resource* src,
-                                        uint64_t src_offset,
-                                        D3D12_RESOURCE_STATES src_state);
+                                        const D3D12BufferRegion& src);
 
  private:
   std::mutex mutex_;

--- a/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
@@ -58,9 +58,13 @@ StatusOr<DmlGpuEvent> DmlUploadHeap::BeginUploadToGpu(
          src.size());
   chunk->resource->Unmap(0, nullptr);
 
-  auto upload_resource = D3D12BufferRegion(offset_in_chunk, src.size(),
-                                           D3D12_RESOURCE_STATE_GENERIC_READ,
-                                           chunk->resource.Get());
+  // Allocations from the upload pool are only ever used as copy sources.
+  auto upload_resource = D3D12BufferRegion(offset_in_chunk,        // offset
+                                           src.size(),             // size,
+                                           nullptr,                // uav state
+                                           chunk->resource.Get(),  // copy src
+                                           nullptr                 // copy dst
+  );
 
   // Copy from the upload heap into the destination resource
   DmlGpuEvent done_event =

--- a/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
+++ b/tensorflow/core/common_runtime/dml/dml_upload_heap.cc
@@ -63,8 +63,8 @@ StatusOr<DmlGpuEvent> DmlUploadHeap::BeginUploadToGpu(
                                            chunk->resource.Get());
 
   // Copy from the upload heap into the destination resource
-  DmlGpuEvent done_event = execution_context_->CopyBufferRegion(
-      dst, upload_resource);
+  DmlGpuEvent done_event =
+      execution_context_->CopyBufferRegion(dst, upload_resource);
 
   // Add an allocation entry to the chunk
   chunk->allocations.push_back(Allocation{static_cast<uint64_t>(src.size()),

--- a/tensorflow/core/common_runtime/dml/dml_upload_heap.h
+++ b/tensorflow/core/common_runtime/dml/dml_upload_heap.h
@@ -33,9 +33,7 @@ class DmlUploadHeap : public DmlPooledHeap {
   // resource, and returns a DmlGpuEvent which will become signaled when the
   // copy is complete. The destination resource must be a default or readback
   // buffer.
-  StatusOr<DmlGpuEvent> BeginUploadToGpu(ID3D12Resource* dst,
-                                         uint64_t dst_offset,
-                                         D3D12_RESOURCE_STATES dst_state,
+  StatusOr<DmlGpuEvent> BeginUploadToGpu(const D3D12BufferRegion& dst,
                                          absl::Span<const uint8_t> src);
 
  private:

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -314,8 +314,12 @@ D3D12BufferRegion GetBufferForTensor(const DmlDevice* device,
   DmlAllocator* allocator = device->GetAllocator();
   const void* p = tensor.tensor_data().data();
 
-  // DirectML allocators copy by TotalBytes (not AllocatedBytes) and ignore alignment.
-  uint64_t size_in_bytes = tensor.TotalBytes();
+  // Important: we must use AllocatedBytes() here and not TotalBytes() because
+  // AllocatedBytes includes the necessary padding and alignment, whereas
+  // TotalBytes is exactly equal to the number of elements multiplied by the
+  // element size.
+  uint64_t size_in_bytes = tensor.AllocatedBytes();
+
   auto region = allocator->CreateBufferRegion(p, size_in_bytes);
 
   // DML always requires at least 4 byte alignment in all cases, so both the

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -314,12 +314,8 @@ D3D12BufferRegion GetBufferForTensor(const DmlDevice* device,
   DmlAllocator* allocator = device->GetAllocator();
   const void* p = tensor.tensor_data().data();
 
-  // Important: we must use AllocatedBytes() here and not TotalBytes() because
-  // AllocatedBytes includes the necessary padding and alignment, whereas
-  // TotalBytes is exactly equal to the number of elements multiplied by the
-  // element size.
-  uint64_t size_in_bytes = tensor.AllocatedBytes();
-
+  // DirectML allocators copy by TotalBytes (not AllocatedBytes) and ignore alignment.
+  uint64_t size_in_bytes = tensor.TotalBytes();
   auto region = allocator->CreateBufferRegion(p, size_in_bytes);
 
   // DML always requires at least 4 byte alignment in all cases, so both the

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -309,8 +309,8 @@ void CopyTensorInSameDevice(OpKernelContext* op_ctx, Tensor* dst,
       [op_ctx](const Status& s) { OP_REQUIRES_OK(op_ctx, s); });
 }
 
-D3D12BufferRegion CreateBufferForTensor(const DmlDevice* device,
-                                        const Tensor& tensor) {
+D3D12BufferRegion GetBufferForTensor(const DmlDevice* device,
+                                     const Tensor& tensor) {
   DmlAllocator* allocator = device->GetAllocator();
   const void* p = tensor.tensor_data().data();
 

--- a/tensorflow/core/common_runtime/dml/dml_util.h
+++ b/tensorflow/core/common_runtime/dml/dml_util.h
@@ -87,8 +87,8 @@ namespace dml_util {
 void CopyTensorInSameDevice(OpKernelContext* op_ctx, Tensor* dst,
                             const Tensor& src);
 
-D3D12BufferRegion CreateBufferForTensor(const DmlDevice* device,
-                                        const Tensor& tensor);
+D3D12BufferRegion GetBufferForTensor(const DmlDevice* device,
+                                     const Tensor& tensor);
 
 // Calls D3D12BufferRegion::GetBufferBinding on each of the buffers and returns
 // the result.

--- a/tensorflow/core/kernels/dml_cast_op.cc
+++ b/tensorflow/core/kernels/dml_cast_op.cc
@@ -93,7 +93,8 @@ class DmlCastKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cast_op.cc
+++ b/tensorflow/core/kernels/dml_cast_op.cc
@@ -93,7 +93,7 @@ class DmlCastKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cast_op.cc
+++ b/tensorflow/core/kernels/dml_cast_op.cc
@@ -94,7 +94,7 @@ class DmlCastKernel : public DmlKernel {
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
       ctx->GetDmlDeviceContext()->ZeroBuffer(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_check_numerics_op.cc
+++ b/tensorflow/core/kernels/dml_check_numerics_op.cc
@@ -149,12 +149,10 @@ class DmlCheckNumericsKernel : public DmlKernel {
       D3D12BufferRegion output_buffer =
           dml_util::CreateBufferForTensor(device, *output_tensor);
 
-      ctx->CopyBufferToBuffer(output_buffer.Resource(), output_buffer.Offset(),
-                              input_buffer.Resource(), input_buffer.Offset(),
-                              output_tensor->TotalBytes());
+      ctx->GetDmlDeviceContext()->CopyBufferToBuffer(output_buffer, input_buffer.Subregion(0, output_tensor->TotalBytes()));
     }
 
-    return ctx->GetCurrentCompletionEvent();
+    return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();
   }
 
  private:

--- a/tensorflow/core/kernels/dml_check_numerics_op.cc
+++ b/tensorflow/core/kernels/dml_check_numerics_op.cc
@@ -144,10 +144,10 @@ class DmlCheckNumericsKernel : public DmlKernel {
     } else {
       // If everything is fine, we simply copy the input to the output
       D3D12BufferRegion input_buffer =
-          dml_util::CreateBufferForTensor(device, ctx->GetInputTensor(0));
+          dml_util::GetBufferForTensor(device, ctx->GetInputTensor(0));
 
       D3D12BufferRegion output_buffer =
-          dml_util::CreateBufferForTensor(device, *output_tensor);
+          dml_util::GetBufferForTensor(device, *output_tensor);
 
       ctx->GetDmlDeviceContext()->CopyBufferToBuffer(
           output_buffer,

--- a/tensorflow/core/kernels/dml_check_numerics_op.cc
+++ b/tensorflow/core/kernels/dml_check_numerics_op.cc
@@ -149,7 +149,9 @@ class DmlCheckNumericsKernel : public DmlKernel {
       D3D12BufferRegion output_buffer =
           dml_util::CreateBufferForTensor(device, *output_tensor);
 
-      ctx->GetDmlDeviceContext()->CopyBufferToBuffer(output_buffer, input_buffer.Subregion(0, output_tensor->TotalBytes()));
+      ctx->GetDmlDeviceContext()->CopyBufferToBuffer(
+          output_buffer,
+          input_buffer.Subregion(0, output_tensor->TotalBytes()));
     }
 
     return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -161,7 +161,8 @@ class DmlCompositeBinaryKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -267,7 +268,8 @@ class DmlCompositeUnaryKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -752,7 +754,8 @@ class DmlBinaryWithZeroKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -161,7 +161,7 @@ class DmlCompositeBinaryKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -267,7 +267,7 @@ class DmlCompositeUnaryKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -752,7 +752,7 @@ class DmlBinaryWithZeroKernel : public DmlKernel {
 
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -162,7 +162,7 @@ class DmlCompositeBinaryKernel : public DmlKernel {
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
       ctx->GetDmlDeviceContext()->ZeroBuffer(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -269,7 +269,7 @@ class DmlCompositeUnaryKernel : public DmlKernel {
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
       ctx->GetDmlDeviceContext()->ZeroBuffer(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);
@@ -755,7 +755,7 @@ class DmlBinaryWithZeroKernel : public DmlKernel {
     // TFDML #24881131
     if (Is64BitUnsignedIntegerType(output->dtype())) {
       ctx->GetDmlDeviceContext()->ZeroBuffer(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_data_format_dim_map.cc
+++ b/tensorflow/core/kernels/dml_data_format_dim_map.cc
@@ -198,7 +198,8 @@ class DmlDataFormaDimMapKernel : public DmlKernel {
     // Since we gather uint8 values with strides of 4 or 8, we always need to
     // zero the buffer
     Tensor* output = ctx->GetOutputTensor(0);
-    ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+    ctx->GetDmlDeviceContext()->ZeroBuffer(
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     return DmlKernel::Compute(ctx);
   }
 };

--- a/tensorflow/core/kernels/dml_data_format_dim_map.cc
+++ b/tensorflow/core/kernels/dml_data_format_dim_map.cc
@@ -199,7 +199,7 @@ class DmlDataFormaDimMapKernel : public DmlKernel {
     // zero the buffer
     Tensor* output = ctx->GetOutputTensor(0);
     ctx->GetDmlDeviceContext()->ZeroBuffer(
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
     return DmlKernel::Compute(ctx);
   }
 };

--- a/tensorflow/core/kernels/dml_data_format_dim_map.cc
+++ b/tensorflow/core/kernels/dml_data_format_dim_map.cc
@@ -198,7 +198,7 @@ class DmlDataFormaDimMapKernel : public DmlKernel {
     // Since we gather uint8 values with strides of 4 or 8, we always need to
     // zero the buffer
     Tensor* output = ctx->GetOutputTensor(0);
-    ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+    ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     return DmlKernel::Compute(ctx);
   }
 };

--- a/tensorflow/core/kernels/dml_data_format_vec_permute.cc
+++ b/tensorflow/core/kernels/dml_data_format_vec_permute.cc
@@ -165,7 +165,8 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
     OP_REQUIRES_OK(ctx, ctx->allocate_output(0, input_shape, &output));
 
     DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
-    auto device_context = static_cast<DMLDeviceContext*>(ctx->op_device_context());
+    auto device_context =
+        static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
     D3D12BufferRegion input_buffer =
         dml_util::CreateBufferForTensor(device, input);

--- a/tensorflow/core/kernels/dml_data_format_vec_permute.cc
+++ b/tensorflow/core/kernels/dml_data_format_vec_permute.cc
@@ -169,10 +169,10 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
         static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
     D3D12BufferRegion input_buffer =
-        dml_util::CreateBufferForTensor(device, input);
+        dml_util::GetBufferForTensor(device, input);
 
     D3D12BufferRegion output_buffer =
-        dml_util::CreateBufferForTensor(device, *output);
+        dml_util::GetBufferForTensor(device, *output);
 
     const int perm_stride = DataTypeSize(input.dtype()) * input_shape.dims();
 

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -42,28 +42,7 @@ class DmlDeepCopyKernel : public OpKernel {
     D3D12BufferRegion output_buffer =
         dml_util::CreateBufferForTensor(device, *output);
 
-    std::array<D3D12_RESOURCE_BARRIER, 2> barriers = {
-        CD3DX12_RESOURCE_BARRIER::Transition(
-            input_buffer.Resource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_COPY_SOURCE),
-        CD3DX12_RESOURCE_BARRIER::Transition(
-            output_buffer.Resource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_COPY_DEST),
-    };
-
-    execution_context->ResourceBarrier(barriers);
-
-    execution_context->CopyBufferRegion(
-        output_buffer.Resource(), output_buffer.Offset(),
-        D3D12_RESOURCE_STATE_COPY_DEST, input_buffer.Resource(),
-        input_buffer.Offset(), D3D12_RESOURCE_STATE_COPY_SOURCE,
-        output_buffer.SizeInBytes());
-
-    for (auto& barrier : barriers) {
-      std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
-    }
-
-    execution_context->ResourceBarrier(barriers);
+    execution_context->CopyBufferRegion(output_buffer, input_buffer);
   }
 };
 

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -42,10 +42,11 @@ class DmlDeepCopyKernel : public OpKernel {
     D3D12BufferRegion output_buffer =
         dml_util::CreateBufferForTensor(device, *output);
 
-    uint64_t copy_size = std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());
+    uint64_t copy_size =
+        std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());
 
-    execution_context->CopyBufferRegion(
-        output_buffer, input_buffer.Subregion(0, copy_size));
+    execution_context->CopyBufferRegion(output_buffer,
+                                        input_buffer.Subregion(0, copy_size));
   }
 };
 

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -37,10 +37,10 @@ class DmlDeepCopyKernel : public OpKernel {
     const auto& execution_context = device->GetExecutionContext();
 
     D3D12BufferRegion input_buffer =
-        dml_util::CreateBufferForTensor(device, input);
+        dml_util::GetBufferForTensor(device, input);
 
     D3D12BufferRegion output_buffer =
-        dml_util::CreateBufferForTensor(device, *output);
+        dml_util::GetBufferForTensor(device, *output);
 
     uint64_t copy_size =
         std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -42,7 +42,10 @@ class DmlDeepCopyKernel : public OpKernel {
     D3D12BufferRegion output_buffer =
         dml_util::CreateBufferForTensor(device, *output);
 
-    execution_context->CopyBufferRegion(output_buffer, input_buffer);
+    uint64_t copy_size = std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());
+
+    execution_context->CopyBufferRegion(
+        output_buffer, input_buffer.Subregion(0, copy_size));
   }
 };
 

--- a/tensorflow/core/kernels/dml_diag_op.cc
+++ b/tensorflow/core/kernels/dml_diag_op.cc
@@ -137,7 +137,7 @@ class DmlDiagKernel : public DmlKernel {
     // Zero the buffer since we use strides to skip over elements
     Tensor* output = ctx->GetOutputTensor(0);
     ctx->GetDmlDeviceContext()->ZeroBuffer(
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
 
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_diag_op.cc
+++ b/tensorflow/core/kernels/dml_diag_op.cc
@@ -136,7 +136,8 @@ class DmlDiagKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Zero the buffer since we use strides to skip over elements
     Tensor* output = ctx->GetOutputTensor(0);
-    ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+    ctx->GetDmlDeviceContext()->ZeroBuffer(
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
 
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_diag_op.cc
+++ b/tensorflow/core/kernels/dml_diag_op.cc
@@ -136,7 +136,7 @@ class DmlDiagKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     // Zero the buffer since we use strides to skip over elements
     Tensor* output = ctx->GetOutputTensor(0);
-    ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+    ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
 
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
@@ -114,13 +114,13 @@ class DmlDynamicStitchKernel : public OpKernel {
       }
 
       D3D12BufferRegion input_buffer =
-          dml_util::CreateBufferForTensor(device, data_tensor);
+          dml_util::GetBufferForTensor(device, data_tensor);
 
       input_buffers.push_back(std::move(input_buffer));
     }
 
     D3D12BufferRegion output_buffer =
-        dml_util::CreateBufferForTensor(device, *output_tensor);
+        dml_util::GetBufferForTensor(device, *output_tensor);
 
     DCHECK(indices_inputs.size() == data_inputs.size());
     for (int tensor_idx = 0; tensor_idx < indices_inputs.size(); ++tensor_idx) {

--- a/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
@@ -141,7 +141,8 @@ class DmlDynamicStitchKernel : public OpKernel {
         const uint64_t src_offset = byte_stride * i;
         const uint64_t dst_offset = byte_stride * output_idx;
 
-        auto device_context = static_cast<DMLDeviceContext*>(ctx->op_device_context());
+        auto device_context =
+            static_cast<DMLDeviceContext*>(ctx->op_device_context());
         device_context->CopyBufferToBuffer(
             output_buffer.Subregion(dst_offset),
             input_buffer.Subregion(src_offset, byte_stride));

--- a/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
@@ -96,6 +96,8 @@ class DmlDynamicStitchKernel : public OpKernel {
     }
 
     DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
+    auto* device_context =
+        static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
     const uint64_t data_type_size = DataTypeSize(ctx->expected_output_dtype(0));
 
@@ -104,9 +106,6 @@ class DmlDynamicStitchKernel : public OpKernel {
 
     std::vector<D3D12BufferRegion> input_buffers;
     input_buffers.reserve(data_inputs.size());
-
-    std::vector<D3D12_RESOURCE_BARRIER> barriers;
-    barriers.reserve(data_inputs.size() + 1);
 
     for (const Tensor& data_tensor : data_inputs) {
       if (data_tensor.NumElements() == 0) {
@@ -117,21 +116,11 @@ class DmlDynamicStitchKernel : public OpKernel {
       D3D12BufferRegion input_buffer =
           dml_util::CreateBufferForTensor(device, data_tensor);
 
-      barriers.push_back(CD3DX12_RESOURCE_BARRIER::Transition(
-          input_buffer.Resource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-          D3D12_RESOURCE_STATE_COPY_SOURCE));
-
       input_buffers.push_back(std::move(input_buffer));
     }
 
     D3D12BufferRegion output_buffer =
         dml_util::CreateBufferForTensor(device, *output_tensor);
-
-    barriers.push_back(CD3DX12_RESOURCE_BARRIER::Transition(
-        output_buffer.Resource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-        D3D12_RESOURCE_STATE_COPY_DEST));
-
-    device->GetExecutionContext()->ResourceBarrier(barriers);
 
     DCHECK(indices_inputs.size() == data_inputs.size());
     for (int tensor_idx = 0; tensor_idx < indices_inputs.size(); ++tensor_idx) {
@@ -149,22 +138,15 @@ class DmlDynamicStitchKernel : public OpKernel {
       for (int i = 0; i < indices_tensor.NumElements(); ++i) {
         int32 output_idx = indices(i);
 
-        const uint64_t src_offset = input_buffer.Offset() + byte_stride * i;
-        const uint64_t dst_offset =
-            output_buffer.Offset() + byte_stride * output_idx;
+        const uint64_t src_offset = byte_stride * i;
+        const uint64_t dst_offset = byte_stride * output_idx;
 
-        device->GetExecutionContext()->CopyBufferRegion(
-            output_buffer.Resource(), dst_offset,
-            D3D12_RESOURCE_STATE_COPY_DEST, input_buffer.Resource(), src_offset,
-            D3D12_RESOURCE_STATE_COPY_SOURCE, byte_stride);
+        auto device_context = static_cast<DMLDeviceContext*>(ctx->op_device_context());
+        device_context->CopyBufferToBuffer(
+            output_buffer.Subregion(dst_offset),
+            input_buffer.Subregion(src_offset, byte_stride));
       }
     }
-
-    for (auto& barrier : barriers) {
-      std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
-    }
-
-    device->GetExecutionContext()->ResourceBarrier(barriers);
   }
 };
 

--- a/tensorflow/core/kernels/dml_empty_op.cc
+++ b/tensorflow/core/kernels/dml_empty_op.cc
@@ -47,7 +47,7 @@ class DmlEmptyKernel : public OpKernel {
           static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
       D3D12BufferRegion output_buffer =
-          dml_util::CreateBufferForTensor(device, *output_tensor);
+          dml_util::GetBufferForTensor(device, *output_tensor);
 
       device_context->ZeroBuffer(output_buffer);
     }

--- a/tensorflow/core/kernels/dml_empty_op.cc
+++ b/tensorflow/core/kernels/dml_empty_op.cc
@@ -43,15 +43,13 @@ class DmlEmptyKernel : public OpKernel {
 
     if (init_ && out_shape.num_elements() > 0) {
       DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
+      auto device_context =
+          static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
       D3D12BufferRegion output_buffer =
           dml_util::CreateBufferForTensor(device, *output_tensor);
 
-      uint8_t pattern[] = {0};
-
-      device->GetExecutionContext()->FillBufferWithPattern(
-          output_buffer.Resource(), output_buffer.Offset(),
-          output_buffer.SizeInBytes(), pattern);
+      device_context->ZeroBuffer(output_buffer);
     }
   }
 

--- a/tensorflow/core/kernels/dml_gather_nd_op.cc
+++ b/tensorflow/core/kernels/dml_gather_nd_op.cc
@@ -302,7 +302,8 @@ class DmlGatherNdKernel : public DmlKernel {
 
     // Create input buffers
     absl::InlinedVector<D3D12BufferRegion, 2> input_buffers;
-    input_buffers.push_back(ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor));
+    input_buffers.push_back(
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor));
 
     // Create input bindings
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 2> input_bindings;
@@ -311,7 +312,8 @@ class DmlGatherNdKernel : public DmlKernel {
     // When last_indices_dim == 0, we use a tile instead of a gather, and
     // therefore we don't need a second input
     if (last_indices_dim != 0) {
-      input_buffers.push_back(ctx->GetDmlDeviceContext()->CreateBufferForTensor(indices_tensor));
+      input_buffers.push_back(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(indices_tensor));
       input_bindings.push_back(input_buffers[1].GetBufferBinding());
     }
 
@@ -320,7 +322,8 @@ class DmlGatherNdKernel : public DmlKernel {
 
     Tensor* output = ctx->GetOutputTensor(0);
 
-    D3D12BufferRegion output_buffer = ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output);
+    D3D12BufferRegion output_buffer =
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output);
 
     output_bindings.push_back(output_buffer.GetBufferBinding());
 

--- a/tensorflow/core/kernels/dml_gather_nd_op.cc
+++ b/tensorflow/core/kernels/dml_gather_nd_op.cc
@@ -302,7 +302,7 @@ class DmlGatherNdKernel : public DmlKernel {
 
     // Create input buffers
     absl::InlinedVector<D3D12BufferRegion, 2> input_buffers;
-    input_buffers.push_back(ctx->CreateBufferForTensor(params_tensor));
+    input_buffers.push_back(ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor));
 
     // Create input bindings
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 2> input_bindings;
@@ -311,7 +311,7 @@ class DmlGatherNdKernel : public DmlKernel {
     // When last_indices_dim == 0, we use a tile instead of a gather, and
     // therefore we don't need a second input
     if (last_indices_dim != 0) {
-      input_buffers.push_back(ctx->CreateBufferForTensor(indices_tensor));
+      input_buffers.push_back(ctx->GetDmlDeviceContext()->CreateBufferForTensor(indices_tensor));
       input_bindings.push_back(input_buffers[1].GetBufferBinding());
     }
 
@@ -320,7 +320,7 @@ class DmlGatherNdKernel : public DmlKernel {
 
     Tensor* output = ctx->GetOutputTensor(0);
 
-    D3D12BufferRegion output_buffer = ctx->CreateBufferForTensor(*output);
+    D3D12BufferRegion output_buffer = ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output);
 
     output_bindings.push_back(output_buffer.GetBufferBinding());
 
@@ -330,7 +330,7 @@ class DmlGatherNdKernel : public DmlKernel {
       return status_or_event;
     }
 
-    gpu_event = ctx->InsertUavBarrier();
+    gpu_event = ctx->GetDmlDeviceContext()->InsertUavBarrier();
     return gpu_event;
   }
 };

--- a/tensorflow/core/kernels/dml_gather_nd_op.cc
+++ b/tensorflow/core/kernels/dml_gather_nd_op.cc
@@ -303,7 +303,7 @@ class DmlGatherNdKernel : public DmlKernel {
     // Create input buffers
     absl::InlinedVector<D3D12BufferRegion, 2> input_buffers;
     input_buffers.push_back(
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor));
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(params_tensor));
 
     // Create input bindings
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 2> input_bindings;
@@ -313,7 +313,7 @@ class DmlGatherNdKernel : public DmlKernel {
     // therefore we don't need a second input
     if (last_indices_dim != 0) {
       input_buffers.push_back(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(indices_tensor));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(indices_tensor));
       input_bindings.push_back(input_buffers[1].GetBufferBinding());
     }
 
@@ -323,7 +323,7 @@ class DmlGatherNdKernel : public DmlKernel {
     Tensor* output = ctx->GetOutputTensor(0);
 
     D3D12BufferRegion output_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output);
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(*output);
 
     output_bindings.push_back(output_buffer.GetBufferBinding());
 

--- a/tensorflow/core/kernels/dml_gather_op.cc
+++ b/tensorflow/core/kernels/dml_gather_op.cc
@@ -295,12 +295,12 @@ class DmlGatherKernel : public DmlKernel {
     auto init_helper = ctx->GetInitializationHelper<InitHelper>();
 
     D3D12BufferRegion input_buffers[] = {
-        ctx->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
             init_helper->GetParamsTensor(ctx->GetOpKernelContext())),
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(1)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(1)),
     };
 
-    D3D12BufferRegion output_buffers[] = {ctx->CreateBufferForTensor(*output)};
+    D3D12BufferRegion output_buffers[] = {ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output)};
 
     // Create bindings
     auto input_bindings = dml_util::GetBufferBindings(input_buffers);

--- a/tensorflow/core/kernels/dml_gather_op.cc
+++ b/tensorflow/core/kernels/dml_gather_op.cc
@@ -295,14 +295,14 @@ class DmlGatherKernel : public DmlKernel {
     auto init_helper = ctx->GetInitializationHelper<InitHelper>();
 
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             init_helper->GetParamsTensor(ctx->GetOpKernelContext())),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(1)),
     };
 
     D3D12BufferRegion output_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output)};
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(*output)};
 
     // Create bindings
     auto input_bindings = dml_util::GetBufferBindings(input_buffers);

--- a/tensorflow/core/kernels/dml_gather_op.cc
+++ b/tensorflow/core/kernels/dml_gather_op.cc
@@ -297,10 +297,12 @@ class DmlGatherKernel : public DmlKernel {
     D3D12BufferRegion input_buffers[] = {
         ctx->GetDmlDeviceContext()->CreateBufferForTensor(
             init_helper->GetParamsTensor(ctx->GetOpKernelContext())),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(1)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            ctx->GetInputTensor(1)),
     };
 
-    D3D12BufferRegion output_buffers[] = {ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output)};
+    D3D12BufferRegion output_buffers[] = {
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output)};
 
     // Create bindings
     auto input_bindings = dml_util::GetBufferBindings(input_buffers);

--- a/tensorflow/core/kernels/dml_gru_ops.cc
+++ b/tensorflow/core/kernels/dml_gru_ops.cc
@@ -229,7 +229,7 @@ class DmlGruBlockCellOp : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
       ctx->GetDmlDeviceContext()->ZeroBuffer(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(
               *ctx->GetOutputTensor(i)));
     }
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_gru_ops.cc
+++ b/tensorflow/core/kernels/dml_gru_ops.cc
@@ -228,7 +228,7 @@ class DmlGruBlockCellOp : public DmlKernel {
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
     }
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_gru_ops.cc
+++ b/tensorflow/core/kernels/dml_gru_ops.cc
@@ -228,7 +228,9 @@ class DmlGruBlockCellOp : public DmlKernel {
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+              *ctx->GetOutputTensor(i)));
     }
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_inplace_ops.cc
+++ b/tensorflow/core/kernels/dml_inplace_ops.cc
@@ -132,16 +132,16 @@ class DmlInplaceKernel : public DmlKernel {
     auto device_context = ctx->GetDmlDeviceContext();
 
     D3D12BufferRegion input_buffer =
-        device_context->CreateBufferForTensor(ctx->GetInputTensor(0));
+        device_context->GetBufferForTensor(ctx->GetInputTensor(0));
 
     D3D12BufferRegion indices_buffer =
-        device_context->CreateBufferForTensor(ctx->GetInputTensor(1));
+        device_context->GetBufferForTensor(ctx->GetInputTensor(1));
 
     D3D12BufferRegion updates_buffer =
-        device_context->CreateBufferForTensor(ctx->GetInputTensor(2));
+        device_context->GetBufferForTensor(ctx->GetInputTensor(2));
 
     D3D12BufferRegion output_buffer =
-        device_context->CreateBufferForTensor(*ctx->GetOutputTensor(0));
+        device_context->GetBufferForTensor(*ctx->GetOutputTensor(0));
 
     const absl::optional<DML_BUFFER_BINDING> input_bindings[3] = {
         input_buffer.GetBufferBinding(),

--- a/tensorflow/core/kernels/dml_inplace_ops.cc
+++ b/tensorflow/core/kernels/dml_inplace_ops.cc
@@ -160,8 +160,9 @@ class DmlInplaceKernel : public DmlKernel {
       return status_or_gpu_event;
     }
 
+    uint64_t copy_size = std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());
     device_context->CopyBufferToBuffer(
-        input_buffer, output_buffer.Subregion(0, input_buffer.SizeInBytes()));
+        input_buffer, output_buffer.Subregion(0, copy_size));
 
     return device_context->InsertUavBarrier();
   }

--- a/tensorflow/core/kernels/dml_inplace_ops.cc
+++ b/tensorflow/core/kernels/dml_inplace_ops.cc
@@ -160,7 +160,8 @@ class DmlInplaceKernel : public DmlKernel {
       return status_or_gpu_event;
     }
 
-    device_context->CopyBufferToBuffer(input_buffer, output_buffer);
+    device_context->CopyBufferToBuffer(
+        input_buffer, output_buffer.Subregion(0, input_buffer.SizeInBytes()));
 
     return device_context->InsertUavBarrier();
   }

--- a/tensorflow/core/kernels/dml_inplace_ops.cc
+++ b/tensorflow/core/kernels/dml_inplace_ops.cc
@@ -160,9 +160,10 @@ class DmlInplaceKernel : public DmlKernel {
       return status_or_gpu_event;
     }
 
-    uint64_t copy_size = std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());
-    device_context->CopyBufferToBuffer(
-        input_buffer, output_buffer.Subregion(0, copy_size));
+    uint64_t copy_size =
+        std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());
+    device_context->CopyBufferToBuffer(input_buffer,
+                                       output_buffer.Subregion(0, copy_size));
 
     return device_context->InsertUavBarrier();
   }

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -92,7 +92,7 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
         // If the tensor is nonempty, fill it with zero's
         if (output_tensor->NumElements() != 0) {
           D3D12BufferRegion buffer =
-              dml_util::CreateBufferForTensor(dml_device, *output_tensor);
+              dml_util::GetBufferForTensor(dml_device, *output_tensor);
           static_cast<DMLDeviceContext*>(ctx->op_device_context())
               ->ZeroBuffer(buffer);
         }

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -93,11 +93,7 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
         if (output_tensor->NumElements() != 0) {
           D3D12BufferRegion buffer =
               dml_util::CreateBufferForTensor(dml_device, *output_tensor);
-
-          const uint8_t fill_pattern[] = {0};
-          dml_device->GetExecutionContext()->FillBufferWithPattern(
-              buffer.Resource(), buffer.Offset(), buffer.SizeInBytes(),
-              fill_pattern);
+          static_cast<DMLDeviceContext*>(ctx->op_device_context())->ZeroBuffer(buffer);
         }
       }
       return;

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -93,7 +93,8 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
         if (output_tensor->NumElements() != 0) {
           D3D12BufferRegion buffer =
               dml_util::CreateBufferForTensor(dml_device, *output_tensor);
-          static_cast<DMLDeviceContext*>(ctx->op_device_context())->ZeroBuffer(buffer);
+          static_cast<DMLDeviceContext*>(ctx->op_device_context())
+              ->ZeroBuffer(buffer);
         }
       }
       return;

--- a/tensorflow/core/kernels/dml_lstm_ops.cc
+++ b/tensorflow/core/kernels/dml_lstm_ops.cc
@@ -1134,7 +1134,7 @@ class DmlBlockLstmOp : public DmlKernel {
       for (uint32_t i = 0; i < num_out; ++i) {
         Tensor* output = ctx->GetOutputTensor(i);
         ctx->GetDmlDeviceContext()->ZeroBuffer(
-            ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+            ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
       }
       return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();
     }
@@ -1691,7 +1691,7 @@ class DmlBlockLstmGradOp : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
       ctx->GetDmlDeviceContext()->ZeroBuffer(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(
               *ctx->GetOutputTensor(i)));
     }
     if (skip_) {

--- a/tensorflow/core/kernels/dml_lstm_ops.cc
+++ b/tensorflow/core/kernels/dml_lstm_ops.cc
@@ -1133,9 +1133,9 @@ class DmlBlockLstmOp : public DmlKernel {
       uint32_t num_out = ctx->GetOutputCount();
       for (uint32_t i = 0; i < num_out; ++i) {
         Tensor* output = ctx->GetOutputTensor(i);
-        ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+        ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
       }
-      return ctx->GetCurrentCompletionEvent();
+      return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();
     }
     return DmlKernel::Compute(ctx);
   }
@@ -1689,10 +1689,10 @@ class DmlBlockLstmGradOp : public DmlKernel {
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
     }
     if (skip_) {
-      return ctx->GetCurrentCompletionEvent();
+      return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();
     }
     return DmlKernel::Compute(ctx);
   }

--- a/tensorflow/core/kernels/dml_lstm_ops.cc
+++ b/tensorflow/core/kernels/dml_lstm_ops.cc
@@ -1133,7 +1133,8 @@ class DmlBlockLstmOp : public DmlKernel {
       uint32_t num_out = ctx->GetOutputCount();
       for (uint32_t i = 0; i < num_out; ++i) {
         Tensor* output = ctx->GetOutputTensor(i);
-        ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+        ctx->GetDmlDeviceContext()->ZeroBuffer(
+            ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
       }
       return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();
     }
@@ -1689,7 +1690,9 @@ class DmlBlockLstmGradOp : public DmlKernel {
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     for (int i = 0; i < ctx->GetOutputCount(); ++i) {
-      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*ctx->GetOutputTensor(i)));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+              *ctx->GetOutputTensor(i)));
     }
     if (skip_) {
       return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();

--- a/tensorflow/core/kernels/dml_matrix_diag_ops.cc
+++ b/tensorflow/core/kernels/dml_matrix_diag_ops.cc
@@ -320,7 +320,7 @@ class DmlMatrixDiagKernel : public DmlKernel {
       // over elements
       Tensor* output = ctx->GetOutputTensor(0);
       ctx->GetDmlDeviceContext()->FillBufferWithValue(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output),
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output),
           static_cast<float>(padding_value_));
     }
 

--- a/tensorflow/core/kernels/dml_matrix_diag_ops.cc
+++ b/tensorflow/core/kernels/dml_matrix_diag_ops.cc
@@ -319,7 +319,7 @@ class DmlMatrixDiagKernel : public DmlKernel {
       // Fill the buffer with the padding value since we use strides to skip
       // over elements
       Tensor* output = ctx->GetOutputTensor(0);
-      ctx->FillBufferWithValue(ctx->CreateBufferForTensor(*output),
+      ctx->GetDmlDeviceContext()->FillBufferWithValue(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output),
                                static_cast<float>(padding_value_));
     }
 

--- a/tensorflow/core/kernels/dml_matrix_diag_ops.cc
+++ b/tensorflow/core/kernels/dml_matrix_diag_ops.cc
@@ -319,8 +319,9 @@ class DmlMatrixDiagKernel : public DmlKernel {
       // Fill the buffer with the padding value since we use strides to skip
       // over elements
       Tensor* output = ctx->GetOutputTensor(0);
-      ctx->GetDmlDeviceContext()->FillBufferWithValue(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output),
-                               static_cast<float>(padding_value_));
+      ctx->GetDmlDeviceContext()->FillBufferWithValue(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output),
+          static_cast<float>(padding_value_));
     }
 
     return DmlKernel::Compute(ctx);
@@ -330,20 +331,20 @@ class DmlMatrixDiagKernel : public DmlKernel {
   bool use_fast_path_ = false;
 };
 
-#define REGISTER_DML_KERNEL(type)                                           \
-  REGISTER_KERNEL_BUILDER(Name("MatrixDiagV2")                              \
-                              .Device(DEVICE_DML)                           \
-                              .TypeConstraint<type>("T")                    \
-                              .HostMemory("k")                              \
-                              .HostMemory("num_rows")                       \
-                              .HostMemory("num_cols")                       \
-                              .HostMemory("padding_value"),                 \
-                          DmlKernelWrapper<DmlMatrixDiagKernel<type>,       \
-                                           MatrixDiagShapeHelper<type>>);   \
-  REGISTER_KERNEL_BUILDER(                                                  \
-      Name("MatrixDiag").Device(DEVICE_DML).TypeConstraint<type>("T"),      \
-      DmlKernelWrapper<DmlMatrixDiagKernel<type>,                           \
-                       MatrixDiagShapeHelper<type>>);                       \
+#define REGISTER_DML_KERNEL(type)                                         \
+  REGISTER_KERNEL_BUILDER(Name("MatrixDiagV2")                            \
+                              .Device(DEVICE_DML)                         \
+                              .TypeConstraint<type>("T")                  \
+                              .HostMemory("k")                            \
+                              .HostMemory("num_rows")                     \
+                              .HostMemory("num_cols")                     \
+                              .HostMemory("padding_value"),               \
+                          DmlKernelWrapper<DmlMatrixDiagKernel<type>,     \
+                                           MatrixDiagShapeHelper<type>>); \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("MatrixDiag").Device(DEVICE_DML).TypeConstraint<type>("T"),    \
+      DmlKernelWrapper<DmlMatrixDiagKernel<type>,                         \
+                       MatrixDiagShapeHelper<type>>);
 
 TF_CALL_float(REGISTER_DML_KERNEL);
 TF_CALL_half(REGISTER_DML_KERNEL);

--- a/tensorflow/core/kernels/dml_ops_common.cc
+++ b/tensorflow/core/kernels/dml_ops_common.cc
@@ -397,7 +397,7 @@ absl::InlinedVector<D3D12BufferRegion, 8> DmlKernel::CreateInputBuffers(
 
       const Tensor& input_tensor = ctx->GetInputTensor(kernel_index);
       input_buffers[i] =
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor);
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(input_tensor);
     }
   }
 
@@ -415,7 +415,7 @@ absl::InlinedVector<D3D12BufferRegion, 4> DmlKernel::CreateOutputBuffers(
 
       Tensor* output_tensor = ctx->GetOutputTensor(kernel_index);
       output_buffers[i] =
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output_tensor);
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output_tensor);
     }
   }
 

--- a/tensorflow/core/kernels/dml_ops_common.cc
+++ b/tensorflow/core/kernels/dml_ops_common.cc
@@ -221,29 +221,30 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
             << " persistent resource for kernel "
             << ctx->GetOpKernelContext()->op_kernel().type_string();
 
-   CD3DX12_HEAP_PROPERTIES default_heap_properties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-   CD3DX12_RESOURCE_DESC persistent_resource_desc = CD3DX12_RESOURCE_DESC::Buffer(
-       exec_binding_props.PersistentResourceSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-   
-   HRESULT hr = ctx->GetD3D12Device()->CreateCommittedResource(
-       &default_heap_properties,
-       D3D12_HEAP_FLAG_NONE,
-       &persistent_resource_desc,
-       D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-       nullptr,
-       IID_PPV_ARGS(&persistent_resource_));
+    CD3DX12_HEAP_PROPERTIES default_heap_properties =
+        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+    CD3DX12_RESOURCE_DESC persistent_resource_desc =
+        CD3DX12_RESOURCE_DESC::Buffer(
+            exec_binding_props.PersistentResourceSize,
+            D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+    HRESULT hr = ctx->GetD3D12Device()->CreateCommittedResource(
+        &default_heap_properties, D3D12_HEAP_FLAG_NONE,
+        &persistent_resource_desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        nullptr, IID_PPV_ARGS(&persistent_resource_));
 
     if (dml_util::HrIsOutOfMemory(hr)) {
       assert(!persistent_resource_);
       OP_REQUIRES(ctx->GetOpKernelContext(), persistent_resource_,
-            errors::ResourceExhausted(
-                "OOM when allocating a persistent resource buffer of ",
-                exec_binding_props.PersistentResourceSize, " bytes"));
+                  errors::ResourceExhausted(
+                      "OOM when allocating a persistent resource buffer of ",
+                      exec_binding_props.PersistentResourceSize, " bytes"));
     }
-  
+
     DML_CHECK_SUCCEEDED(hr);
 
-    persistent_resource_binding_ = {persistent_resource_.Get(), 0, exec_binding_props.PersistentResourceSize};
+    persistent_resource_binding_ = {persistent_resource_.Get(), 0,
+                                    exec_binding_props.PersistentResourceSize};
   }
 
   // Initialize the operator
@@ -260,7 +261,8 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   // Unfortunately we have to use make_shared here to make it copyable, so it
   // can be captured in the lambda below
   auto descriptor_range = std::make_shared<DescriptorAllocation>(
-      ctx->GetDmlDeviceContext()->AllocateDescriptors(init_binding_props.RequiredDescriptorCount));
+      ctx->GetDmlDeviceContext()->AllocateDescriptors(
+          init_binding_props.RequiredDescriptorCount));
 
   D3D12DescriptorHandles descriptor_handles =
       descriptor_range->GetDescriptorHandles();
@@ -282,7 +284,8 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   DmlBuffer temp_resource;
   absl::optional<DML_BUFFER_BINDING> temp_resource_binding;
   if (temporary_resource_size > 0) {
-    temp_resource = ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(temporary_resource_size);
+    temp_resource = ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(
+        temporary_resource_size);
 
     OP_REQUIRES(ctx->GetOpKernelContext(), temp_resource,
                 errors::ResourceExhausted("OOM when allocating a buffer of ",
@@ -304,7 +307,8 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
     p = nullptr;
     p2->Reset();
   };
-  ctx->GetDmlDeviceContext()->EnqueueCallbackForGpuEvent(init_gpu_event, on_initialize_completed);
+  ctx->GetDmlDeviceContext()->EnqueueCallbackForGpuEvent(
+      init_gpu_event, on_initialize_completed);
 }
 
 StatusOr<DmlGpuEvent> DmlKernel::Compute(DmlKernelContext* ctx) const {
@@ -329,7 +333,8 @@ StatusOr<DmlGpuEvent> DmlKernel::Compute(
   // Unfortunately we have to use make_shared here to make it copyable, so it
   // can be captured in the lambda below
   auto descriptor_range = std::make_shared<DescriptorAllocation>(
-      ctx->GetDmlDeviceContext()->AllocateDescriptors(exec_binding_props.RequiredDescriptorCount));
+      ctx->GetDmlDeviceContext()->AllocateDescriptors(
+          exec_binding_props.RequiredDescriptorCount));
 
   D3D12DescriptorHandles descriptor_handles =
       descriptor_range->GetDescriptorHandles();
@@ -355,7 +360,8 @@ StatusOr<DmlGpuEvent> DmlKernel::Compute(
     // freeing allows the resource to be shared with other operators, but
     // because the allocator is multi-threaded we need to at least keep a use on
     // it until we're done with it locally to prevent the buffer being reused.
-    temp_resource = ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(temporary_resource_size);
+    temp_resource = ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(
+        temporary_resource_size);
     if (!temp_resource) {
       return errors::ResourceExhausted("OOM when allocating a buffer of ",
                                        temporary_resource_size, " bytes");
@@ -373,10 +379,10 @@ StatusOr<DmlGpuEvent> DmlKernel::Compute(
   // be released when the execution completes on the GPU. Note that we don't
   // need to keep the binding table alive - recall that lifetime is tied to the
   // underlying descriptors, not the binding table itself.
-  ctx->GetDmlDeviceContext()->EnqueueCallbackForGpuEvent(gpu_event,
-                                  [p = std::move(descriptor_range)]() mutable {
-                                    p->Reset();  // Release the descriptor range
-                                  });
+  ctx->GetDmlDeviceContext()->EnqueueCallbackForGpuEvent(
+      gpu_event, [p = std::move(descriptor_range)]() mutable {
+        p->Reset();  // Release the descriptor range
+      });
 
   return gpu_event;
 }
@@ -390,7 +396,8 @@ absl::InlinedVector<D3D12BufferRegion, 8> DmlKernel::CreateInputBuffers(
       uint32_t kernel_index = input_descs_[i]->kernel_index;
 
       const Tensor& input_tensor = ctx->GetInputTensor(kernel_index);
-      input_buffers[i] = ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor);
+      input_buffers[i] =
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor);
     }
   }
 
@@ -407,7 +414,8 @@ absl::InlinedVector<D3D12BufferRegion, 4> DmlKernel::CreateOutputBuffers(
       uint32_t kernel_index = output_descs_[i]->kernel_index;
 
       Tensor* output_tensor = ctx->GetOutputTensor(kernel_index);
-      output_buffers[i] = ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output_tensor);
+      output_buffers[i] =
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output_tensor);
     }
   }
 

--- a/tensorflow/core/kernels/dml_parallel_concat_ops.cc
+++ b/tensorflow/core/kernels/dml_parallel_concat_ops.cc
@@ -83,12 +83,10 @@ class DmlParallelConcatUpdateKernel : public OpKernel {
     // Guard the row index range
     const int64 row_index = (loc_ % nrows + nrows) % nrows;
     const uint64_t dst_offset = output_buffer.Offset() + row_index * stride;
-    const uint64_t src_offset = update_buffer.Offset();
 
     device->GetExecutionContext()->CopyBufferRegion(
-        output_buffer.Resource(), dst_offset, D3D12_RESOURCE_STATE_COPY_DEST,
-        update_buffer.Resource(), src_offset, D3D12_RESOURCE_STATE_COPY_SOURCE,
-        stride);
+        output_buffer.Subregion(dst_offset),
+        update_buffer.Subregion(0, stride));
 
     ctx->set_output(0, output_tensor);
   }

--- a/tensorflow/core/kernels/dml_parallel_concat_ops.cc
+++ b/tensorflow/core/kernels/dml_parallel_concat_ops.cc
@@ -71,9 +71,9 @@ class DmlParallelConcatUpdateKernel : public OpKernel {
     Tensor output_tensor = value_tensor;
 
     D3D12BufferRegion update_buffer =
-        dml_util::CreateBufferForTensor(device, update_tensor);
+        dml_util::GetBufferForTensor(device, update_tensor);
     D3D12BufferRegion output_buffer =
-        dml_util::CreateBufferForTensor(device, output_tensor);
+        dml_util::GetBufferForTensor(device, output_tensor);
 
     const int64 nrows = output_tensor.dim_size(0);
     const int dtype_size_in_bytes = DataTypeSize(output_tensor.dtype());

--- a/tensorflow/core/kernels/dml_parallel_concat_ops.cc
+++ b/tensorflow/core/kernels/dml_parallel_concat_ops.cc
@@ -82,7 +82,7 @@ class DmlParallelConcatUpdateKernel : public OpKernel {
 
     // Guard the row index range
     const int64 row_index = (loc_ % nrows + nrows) % nrows;
-    const uint64_t dst_offset = output_buffer.Offset() + row_index * stride;
+    const uint64_t dst_offset = row_index * stride;
 
     device->GetExecutionContext()->CopyBufferRegion(
         output_buffer.Subregion(dst_offset),

--- a/tensorflow/core/kernels/dml_random_ops.cc
+++ b/tensorflow/core/kernels/dml_random_ops.cc
@@ -251,7 +251,7 @@ class DmlStatelessRandomUniformKernel : public DmlKernel {
     DmlBuffer input_state_buffer =
         ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(6 * sizeof(uint32_t));
     D3D12BufferRegion output_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             *ctx->GetOutputTensor(0));
 
     if (!input_state_buffer) {
@@ -451,7 +451,7 @@ class DmlRandomUniformKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx,
                                 GuardedPhiloxRandom& generator) const {
     D3D12BufferRegion output_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             *ctx->GetOutputTensor(0));
 
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 1> input_bindings;

--- a/tensorflow/core/kernels/dml_random_ops.cc
+++ b/tensorflow/core/kernels/dml_random_ops.cc
@@ -249,9 +249,10 @@ class DmlStatelessRandomUniformKernel : public DmlKernel {
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
     DmlBuffer input_state_buffer =
-        ctx->AllocateDefaultBuffer(6 * sizeof(uint32_t));
+        ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(6 * sizeof(uint32_t));
     D3D12BufferRegion output_buffer =
-        ctx->CreateBufferForTensor(*ctx->GetOutputTensor(0));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            *ctx->GetOutputTensor(0));
 
     if (!input_state_buffer) {
       return errors::ResourceExhausted("OOM when allocating a buffer of ",
@@ -269,8 +270,8 @@ class DmlStatelessRandomUniformKernel : public DmlKernel {
     auto byte_span =
         absl::MakeSpan(byte_ptr, input_state_.size() * sizeof(input_state_[0]));
 
-    ctx->CopyHostToBuffer(input_state_buffer.Resource(),
-                          input_state_buffer.Offset(), byte_span);
+    ctx->GetDmlDeviceContext()->CopyHostToBuffer(input_state_buffer.Region(),
+                                                 byte_span);
 
     return DmlKernel::Compute(ctx, input_bindings, output_bindings);
   }
@@ -399,7 +400,8 @@ class DmlRandomUniformKernel : public DmlKernel {
     num_output_elements_ =
         static_cast<uint32_t>(init_helper->GetOutputShape().num_elements());
 
-    state_buffer_ = ctx->AllocateDefaultBuffer(6 * sizeof(uint32_t));
+    state_buffer_ =
+        ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(6 * sizeof(uint32_t));
 
     OP_REQUIRES(ctx->GetOpKernelContext(), state_buffer_,
                 errors::ResourceExhausted("OOM when allocating a buffer of ",
@@ -449,7 +451,8 @@ class DmlRandomUniformKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx,
                                 GuardedPhiloxRandom& generator) const {
     D3D12BufferRegion output_buffer =
-        ctx->CreateBufferForTensor(*ctx->GetOutputTensor(0));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            *ctx->GetOutputTensor(0));
 
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 1> input_bindings;
     input_bindings.push_back(state_buffer_->GetBufferBinding());
@@ -474,8 +477,8 @@ class DmlRandomUniformKernel : public DmlKernel {
     auto byte_span =
         absl::MakeSpan(byte_ptr, state_buf.size() * sizeof(state_buf[0]));
 
-    ctx->CopyHostToBuffer(state_buffer_->Resource(), state_buffer_->Offset(),
-                          byte_span);
+    ctx->GetDmlDeviceContext()->CopyHostToBuffer(state_buffer_->Region(),
+                                                 byte_span);
 
     return DmlKernel::Compute(ctx, input_bindings, output_bindings);
   }

--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -443,11 +443,11 @@ class DmlReduceKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const {
     if (zero_outputs_) {
       Tensor* output = ctx->GetOutputTensor(0);
-      ctx->ZeroBuffer(ctx->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     if (is_no_op_) {
-      return ctx->GetCurrentCompletionEvent();
+      return ctx->GetDmlDeviceContext()->GetCurrentCompletionEvent();
     }
 
     return DmlKernel::Compute(ctx);

--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -87,8 +87,7 @@ class ReduceInitializationHelper : public InitializationHelper {
                                !reduction_helper_.reduce_first_axis()));
 
     absl::optional<int> return_val;
-    if (is_identity)
-    {
+    if (is_identity) {
       return_val = 0;
     }
 
@@ -443,7 +442,8 @@ class DmlReduceKernel : public DmlKernel {
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const {
     if (zero_outputs_) {
       Tensor* output = ctx->GetOutputTensor(0);
-      ctx->GetDmlDeviceContext()->ZeroBuffer(ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+      ctx->GetDmlDeviceContext()->ZeroBuffer(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
     }
 
     if (is_no_op_) {

--- a/tensorflow/core/kernels/dml_reduce_ops.cc
+++ b/tensorflow/core/kernels/dml_reduce_ops.cc
@@ -443,7 +443,7 @@ class DmlReduceKernel : public DmlKernel {
     if (zero_outputs_) {
       Tensor* output = ctx->GetOutputTensor(0);
       ctx->GetDmlDeviceContext()->ZeroBuffer(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(*output));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output));
     }
 
     if (is_no_op_) {

--- a/tensorflow/core/kernels/dml_resource_scatter_ops.cc
+++ b/tensorflow/core/kernels/dml_resource_scatter_ops.cc
@@ -242,10 +242,10 @@ class DmlResourceScatterNDUpdateKernel : public DmlKernel {
 
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(params_tensor),
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(1)),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(2)),
     };
 
@@ -476,10 +476,10 @@ class DmlResourceScatterNDBinaryKernel : public DmlKernel {
 
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(params_tensor),
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(1)),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(2)),
     };
 
@@ -496,7 +496,7 @@ class DmlResourceScatterNDBinaryKernel : public DmlKernel {
     const bool isTensorInput = init_helper->IsTensorInput();
     if (isTensorInput) {
       D3D12BufferRegion output_buffer =
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(
               *ctx->GetOutputTensor(0));
       output_bindings.push_back(output_buffer.GetBufferBinding());
 

--- a/tensorflow/core/kernels/dml_resource_variable_ops.cc
+++ b/tensorflow/core/kernels/dml_resource_variable_ops.cc
@@ -91,8 +91,10 @@ class DmlUpdateVariableOp : public DmlKernel {
         op_ctx, var_tensor, variable->copy_on_read_mode.load(),
         &dml_util::CopyTensorInSameDevice));
 
-    D3D12BufferRegion var_resource = ctx->GetDmlDeviceContext()->CreateBufferForTensor(*var_tensor);
-    D3D12BufferRegion value_resource = ctx->GetDmlDeviceContext()->CreateBufferForTensor(value);
+    D3D12BufferRegion var_resource =
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*var_tensor);
+    D3D12BufferRegion value_resource =
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(value);
 
     absl::optional<DML_BUFFER_BINDING> input_bindings[] = {
         var_resource.GetBufferBinding(),

--- a/tensorflow/core/kernels/dml_resource_variable_ops.cc
+++ b/tensorflow/core/kernels/dml_resource_variable_ops.cc
@@ -92,9 +92,9 @@ class DmlUpdateVariableOp : public DmlKernel {
         &dml_util::CopyTensorInSameDevice));
 
     D3D12BufferRegion var_resource =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*var_tensor);
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(*var_tensor);
     D3D12BufferRegion value_resource =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(value);
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(value);
 
     absl::optional<DML_BUFFER_BINDING> input_bindings[] = {
         var_resource.GetBufferBinding(),

--- a/tensorflow/core/kernels/dml_resource_variable_ops.cc
+++ b/tensorflow/core/kernels/dml_resource_variable_ops.cc
@@ -91,8 +91,8 @@ class DmlUpdateVariableOp : public DmlKernel {
         op_ctx, var_tensor, variable->copy_on_read_mode.load(),
         &dml_util::CopyTensorInSameDevice));
 
-    D3D12BufferRegion var_resource = ctx->CreateBufferForTensor(*var_tensor);
-    D3D12BufferRegion value_resource = ctx->CreateBufferForTensor(value);
+    D3D12BufferRegion var_resource = ctx->GetDmlDeviceContext()->CreateBufferForTensor(*var_tensor);
+    D3D12BufferRegion value_resource = ctx->GetDmlDeviceContext()->CreateBufferForTensor(value);
 
     absl::optional<DML_BUFFER_BINDING> input_bindings[] = {
         var_resource.GetBufferBinding(),

--- a/tensorflow/core/kernels/dml_scatter_nd_op.cc
+++ b/tensorflow/core/kernels/dml_scatter_nd_op.cc
@@ -266,16 +266,20 @@ class DmlScatterNdKernel : public DmlKernel {
   }
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
-    DmlBuffer params_buffer = ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffer_size_);
+    DmlBuffer params_buffer =
+        ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffer_size_);
 
     D3D12BufferRegion indices_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(0));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            ctx->GetInputTensor(0));
 
     D3D12BufferRegion updates_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(1));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            ctx->GetInputTensor(1));
 
     D3D12BufferRegion output_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*ctx->GetOutputTensor(0));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            *ctx->GetOutputTensor(0));
 
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 3> input_bindings;
     input_bindings.push_back(params_buffer.GetBufferBinding());

--- a/tensorflow/core/kernels/dml_scatter_nd_op.cc
+++ b/tensorflow/core/kernels/dml_scatter_nd_op.cc
@@ -266,16 +266,16 @@ class DmlScatterNdKernel : public DmlKernel {
   }
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
-    DmlBuffer params_buffer = ctx->AllocateDefaultBuffer(input_buffer_size_);
+    DmlBuffer params_buffer = ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffer_size_);
 
     D3D12BufferRegion indices_buffer =
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(0));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(0));
 
     D3D12BufferRegion updates_buffer =
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(1));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(1));
 
     D3D12BufferRegion output_buffer =
-        ctx->CreateBufferForTensor(*ctx->GetOutputTensor(0));
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(*ctx->GetOutputTensor(0));
 
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 3> input_bindings;
     input_bindings.push_back(params_buffer.GetBufferBinding());
@@ -285,8 +285,7 @@ class DmlScatterNdKernel : public DmlKernel {
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 1> output_bindings;
     output_bindings.push_back(output_buffer.GetBufferBinding());
 
-    ctx->ZeroBuffer(params_buffer.Resource(), params_buffer.Offset(),
-                    params_buffer.SizeInBytes());
+    ctx->GetDmlDeviceContext()->ZeroBuffer(params_buffer.Region());
 
     return DmlKernel::Compute(ctx, input_bindings, output_bindings);
   }

--- a/tensorflow/core/kernels/dml_scatter_nd_op.cc
+++ b/tensorflow/core/kernels/dml_scatter_nd_op.cc
@@ -270,15 +270,15 @@ class DmlScatterNdKernel : public DmlKernel {
         ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffer_size_);
 
     D3D12BufferRegion indices_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(0));
 
     D3D12BufferRegion updates_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(1));
 
     D3D12BufferRegion output_buffer =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             *ctx->GetOutputTensor(0));
 
     absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 3> input_bindings;

--- a/tensorflow/core/kernels/dml_scatter_update_ops.cc
+++ b/tensorflow/core/kernels/dml_scatter_update_ops.cc
@@ -380,10 +380,10 @@ class DmlScatterUpdateKernel : public DmlKernel {
 
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(params_tensor),
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(1)),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(2)),
     };
 

--- a/tensorflow/core/kernels/dml_scatter_update_ops.cc
+++ b/tensorflow/core/kernels/dml_scatter_update_ops.cc
@@ -381,8 +381,10 @@ class DmlScatterUpdateKernel : public DmlKernel {
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
         ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(1)),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(2)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            ctx->GetInputTensor(1)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            ctx->GetInputTensor(2)),
     };
 
     // Create input bindings
@@ -408,7 +410,8 @@ class DmlScatterUpdateKernel : public DmlKernel {
       gpu_event = status_or_event.ValueOrDie();
     } else {
       DmlBuffer output_buffer =
-          ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffers[0].SizeInBytes());
+          ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(
+              input_buffers[0].SizeInBytes());
 
       absl::optional<DML_BUFFER_BINDING> output_bindings[] = {
           output_buffer.GetBufferBinding(),
@@ -421,7 +424,7 @@ class DmlScatterUpdateKernel : public DmlKernel {
       }
 
       ctx->GetDmlDeviceContext()->CopyBufferToBuffer(input_buffers[0],
-                              output_buffer.Region());
+                                                     output_buffer.Region());
 
       gpu_event = ctx->GetDmlDeviceContext()->InsertUavBarrier();
     }

--- a/tensorflow/core/kernels/dml_scatter_update_ops.cc
+++ b/tensorflow/core/kernels/dml_scatter_update_ops.cc
@@ -380,9 +380,9 @@ class DmlScatterUpdateKernel : public DmlKernel {
 
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
-        ctx->CreateBufferForTensor(params_tensor),
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(1)),
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(2)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(params_tensor),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(1)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(2)),
     };
 
     // Create input bindings
@@ -408,7 +408,7 @@ class DmlScatterUpdateKernel : public DmlKernel {
       gpu_event = status_or_event.ValueOrDie();
     } else {
       DmlBuffer output_buffer =
-          ctx->AllocateDefaultBuffer(input_buffers[0].SizeInBytes());
+          ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffers[0].SizeInBytes());
 
       absl::optional<DML_BUFFER_BINDING> output_bindings[] = {
           output_buffer.GetBufferBinding(),
@@ -420,12 +420,10 @@ class DmlScatterUpdateKernel : public DmlKernel {
         return status_or_event;
       }
 
-      ctx->CopyBufferToBuffer(input_buffers[0].Resource(),
-                              input_buffers[0].Offset(),
-                              output_buffer.Resource(), output_buffer.Offset(),
-                              output_buffer.SizeInBytes());
+      ctx->GetDmlDeviceContext()->CopyBufferToBuffer(input_buffers[0],
+                              output_buffer.Region());
 
-      gpu_event = ctx->InsertUavBarrier();
+      gpu_event = ctx->GetDmlDeviceContext()->InsertUavBarrier();
     }
 
     return gpu_event;

--- a/tensorflow/core/kernels/dml_strided_slice_op.cc
+++ b/tensorflow/core/kernels/dml_strided_slice_op.cc
@@ -727,10 +727,10 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
     // Identity can be done in-place
     if (init_helper->IsIdentity()) {
       D3D12BufferRegion input_buffer =
-          ctx->CreateBufferForTensor(ctx->GetInputTensor(4));
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(4));
 
       D3D12BufferRegion output_buffer =
-          ctx->CreateBufferForTensor(input_tensor);
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor);
 
       absl::optional<DML_BUFFER_BINDING> input_bindings[] = {
           input_buffer.GetBufferBinding(),
@@ -745,8 +745,8 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
 
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(4)),
-        ctx->CreateBufferForTensor(input_tensor),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(4)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor),
     };
 
     // Create input bindings
@@ -756,7 +756,7 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
     };
 
     DmlBuffer output_buffer =
-        ctx->AllocateDefaultBuffer(input_buffers[1].SizeInBytes());
+        ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffers[1].SizeInBytes());
 
     absl::optional<DML_BUFFER_BINDING> output_bindings[] = {
         output_buffer.GetBufferBinding(),
@@ -768,12 +768,9 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
       return status_or_event;
     }
 
-    ctx->CopyBufferToBuffer(input_buffers[1].Resource(),
-                            input_buffers[1].Offset(), output_buffer.Resource(),
-                            output_buffer.Offset(),
-                            output_buffer.SizeInBytes());
+    ctx->GetDmlDeviceContext()->CopyBufferToBuffer(input_buffers[1], output_buffer.Region());
 
-    return ctx->InsertUavBarrier();
+    return ctx->GetDmlDeviceContext()->InsertUavBarrier();
   }
 };
 

--- a/tensorflow/core/kernels/dml_strided_slice_op.cc
+++ b/tensorflow/core/kernels/dml_strided_slice_op.cc
@@ -727,7 +727,8 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
     // Identity can be done in-place
     if (init_helper->IsIdentity()) {
       D3D12BufferRegion input_buffer =
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(4));
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+              ctx->GetInputTensor(4));
 
       D3D12BufferRegion output_buffer =
           ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor);
@@ -745,7 +746,8 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
 
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(ctx->GetInputTensor(4)),
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            ctx->GetInputTensor(4)),
         ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor),
     };
 
@@ -755,8 +757,8 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
         input_buffers[1].GetBufferBinding(),
     };
 
-    DmlBuffer output_buffer =
-        ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(input_buffers[1].SizeInBytes());
+    DmlBuffer output_buffer = ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(
+        input_buffers[1].SizeInBytes());
 
     absl::optional<DML_BUFFER_BINDING> output_bindings[] = {
         output_buffer.GetBufferBinding(),
@@ -768,7 +770,8 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
       return status_or_event;
     }
 
-    ctx->GetDmlDeviceContext()->CopyBufferToBuffer(input_buffers[1], output_buffer.Region());
+    ctx->GetDmlDeviceContext()->CopyBufferToBuffer(input_buffers[1],
+                                                   output_buffer.Region());
 
     return ctx->GetDmlDeviceContext()->InsertUavBarrier();
   }

--- a/tensorflow/core/kernels/dml_strided_slice_op.cc
+++ b/tensorflow/core/kernels/dml_strided_slice_op.cc
@@ -727,11 +727,11 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
     // Identity can be done in-place
     if (init_helper->IsIdentity()) {
       D3D12BufferRegion input_buffer =
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(
               ctx->GetInputTensor(4));
 
       D3D12BufferRegion output_buffer =
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor);
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(input_tensor);
 
       absl::optional<DML_BUFFER_BINDING> input_bindings[] = {
           input_buffer.GetBufferBinding(),
@@ -746,9 +746,9 @@ class DmlStridedSliceAssignKernel : public DmlKernel {
 
     // Create input buffers
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             ctx->GetInputTensor(4)),
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor),
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(input_tensor),
     };
 
     // Create input bindings

--- a/tensorflow/core/kernels/dml_tensor_array.cc
+++ b/tensorflow/core/kernels/dml_tensor_array.cc
@@ -79,7 +79,7 @@ void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
 
   D3D12BufferRegion dst =
       dml_util::CreateBufferForTensor(device, *output_tensor);
-  uint64_t dst_offset = dst.Offset();
+  uint64_t dst_offset = 0;
 
   for (PersistentTensor& value : values) {
     const Tensor& input_tensor = *value.AccessTensor(ctx);
@@ -93,7 +93,7 @@ void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
         dml_util::CreateBufferForTensor(device, input_tensor);
 
     device_context->CopyBufferToBuffer(
-        dst, src.Subregion(0, bytes_to_copy));
+        dst.Subregion(dst_offset), src.Subregion(0, bytes_to_copy));
 
     dst_offset += bytes_to_copy;
     CHECK(dst_offset <= dst.ResourceInCopyDstState()->GetDesc().Width);

--- a/tensorflow/core/kernels/dml_tensor_array.cc
+++ b/tensorflow/core/kernels/dml_tensor_array.cc
@@ -67,7 +67,7 @@ void DmlTensorSetZero(OpKernelContext* ctx, Tensor* value) {
   auto device_context =
       static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
-  D3D12BufferRegion dst = dml_util::CreateBufferForTensor(device, *value);
+  D3D12BufferRegion dst = dml_util::GetBufferForTensor(device, *value);
   device_context->ZeroBuffer(dst);
 }
 
@@ -78,7 +78,7 @@ void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
       static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
   D3D12BufferRegion dst =
-      dml_util::CreateBufferForTensor(device, *output_tensor);
+      dml_util::GetBufferForTensor(device, *output_tensor);
   uint64_t dst_offset = 0;
 
   for (PersistentTensor& value : values) {
@@ -90,7 +90,7 @@ void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
 
     uint64_t bytes_to_copy = input_tensor.TotalBytes();
     D3D12BufferRegion src =
-        dml_util::CreateBufferForTensor(device, input_tensor);
+        dml_util::GetBufferForTensor(device, input_tensor);
 
     device_context->CopyBufferToBuffer(dst.Subregion(dst_offset),
                                        src.Subregion(0, bytes_to_copy));
@@ -117,8 +117,8 @@ void DmlSplitTensor(OpKernelContext* ctx, Tensor* output_tensor,
   auto device_context =
       static_cast<DMLDeviceContext*>(ctx->op_device_context());
   D3D12BufferRegion dst =
-      dml_util::CreateBufferForTensor(device, *output_tensor);
-  D3D12BufferRegion src = dml_util::CreateBufferForTensor(device, input_tensor);
+      dml_util::GetBufferForTensor(device, *output_tensor);
+  D3D12BufferRegion src = dml_util::GetBufferForTensor(device, input_tensor);
 
   device_context->CopyBufferToBuffer(dst,
                                      src.Subregion(src_offset, bytes_to_copy));

--- a/tensorflow/core/kernels/dml_tensor_array.cc
+++ b/tensorflow/core/kernels/dml_tensor_array.cc
@@ -92,8 +92,8 @@ void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
     D3D12BufferRegion src =
         dml_util::CreateBufferForTensor(device, input_tensor);
 
-    device_context->CopyBufferToBuffer(
-        dst.Subregion(dst_offset), src.Subregion(0, bytes_to_copy));
+    device_context->CopyBufferToBuffer(dst.Subregion(dst_offset),
+                                       src.Subregion(0, bytes_to_copy));
 
     dst_offset += bytes_to_copy;
     CHECK(dst_offset <= dst.ResourceInCopyDstState()->GetDesc().Width);

--- a/tensorflow/core/kernels/dml_tensor_scatter_ops.cc
+++ b/tensorflow/core/kernels/dml_tensor_scatter_ops.cc
@@ -295,19 +295,22 @@ class DmlTensorScatterBinaryKernel : public DmlKernel {
   }
 
   StatusOr<DmlGpuEvent> Compute(DmlKernelContext* ctx) const override {
+    auto device_context = ctx->GetDmlDeviceContext();
+
     D3D12BufferRegion input_buffer =
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(0));
+        device_context->CreateBufferForTensor(ctx->GetInputTensor(0));
 
     D3D12BufferRegion indices_buffer =
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(1));
+        device_context->CreateBufferForTensor(ctx->GetInputTensor(1));
 
     D3D12BufferRegion updates_buffer =
-        ctx->CreateBufferForTensor(ctx->GetInputTensor(2));
+        device_context->CreateBufferForTensor(ctx->GetInputTensor(2));
 
     D3D12BufferRegion output_buffer =
-        ctx->CreateBufferForTensor(*ctx->GetOutputTensor(0));
+        device_context->CreateBufferForTensor(*ctx->GetOutputTensor(0));
 
-    DmlBuffer empty_buffer = ctx->AllocateDefaultBuffer(empty_buffer_size_);
+    DmlBuffer empty_buffer =
+        device_context->AllocateDefaultBuffer(empty_buffer_size_);
 
     const absl::optional<DML_BUFFER_BINDING> input_bindings[4] = {
         input_buffer.GetBufferBinding(),
@@ -320,8 +323,7 @@ class DmlTensorScatterBinaryKernel : public DmlKernel {
         output_buffer.GetBufferBinding(),
     };
 
-    ctx->ZeroBuffer(empty_buffer.Resource(), empty_buffer.Offset(),
-                    empty_buffer.SizeInBytes());
+    device_context->ZeroBuffer(empty_buffer.Region());
 
     return DmlKernel::Compute(ctx, input_bindings, output_bindings);
   }

--- a/tensorflow/core/kernels/dml_tensor_scatter_ops.cc
+++ b/tensorflow/core/kernels/dml_tensor_scatter_ops.cc
@@ -298,16 +298,16 @@ class DmlTensorScatterBinaryKernel : public DmlKernel {
     auto device_context = ctx->GetDmlDeviceContext();
 
     D3D12BufferRegion input_buffer =
-        device_context->CreateBufferForTensor(ctx->GetInputTensor(0));
+        device_context->GetBufferForTensor(ctx->GetInputTensor(0));
 
     D3D12BufferRegion indices_buffer =
-        device_context->CreateBufferForTensor(ctx->GetInputTensor(1));
+        device_context->GetBufferForTensor(ctx->GetInputTensor(1));
 
     D3D12BufferRegion updates_buffer =
-        device_context->CreateBufferForTensor(ctx->GetInputTensor(2));
+        device_context->GetBufferForTensor(ctx->GetInputTensor(2));
 
     D3D12BufferRegion output_buffer =
-        device_context->CreateBufferForTensor(*ctx->GetOutputTensor(0));
+        device_context->GetBufferForTensor(*ctx->GetOutputTensor(0));
 
     DmlBuffer empty_buffer =
         device_context->AllocateDefaultBuffer(empty_buffer_size_);

--- a/tensorflow/core/kernels/dml_training_ops.cc
+++ b/tensorflow/core/kernels/dml_training_ops.cc
@@ -202,7 +202,7 @@ class DmlTrainingKernel : public DmlKernel {
     absl::InlinedVector<D3D12BufferRegion, 16> input_buffers;
     for (const Tensor& input_tensor : input_tensors) {
       input_buffers.push_back(
-          ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(input_tensor));
     }
 
     // Create input bindings
@@ -447,7 +447,7 @@ class DmlApplyAdamKernel : public DmlTrainingKernel {
 
     // Upload the training step scalar T to the GPU buffer
     D3D12BufferRegion dst =
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(t_tensor);
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(t_tensor);
     auto src = absl::MakeSpan(reinterpret_cast<const uint8_t*>(&t), sizeof(t));
     TF_RETURN_IF_ERROR(
         ctx->GetDmlDeviceContext()->CopyHostToBuffer(dst, src).status());
@@ -461,15 +461,15 @@ class DmlApplyAdamKernel : public DmlTrainingKernel {
     };
 
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             input_tensors[0]),  // InputParameters (var)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             input_tensors[1]),  // InputFirstMoment (m)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             input_tensors[2]),  // InputSecondMoment (v)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             input_tensors[3]),  // Gradient (grad)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+        ctx->GetDmlDeviceContext()->GetBufferForTensor(
             input_tensors[4]),  // TrainingStep
     };
 

--- a/tensorflow/core/kernels/dml_training_ops.cc
+++ b/tensorflow/core/kernels/dml_training_ops.cc
@@ -201,7 +201,8 @@ class DmlTrainingKernel : public DmlKernel {
     // Create input buffers
     absl::InlinedVector<D3D12BufferRegion, 16> input_buffers;
     for (const Tensor& input_tensor : input_tensors) {
-      input_buffers.push_back(ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor));
+      input_buffers.push_back(
+          ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensor));
     }
 
     // Create input bindings
@@ -227,7 +228,8 @@ class DmlTrainingKernel : public DmlKernel {
       } else {
         uint64_t intermediate_resource_size = input_tensors[i].TotalBytes();
         DmlBuffer intermediate_buffer =
-            ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(intermediate_resource_size);
+            ctx->GetDmlDeviceContext()->AllocateDefaultBuffer(
+                intermediate_resource_size);
         output_bindings.push_back(intermediate_buffer.GetBufferBinding());
         intermediate_buffers.push_back(std::move(intermediate_buffer));
       }
@@ -255,7 +257,8 @@ class DmlTrainingKernel : public DmlKernel {
 
         auto& input_buffer = input_buffers[input_index];
 
-        ctx->GetDmlDeviceContext()->CopyBufferToBuffer(input_buffer, intermediate_buffers[output_index].Region());
+        ctx->GetDmlDeviceContext()->CopyBufferToBuffer(
+            input_buffer, intermediate_buffers[output_index].Region());
       }
 
       status_or_gpu_event = ctx->GetDmlDeviceContext()->InsertUavBarrier();
@@ -443,7 +446,8 @@ class DmlApplyAdamKernel : public DmlTrainingKernel {
     TF_RETURN_IF_ERROR(op_ctx->allocate_temp(DT_UINT32, {}, &t_tensor));
 
     // Upload the training step scalar T to the GPU buffer
-    D3D12BufferRegion dst = ctx->GetDmlDeviceContext()->CreateBufferForTensor(t_tensor);
+    D3D12BufferRegion dst =
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(t_tensor);
     auto src = absl::MakeSpan(reinterpret_cast<const uint8_t*>(&t), sizeof(t));
     TF_RETURN_IF_ERROR(
         ctx->GetDmlDeviceContext()->CopyHostToBuffer(dst, src).status());
@@ -457,11 +461,16 @@ class DmlApplyAdamKernel : public DmlTrainingKernel {
     };
 
     D3D12BufferRegion input_buffers[] = {
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensors[0]),  // InputParameters (var)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensors[1]),  // InputFirstMoment (m)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensors[2]),  // InputSecondMoment (v)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensors[3]),  // Gradient (grad)
-        ctx->GetDmlDeviceContext()->CreateBufferForTensor(input_tensors[4]),  // TrainingStep
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            input_tensors[0]),  // InputParameters (var)
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            input_tensors[1]),  // InputFirstMoment (m)
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            input_tensors[2]),  // InputSecondMoment (v)
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            input_tensors[3]),  // Gradient (grad)
+        ctx->GetDmlDeviceContext()->CreateBufferForTensor(
+            input_tensors[4]),  // TrainingStep
     };
 
     absl::optional<DML_BUFFER_BINDING> input_bindings[] = {
@@ -1237,13 +1246,13 @@ class DmlApplyKerasMomentumKernel : public DmlTrainingKernel {
   }
 };
 
-#define REGISTER_KERNEL(type)                                                  \
-  REGISTER_KERNEL_BUILDER(                                                     \
-      Name("ResourceApplyKerasMomentum")                                       \
-          .Device(DEVICE_DML)                                                  \
-          .HostMemory("var")                                                   \
-          .HostMemory("accum")                                                 \
-          .TypeConstraint<type>("T"),                                          \
+#define REGISTER_KERNEL(type)            \
+  REGISTER_KERNEL_BUILDER(               \
+      Name("ResourceApplyKerasMomentum") \
+          .Device(DEVICE_DML)            \
+          .HostMemory("var")             \
+          .HostMemory("accum")           \
+          .TypeConstraint<type>("T"),    \
       DmlKernelWrapper<DmlApplyKerasMomentumKernel, NoOutputShapeHelper>);
 
 TF_CALL_DML_FLOAT_TYPES(REGISTER_KERNEL);

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -39,8 +39,7 @@ static void SetTensorToZero(OpKernelContext* ctx, const Tensor& tensor) {
   uint8_t pattern[] = {0};
 
   device->GetExecutionContext()->FillBufferWithPattern(
-      output_buffer.Resource(), output_buffer.Offset(),
-      output_buffer.SizeInBytes(), pattern);
+      output_buffer, pattern);
 }
 
 static Status DmlZerosLikeTensor(OpKernelContext* ctx, const Tensor& x,

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -35,7 +35,7 @@ static void SetTensorToZero(OpKernelContext* ctx, const Tensor& tensor) {
       static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
   D3D12BufferRegion output_buffer =
-      device_context->CreateBufferForTensor(tensor);
+      device_context->GetBufferForTensor(tensor);
 
   device_context->ZeroBuffer(output_buffer);
 }

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -31,9 +31,11 @@ template <typename T>
 static Status DmlVariantZerosLike(OpKernelContext* ctx, const T& x, T* y);
 
 static void SetTensorToZero(OpKernelContext* ctx, const Tensor& tensor) {
-  auto device_context = static_cast<DMLDeviceContext*>(ctx->op_device_context());
+  auto device_context =
+      static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
-  D3D12BufferRegion output_buffer = device_context->CreateBufferForTensor(tensor);
+  D3D12BufferRegion output_buffer =
+      device_context->CreateBufferForTensor(tensor);
 
   device_context->ZeroBuffer(output_buffer);
 }

--- a/tensorflow/core/kernels/dml_zeros_like_op.cc
+++ b/tensorflow/core/kernels/dml_zeros_like_op.cc
@@ -31,15 +31,11 @@ template <typename T>
 static Status DmlVariantZerosLike(OpKernelContext* ctx, const T& x, T* y);
 
 static void SetTensorToZero(OpKernelContext* ctx, const Tensor& tensor) {
-  DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
+  auto device_context = static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
-  D3D12BufferRegion output_buffer =
-      dml_util::CreateBufferForTensor(device, tensor);
+  D3D12BufferRegion output_buffer = device_context->CreateBufferForTensor(tensor);
 
-  uint8_t pattern[] = {0};
-
-  device->GetExecutionContext()->FillBufferWithPattern(
-      output_buffer, pattern);
+  device_context->ZeroBuffer(output_buffer);
 }
 
 static Status DmlZerosLikeTensor(OpKernelContext* ctx, const Tensor& x,


### PR DESCRIPTION
Ideally this change would be split into smaller ones, so I apologize in advanced for the large size. 

The major changes:

1. The primary DML suballocator (`D3D12HeapAllocator`) now supports allocations that are backed by multiple heaps (tiling) to better utilize local video memory and avoid demotion to non-local memory. The previous behavior of using contiguous heaps and placed resources is retained as a fallback for hardware that doesn't support tiled buffers.

2. The `D3D12HeapAllocator` no longer maintains a pool of resources for each allocation; instead, it has three otherwise identical resources that remain in fixed states: UAV, COPY_SRC, and COPY_DST. This change is important for change No. 1 because while placed resources are cheap, reserved resources can consume significant memory with their unique page tables. Consequently, `D3D12BufferRegion`s no longer take ownership of pooled resources and are now lightweight wrappers that help manage access to memory regions without kernels having to deal with resource state transitions directly.

3. Significant refactoring of the DML kernel context to move various helpers to a single interface (`DmlDeviceContext`). We previously had kernels calling into DmlKernelContext, DmlKernelConstruction, dml_util, DmlExecutionContext, DmlDeviceContext, and the upload/readback pooled allocators. This makes is extremely tedious to refactor any code involving allocations or copies without touching dozens of files. Going forward kernel code should go straight to the `DmlDeviceContext` for anything related to copies or allocation. It's important to transition most code away from using raw ID3D12Resource* objects and offsets and instead using `D3D12BufferRegion` now that resources aren't pooled: it would be easy to use the wrong ID3D12Resource* handle wrapped by this helper.

4. Memory growth is turned on by default for *all* adapters, not just UMA adapters. It's possible to go back to the GPU device policy by setting the TF_GPU_FORCE_ALLOW_GROWTH environment variable to "false". Memory growth isn't crucial now with reserved resources, but TFDML is most likely used for local training where we shouldn't assume TF deserves all the memory.

A bit more context for change No. 2. Recall that the BFC allocator carves up contiguous allocations and ensures distinct tensors live in physically separate chunks. However, the D3D API exposes GPU memory *primarily* through resources, not virtual addresses, so we must have resource objects to bind memory when executing operators. Creating resources on the fly is expensive, but caching resources is difficult since chunks are continually merged and split: the offsets and sizes of memory with an allocation/heap will vary significantly from resource to resource. The resource pool solved this by having all resources span the entirety of a heap and rely on offsets during binding. Multiple resources (all of which span the same region of heap memory) allowed callers to get unique instances for the purpose of resource barriers.

**NOTE**: this change will require some changes to DML debug layer validation (simultaneous bindings of same resource), which isn't enabled in TF by default.