### PR TITLE
Fix invalid write in the DML ops simple test

### DIFF
--- a/tensorflow/core/kernels/dml_ops_simple_test.cc
+++ b/tensorflow/core/kernels/dml_ops_simple_test.cc
@@ -157,12 +157,12 @@ TEST(DmlKernelTests, SimpleExample) {
   inputs.emplace(max, 1.2f);
   TF_CHECK_OK(session.Run(inputs, {result}, &outputs));
 
-  output = outputs[0].matrix<float>();
+  auto output2 = outputs[0].matrix<float>();
   LOG(INFO) << output;
-  EXPECT_FLOAT_EQ(output(0, 0), 0.7f);
-  EXPECT_FLOAT_EQ(output(0, 1), 0.9f);
-  EXPECT_FLOAT_EQ(output(1, 0), 1.1f);
-  EXPECT_FLOAT_EQ(output(1, 1), 1.2f);
+  EXPECT_FLOAT_EQ(output2(0, 0), 0.7f);
+  EXPECT_FLOAT_EQ(output2(0, 1), 0.9f);
+  EXPECT_FLOAT_EQ(output2(1, 0), 1.1f);
+  EXPECT_FLOAT_EQ(output2(1, 1), 1.2f);
 }
 
 TEST(DmlKernelTests, Relu) {


### PR DESCRIPTION
`Eigen::TensorMap::operator=` isn't a trivial operation that simply creates an entirely new object. Instead, it does memcpy on memory that has already been allocated in the past. Since we clear the `outputs` vector, that memory has been deallocated but we still try to do a memcpy on it.