### PR TITLE
Avoid BFC warnings about allocating 0 descriptors

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.cc
@@ -28,8 +28,9 @@ DmlDescriptorAllocator::DmlDescriptorAllocator(
 DescriptorAllocation DmlDescriptorAllocator::Alloc(size_t size_in_descriptors) {
   if (size_in_descriptors == 0) {
     // An empty allocation is possible and valid (e.g. initializing an op with
-    // no descriptors required), so don't bother calling AllocateRaw. The returned
-    // DescriptorAllocation with is valid for initializers that require zero descriptors.
+    // no descriptors required), so don't bother calling AllocateRaw. The
+    // returned DescriptorAllocation with is valid for initializers that require
+    // zero descriptors.
     return DescriptorAllocation(nullptr, nullptr, 0);
   }
 

--- a/tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.cc
@@ -28,7 +28,8 @@ DmlDescriptorAllocator::DmlDescriptorAllocator(
 DescriptorAllocation DmlDescriptorAllocator::Alloc(size_t size_in_descriptors) {
   if (size_in_descriptors == 0) {
     // An empty allocation is possible and valid (e.g. initializing an op with
-    // no descriptors required).
+    // no descriptors required), so don't bother calling AllocateRaw. The returned
+    // DescriptorAllocation with is valid for initializers that require zero descriptors.
     return DescriptorAllocation(nullptr, nullptr, 0);
   }
 
@@ -68,8 +69,6 @@ DescriptorAllocation& DescriptorAllocation::operator=(
 
 D3D12DescriptorHandles DescriptorAllocation::GetDescriptorHandles() const {
   if (!allocator_ || !p_) {
-    // TODO: #34700726 use null handles instead of invalid handles when DML is
-    // updated to support this.
     return D3D12DescriptorHandles{nullptr, UINT64(-1), SIZE_T(-1)};
   }
   return allocator_->GetDescriptorHandles(p_);

--- a/tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_descriptor_bfc_allocator.cc
@@ -26,6 +26,12 @@ DmlDescriptorAllocator::DmlDescriptorAllocator(
       heap_allocator_(heap_allocator) {}
 
 DescriptorAllocation DmlDescriptorAllocator::Alloc(size_t size_in_descriptors) {
+  if (size_in_descriptors == 0) {
+    // An empty allocation is possible and valid (e.g. initializing an op with
+    // no descriptors required).
+    return DescriptorAllocation(nullptr, nullptr, 0);
+  }
+
   void* p = this->AllocateRaw(0, size_in_descriptors);
   return DescriptorAllocation(this, p, size_in_descriptors);
 }
@@ -62,10 +68,13 @@ DescriptorAllocation& DescriptorAllocation::operator=(
 
 D3D12DescriptorHandles DescriptorAllocation::GetDescriptorHandles() const {
   if (!allocator_ || !p_) {
+    // TODO: #34700726 use null handles instead of invalid handles when DML is
+    // updated to support this.
     return D3D12DescriptorHandles{nullptr, UINT64(-1), SIZE_T(-1)};
   }
   return allocator_->GetDescriptorHandles(p_);
 }
+
 void DescriptorAllocation::Reset() {
   if (allocator_ && p_) {
     allocator_->DeallocateRaw(p_);


### PR DESCRIPTION
The BFC allocator will emit logging messages if you attempt to Allocate 0 bytes through `AllocateRaw`, which makes sense most of the time, but 0 descriptors is valid. The binding code was already handling this case just fine, but this change will prevent the BFC warnings from being printed to logs.