### PR TITLE
Seed LinearOperatorToeplitzTest tests

### DIFF
--- a/tensorflow/python/ops/linalg/linear_operator_test_util.py
+++ b/tensorflow/python/ops/linalg/linear_operator_test_util.py
@@ -39,6 +39,8 @@ from tensorflow.python.ops.linalg import linalg_impl as linalg
 from tensorflow.python.ops.linalg import linear_operator_util
 from tensorflow.python.platform import test
 
+# Seed the numpy RNG to get reproducible results every time
+np.random.seed(42)
 
 class OperatorShapesInfo(object):
   """Object encoding expected shape for a test.


### PR DESCRIPTION
Even though the graph session was seeded with `random_seed.DEFAULT_GRAPH_SEED`, the numpy random number generator wasn't seeded and therefore was producing unreproducible results. On some hardware, this would eventually yield results that were just outside of the allowed tolerances and fail the test.