### PR TITLE
Fix leaks in 'where' and 'tensorarray' kernels

### DIFF
--- a/tensorflow/core/kernels/dml_tensor_array.cc
+++ b/tensorflow/core/kernels/dml_tensor_array.cc
@@ -56,8 +56,10 @@ Status DmlAddToTensor(OpKernelContext* ctx, Tensor* sum, const Tensor* current,
 
   TensorValue out = op_ctx.release_output(0);
   ctx->device()->CopyTensorInSameDevice(
-      out.tensor, sum, ctx->op_device_context(),
-      [ctx](const Status& s) { OP_REQUIRES_OK(ctx, s); });
+      out.tensor, sum, ctx->op_device_context(), [ctx, out](const Status& s) {
+        OP_REQUIRES_OK(ctx, s);
+        delete out.tensor;
+      });
 
   return op_ctx.status();
 }


### PR DESCRIPTION
Normally the op kernel context frees output tensors upon destruction, but calling `release_output()` method will transfer ownership of the tensor object to the caller. Unfortunately, the DML `Where` kernel and `DmlAddToTensor` functions were using this method and never actually freed the allocations. The `Where` kernel leaked three separate allocations:

1. The scalar tensor that holds the count of nonzero coordinates.
2. The 32-bit UINT tensor output from the DML operator (reference to the tensor is overwritten in `ComputeCast` function).
3. The 64-bit INT tensor output from the cast operation.

The `DmlAddToTensor` function is rarely called but leaks the output tensor (presumably to keep to alive until the GPU copy is completed?).

The fix could be cleaner by refactoring some code and using smart pointers, but these are the only places in DML code that call `release_output()` and the refactoring would be riskier than the fix for now.

This should address the leak in #294 