### PR TITLE
Get rid of zombie processes when tests time out

### DIFF
--- a/third_party/dml/ci/run_tests.py
+++ b/third_party/dml/ci/run_tests.py
@@ -54,24 +54,22 @@ def main():
         else:
           conda_env.install_package(args.tensorflow_wheel)
 
-        if "pipDeps" in json_test_group:
-          for dep in json_test_group["pipDeps"]:
-            conda_env.install_package(dep)
+      if "pipDeps" in json_test_group:
+        for dep in json_test_group["pipDeps"]:
+          conda_env.install_package(dep)
 
-        if "localPipDeps" in json_test_group:
-          for dep in json_test_group["localPipDeps"]:
-            dep_abs_path = os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                dep)
+      if "localPipDeps" in json_test_group:
+        for dep in json_test_group["localPipDeps"]:
+          dep_abs_path = os.path.join(
+              os.path.dirname(os.path.abspath(__file__)),
+              dep)
+        conda_env.install_local_package(dep_abs_path)
 
-            conda_env.install_local_package(dep_abs_path)
-
-        if os.name == "nt" and "windowsPipDeps" in json_test_group:
-          for dep in json_test_group["windowsPipDeps"]:
-            conda_env.install_package(dep)
+      if os.name == "nt" and "windowsPipDeps" in json_test_group:
+        for dep in json_test_group["windowsPipDeps"]:
+          conda_env.install_package(dep)
 
       command_line = [os.path.join(sys.path[0], "tests", script)]
-
       if "arguments" in json_test_group:
         for arg_name, arg_value in json_test_group["arguments"].items():
           command_line.append(f"{arg_name}={arg_value}")

--- a/third_party/dml/ci/run_tests_data.json
+++ b/third_party/dml/ci/run_tests_data.json
@@ -13,7 +13,8 @@
         "numpy==1.18.5",
         "h5py<3.0.0",
         "scipy",
-        "portpicker==1.5.0b1"
+        "portpicker==1.5.0b1",
+        "psutil"
       ],
       "windowsPipDeps": [
         "windows-curses",
@@ -27,6 +28,9 @@
         "--test_binaries_path": "test_binaries/core",
         "--test_framework": "gtest"
       },
+      "pipDeps": [
+        "psutil"
+      ],
       "isPythonTest": false
     },
     "c": {
@@ -35,6 +39,9 @@
         "--test_binaries_path": "test_binaries/c",
         "--test_framework": "gtest"
       },
+      "pipDeps": [
+        "psutil"
+      ],
       "isPythonTest": false
     }
   }


### PR DESCRIPTION
Sometimes when tests time out, some lingering python processes stay alive and we need to manually kill them.