### PR TITLE
Fix buffer region size with unaligned tensors

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_device_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_context.cc
@@ -241,7 +241,7 @@ D3D12BufferRegion DMLDeviceContext::GetBufferForTensor(
   // the bounds of the allocation. Instead we round the total bytes up to an
   // aligned value, which should always fit within the allocated bytes.
   uint64_t size_in_bytes =
-      dml_alignment + (tensor.TotalBytes() - 1) / dml_alignment;
+      (1 + (tensor.TotalBytes() - 1) / dml_alignment) * dml_alignment;
   CHECK(size_in_bytes <= tensor.AllocatedBytes());
 
   auto region = allocator_->CreateBufferRegion(p, size_in_bytes);

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -309,27 +309,6 @@ void CopyTensorInSameDevice(OpKernelContext* op_ctx, Tensor* dst,
       [op_ctx](const Status& s) { OP_REQUIRES_OK(op_ctx, s); });
 }
 
-D3D12BufferRegion GetBufferForTensor(const DmlDevice* device,
-                                     const Tensor& tensor) {
-  DmlAllocator* allocator = device->GetAllocator();
-  const void* p = tensor.tensor_data().data();
-
-  // Important: we must use AllocatedBytes() here and not TotalBytes() because
-  // AllocatedBytes includes the necessary padding and alignment, whereas
-  // TotalBytes is exactly equal to the number of elements multiplied by the
-  // element size.
-  uint64_t size_in_bytes = tensor.AllocatedBytes();
-
-  auto region = allocator->CreateBufferRegion(p, size_in_bytes);
-
-  // DML always requires at least 4 byte alignment in all cases, so both the
-  // offset and size must certainly be divisible by 4
-  DCHECK(region.Offset() % 4 == 0);
-  DCHECK(region.SizeInBytes() % 4 == 0);
-
-  return region;
-}
-
 absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 8> GetBufferBindings(
     absl::Span<const D3D12BufferRegion> buffers) {
   absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 8> bindings;

--- a/tensorflow/core/common_runtime/dml/dml_util.h
+++ b/tensorflow/core/common_runtime/dml/dml_util.h
@@ -87,9 +87,6 @@ namespace dml_util {
 void CopyTensorInSameDevice(OpKernelContext* op_ctx, Tensor* dst,
                             const Tensor& src);
 
-D3D12BufferRegion GetBufferForTensor(const DmlDevice* device,
-                                     const Tensor& tensor);
-
 // Calls D3D12BufferRegion::GetBufferBinding on each of the buffers and returns
 // the result.
 absl::InlinedVector<absl::optional<DML_BUFFER_BINDING>, 8> GetBufferBindings(

--- a/tensorflow/core/kernels/dml_check_numerics_op.cc
+++ b/tensorflow/core/kernels/dml_check_numerics_op.cc
@@ -144,10 +144,11 @@ class DmlCheckNumericsKernel : public DmlKernel {
     } else {
       // If everything is fine, we simply copy the input to the output
       D3D12BufferRegion input_buffer =
-          dml_util::GetBufferForTensor(device, ctx->GetInputTensor(0));
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(
+              ctx->GetInputTensor(0));
 
       D3D12BufferRegion output_buffer =
-          dml_util::GetBufferForTensor(device, *output_tensor);
+          ctx->GetDmlDeviceContext()->GetBufferForTensor(*output_tensor);
 
       ctx->GetDmlDeviceContext()->CopyBufferToBuffer(
           output_buffer,

--- a/tensorflow/core/kernels/dml_data_format_vec_permute.cc
+++ b/tensorflow/core/kernels/dml_data_format_vec_permute.cc
@@ -164,15 +164,13 @@ class DmlDataFormatVecPermuteKernel : public OpKernel {
     Tensor* output = nullptr;
     OP_REQUIRES_OK(ctx, ctx->allocate_output(0, input_shape, &output));
 
-    DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
     auto device_context =
         static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
-    D3D12BufferRegion input_buffer =
-        dml_util::GetBufferForTensor(device, input);
+    D3D12BufferRegion input_buffer = device_context->GetBufferForTensor(input);
 
     D3D12BufferRegion output_buffer =
-        dml_util::GetBufferForTensor(device, *output);
+        device_context->GetBufferForTensor(*output);
 
     const int perm_stride = DataTypeSize(input.dtype()) * input_shape.dims();
 

--- a/tensorflow/core/kernels/dml_deepcopy_op.cc
+++ b/tensorflow/core/kernels/dml_deepcopy_op.cc
@@ -33,20 +33,19 @@ class DmlDeepCopyKernel : public OpKernel {
     Tensor* output = nullptr;
     OP_REQUIRES_OK(ctx, ctx->allocate_output(0, input_shape, &output));
 
-    DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
-    const auto& execution_context = device->GetExecutionContext();
+    auto device_context =
+        static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
-    D3D12BufferRegion input_buffer =
-        dml_util::GetBufferForTensor(device, input);
+    D3D12BufferRegion input_buffer = device_context->GetBufferForTensor(input);
 
     D3D12BufferRegion output_buffer =
-        dml_util::GetBufferForTensor(device, *output);
+        device_context->GetBufferForTensor(*output);
 
     uint64_t copy_size =
         std::min(output_buffer.SizeInBytes(), input_buffer.SizeInBytes());
 
-    execution_context->CopyBufferRegion(output_buffer,
-                                        input_buffer.Subregion(0, copy_size));
+    device_context->CopyBufferToBuffer(output_buffer,
+                                       input_buffer.Subregion(0, copy_size));
   }
 };
 

--- a/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dml_dynamic_stitch_op.cc
@@ -95,7 +95,6 @@ class DmlDynamicStitchKernel : public OpKernel {
       return;
     }
 
-    DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
     auto* device_context =
         static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
@@ -114,13 +113,13 @@ class DmlDynamicStitchKernel : public OpKernel {
       }
 
       D3D12BufferRegion input_buffer =
-          dml_util::GetBufferForTensor(device, data_tensor);
+          device_context->GetBufferForTensor(data_tensor);
 
       input_buffers.push_back(std::move(input_buffer));
     }
 
     D3D12BufferRegion output_buffer =
-        dml_util::GetBufferForTensor(device, *output_tensor);
+        device_context->GetBufferForTensor(*output_tensor);
 
     DCHECK(indices_inputs.size() == data_inputs.size());
     for (int tensor_idx = 0; tensor_idx < indices_inputs.size(); ++tensor_idx) {
@@ -141,8 +140,6 @@ class DmlDynamicStitchKernel : public OpKernel {
         const uint64_t src_offset = byte_stride * i;
         const uint64_t dst_offset = byte_stride * output_idx;
 
-        auto device_context =
-            static_cast<DMLDeviceContext*>(ctx->op_device_context());
         device_context->CopyBufferToBuffer(
             output_buffer.Subregion(dst_offset),
             input_buffer.Subregion(src_offset, byte_stride));

--- a/tensorflow/core/kernels/dml_empty_op.cc
+++ b/tensorflow/core/kernels/dml_empty_op.cc
@@ -42,12 +42,11 @@ class DmlEmptyKernel : public OpKernel {
     OP_REQUIRES_OK(ctx, ctx->allocate_output(0, out_shape, &output_tensor));
 
     if (init_ && out_shape.num_elements() > 0) {
-      DmlDevice* device = static_cast<DmlDevice*>(ctx->device());
       auto device_context =
           static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
       D3D12BufferRegion output_buffer =
-          dml_util::GetBufferForTensor(device, *output_tensor);
+          device_context->GetBufferForTensor(*output_tensor);
 
       device_context->ZeroBuffer(output_buffer);
     }

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -91,10 +91,12 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
 
         // If the tensor is nonempty, fill it with zero's
         if (output_tensor->NumElements() != 0) {
+          auto* device_context =
+              static_cast<DMLDeviceContext*>(ctx->op_device_context());
+
           D3D12BufferRegion buffer =
-              dml_util::GetBufferForTensor(dml_device, *output_tensor);
-          static_cast<DMLDeviceContext*>(ctx->op_device_context())
-              ->ZeroBuffer(buffer);
+              device_context->GetBufferForTensor(*output_tensor);
+          device_context->ZeroBuffer(buffer);
         }
       }
       return;

--- a/tensorflow/core/kernels/dml_tensor_array.cc
+++ b/tensorflow/core/kernels/dml_tensor_array.cc
@@ -63,22 +63,19 @@ Status DmlAddToTensor(OpKernelContext* ctx, Tensor* sum, const Tensor* current,
 }
 
 void DmlTensorSetZero(OpKernelContext* ctx, Tensor* value) {
-  auto* device = static_cast<DmlDevice*>(ctx->device());
   auto device_context =
       static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
-  D3D12BufferRegion dst = dml_util::GetBufferForTensor(device, *value);
+  D3D12BufferRegion dst = device_context->GetBufferForTensor(*value);
   device_context->ZeroBuffer(dst);
 }
 
 void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
                       absl::Span<PersistentTensor> values) {
-  auto* device = static_cast<DmlDevice*>(ctx->device());
   auto device_context =
       static_cast<DMLDeviceContext*>(ctx->op_device_context());
 
-  D3D12BufferRegion dst =
-      dml_util::GetBufferForTensor(device, *output_tensor);
+  D3D12BufferRegion dst = device_context->GetBufferForTensor(*output_tensor);
   uint64_t dst_offset = 0;
 
   for (PersistentTensor& value : values) {
@@ -89,8 +86,7 @@ void DmlConcatTensors(OpKernelContext* ctx, Tensor* output_tensor,
     assert(input_tensor.NumElements() <= output_tensor->NumElements());
 
     uint64_t bytes_to_copy = input_tensor.TotalBytes();
-    D3D12BufferRegion src =
-        dml_util::GetBufferForTensor(device, input_tensor);
+    D3D12BufferRegion src = device_context->GetBufferForTensor(input_tensor);
 
     device_context->CopyBufferToBuffer(dst.Subregion(dst_offset),
                                        src.Subregion(0, bytes_to_copy));
@@ -113,12 +109,10 @@ void DmlSplitTensor(OpKernelContext* ctx, Tensor* output_tensor,
   uint64_t bytes_to_copy = element_count * element_byte_size;
   uint64_t src_offset = start_element * element_byte_size;
 
-  auto* device = static_cast<DmlDevice*>(ctx->device());
   auto device_context =
       static_cast<DMLDeviceContext*>(ctx->op_device_context());
-  D3D12BufferRegion dst =
-      dml_util::GetBufferForTensor(device, *output_tensor);
-  D3D12BufferRegion src = dml_util::GetBufferForTensor(device, input_tensor);
+  D3D12BufferRegion dst = device_context->GetBufferForTensor(*output_tensor);
+  D3D12BufferRegion src = device_context->GetBufferForTensor(input_tensor);
 
   device_context->CopyBufferToBuffer(dst,
                                      src.Subregion(src_offset, bytes_to_copy));


### PR DESCRIPTION
DML tensors have buffers pointing at memory allocated through the BFC allocator, which typically means the pointer/address is at the head of a BFC chunk. BFC chunks are naturally aligned to 256 bytes, which more than satisfies DML alignment requirements, so we've been using the `Tensor::AllocatedBytes` method when creating buffer regions for DML tensor objects. This is almost always safe, but there are some code paths (e.g. `Tensor::Slice`) that can return a new tensor with unaligned memory that does not point at the head of a BFC chunk (the pointer is offset, but the by AllocatedBytes remains unchanged). In these cases using `Tensor::AllocatedBytes` may result in a buffer region that extends beyond the underlying D3D heap/resource. We see this happening more frequently when memory growth is allowed and a test/model uses tensor lists that slice into subtensors.

This change makes our buffer regions created from tensors use the `Tensor::TotalBytes` method instead, but then pad the size to fit into DML requirements. This padding should already exist and fit within the allocation size. This is an alternative to knowing the exact offset of the unaligned tensor (otherwise we'd compute AllocatedBytes - offset for the region size). 

We also had two separate copies of the `GetBufferForTensor` function so the rest of this PR simply removes the duplicate and refactors callers to use the DML device context version.