### PR TITLE
Link with D3D12 and DXGI/DXCore at runtime instead of load time

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -36,9 +36,7 @@ Developer mode is, as the name indicates, only intended to be used for developme
 
 The development headers and libraries used to build DirectX-based applications are included in the Windows SDK; however, this SDK is not available when building for Linux, and some of required APIs may not yet exist in public versions of the SDK. For these reasons, the DirectX development files are integrated a little differently in this project.
 
-The header files for Direct3D, DXCore, and DirectML are downloaded automatically. This project does not use any DirectX headers included in the Windows 10 SDK *except* for dxgi1_6.h, which is part of Windows 10 SDK 10.0.17763.0 or newer. Windows builds also require import libraries for D3D12 and DXGI, which are included in Windows 10 SDK 10.0.17763.0 or newer.
-
-Linux builds do not require the Windows 10 SDK at all (no such SDK exists for Linux), but your build machine must have WSL installed with the DirectX shared libraries available under `/usr/lib/wsl/lib`.
+The header files for Direct3D, DXCore, and DirectML are downloaded automatically. This project does not use any DirectX headers included in the Windows 10 SDK *except* for dxgi1_6.h, which is part of Windows 10 SDK 10.0.17763.0 or newer.
 
 The use of the redistributable DirectML library is governed by a separate license that is found as part of the package (found in `tensorflow_core/python/DirectML_LICENSE.txt` when extracted).
 
@@ -49,15 +47,24 @@ We've tested the following build environments, and we recommend using a Python e
 - **Windows**
   - Visual Studio 2017 (15.x)
   - Windows 10 SDK 10.0.17763.0 or newer
-  - MSYS2 20190524 or newer
+  - MSYS2 20190524 or newer with the *git*, *unzip*, and *patch* packages installed
   - Bazel 0.24.1
+  - Python 3.5, 3.6, or 3.7 environment with the following packages installed:
+    - six
+    - numpy
+    - wheel
+    - keras_applications==1.0.6
+    - keras_preprocessing==1.0.5
 
-- **WSL**
-  - Windows 10 Insider Build with WSL feature enabled (you must have libd3d12.so and libdxcore.so in `C:\Windows\System32\lxss\lib`)
-  - Ubuntu 18.04 or 20.04 with g++ package
+- **Linux**
+  - Any glibc-based distro (we've tested Ubuntu 18.04+) with gcc/g++ packages
   - Bazel 0.24.1
-
-**NOTE**: currently, it's only possible to build the Linux version of tensorflow-directml from a WSL environment. The D3D/DXCore libraries are needed for linking and are not yet available through another distribution channel. The DirectML redistributable package requires nuget.exe (a PE executable) to download, which also requires WSL/Windows interop. We hope to remove these restrictions in the near future.
+  - Python 3.5, 3.6, or 3.7 environment with the following packages installed:
+    - six
+    - numpy
+    - wheel
+    - keras_applications==1.0.6
+    - keras_preprocessing==1.0.5
 
 ## Build Script
 
@@ -119,7 +126,7 @@ Next, activate the environment. Activating an environment will set up the `PATH`
 Within the activated environment, install the following Python packages required for TensorFlow:
 
 ```
-(tfdml) PS> pip install six numpy==1.18.5 wheel
+(tfdml) PS> pip install six numpy wheel
 (tfdml) PS> pip install keras_applications==1.0.6 --no-deps
 (tfdml) PS> pip install keras_preprocessing==1.0.5 --no-deps
 ```

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3666,6 +3666,10 @@ cc_library(
 cc_library(
     name = "dml_runtime_impl",
     srcs = [
+        "common_runtime/dml/dml_adapter.cc",
+        "common_runtime/dml/dml_adapter_impl.cc",
+        "common_runtime/dml/dml_error_handling.cc",
+        "common_runtime/dml/dml_guids.cc",
         "common_runtime/dml/dml_device_cache.cc",
         "common_runtime/dml/dml_bfc_allocator.cc",
         "common_runtime/dml/dml_buffer.cc",
@@ -3693,6 +3697,12 @@ cc_library(
         "common_runtime/dml/dml_tracing.cc",
     ],
     hdrs = [
+        "common_runtime/dml/dml_common.h",
+        "common_runtime/dml/dml_error_handling.h",
+        "common_runtime/dml/dml_adapter.h",
+        "common_runtime/dml/dml_adapter_impl.h",
+        "common_runtime/dml/dml_adapter_heuristics.h",
+        "common_runtime/dml/dml_guids.h",
         "common_runtime/dml/dml_device_cache.h",
         "common_runtime/dml/dml_bfc_allocator.h",
         "common_runtime/dml/dml_buffer.h",
@@ -3735,7 +3745,13 @@ cc_library(
         "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"
     ]),
     deps = [
-        ":dml_core",
+        ":lib",
+        ":lib_internal",
+        "@dml_redist//:headers",
+        "@directml//:directmlx",
+        "@directx_headers//:directx_headers",
+        "@directx_headers//:directx_guids",
+        "@directx_headers//:directx_winadapter",
         ":framework",
         ":framework_internal",
         ":gpu_bfc_allocator",
@@ -3743,6 +3759,12 @@ cc_library(
         ":stream_executor",
         "//tensorflow/stream_executor/platform:dso_loader",
     ] + if_windows(["@pix//:headers"]),
+    linkopts = if_windows([
+        "pathcch.lib",
+        "advapi32.lib",
+    ]) + if_not_windows([
+        "-Wl,-rpath,$$ORIGIN"
+    ]),
 )
 
 cc_library(
@@ -3769,50 +3791,6 @@ cc_library(
     copts = tf_copts() + if_windows([
         "-DDML_BUILD_WINDOWS",
         "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"
-    ]),
-)
-
-cc_library(
-    name = "dml_core",
-    srcs = [
-        "common_runtime/dml/dml_adapter.cc",
-        "common_runtime/dml/dml_adapter_impl.cc",
-        "common_runtime/dml/dml_error_handling.cc",
-        "common_runtime/dml/dml_guids.cc",
-    ],
-    hdrs = [
-        "common_runtime/dml/dml_common.h",
-        "common_runtime/dml/dml_error_handling.h",
-        "common_runtime/dml/dml_adapter.h",
-        "common_runtime/dml/dml_adapter_impl.h",
-        "common_runtime/dml/dml_adapter_heuristics.h",
-        "common_runtime/dml/dml_guids.h",
-    ],
-    linkstatic = 1,
-    deps = [
-        ":lib",
-        ":lib_internal",
-        "@dml_redist//:headers",
-        "@directml//:directmlx",
-        "@directx_headers//:directx_headers",
-        "@directx_headers//:directx_guids",
-        "@directx_headers//:directx_winadapter",
-    ],
-    alwayslink = 1,
-    visibility = ["//visibility:public"],
-    copts = tf_copts() + if_windows([
-        "-DDML_BUILD_WINDOWS",
-        "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"
-    ]),
-    linkopts = if_windows([
-        "d3d12.lib", 
-        "dxgi.lib", 
-        "pathcch.lib",
-        "advapi32.lib",
-    ]) + if_not_windows([
-        "-ld3d12",
-        "-ldxcore",
-        "-Wl,-rpath,$$ORIGIN"
     ]),
 )
 

--- a/tensorflow/core/common_runtime/dml/dml_adapter_impl.cc
+++ b/tensorflow/core/common_runtime/dml/dml_adapter_impl.cc
@@ -116,10 +116,7 @@ std::vector<DmlAdapterImpl> FilterAdapterListFromEnvVar(
 
 DmlAdapterImpl::DmlAdapterImpl(LUID adapter_luid) {
 #if _WIN32
-  ComPtr<IDXGIFactory4> dxgi_factory = TryCreateDxgiFactory();
-  if (!dxgi_factory) {
-    LOG(FATAL) << "Could not create DXGI factory.";
-  }
+  ComPtr<IDXGIFactory4> dxgi_factory = CreateDxgiFactory();
 
   ComPtr<IDXGIAdapter1> adapter;
   DML_CHECK_SUCCEEDED(
@@ -186,7 +183,7 @@ bool IsSoftwareAdapter(IDXGIAdapter1* adapter) {
 };
 
 std::vector<DmlAdapterImpl> EnumerateAdapterImpls() {
-  ComPtr<IDXGIFactory4> dxgi_factory = TryCreateDxgiFactory();
+  ComPtr<IDXGIFactory4> dxgi_factory = TryCreateDxgiFactory(DxCallErrorHandling::Warning);
   if (!dxgi_factory) {
     return {};
   }

--- a/tensorflow/core/common_runtime/dml/dml_device_factory.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_factory.cc
@@ -76,8 +76,8 @@ static bool IsUmaAdapter(const DmlAdapter& adapter) {
   }
 
   D3D12_FEATURE_DATA_ARCHITECTURE feature_data = {};
-  HRESULT hr = d3d12_device->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE,
-                                         &feature_data, sizeof(feature_data));
+  HRESULT hr = d3d12_device->CheckFeatureSupport(
+      D3D12_FEATURE_ARCHITECTURE, &feature_data, sizeof(feature_data));
 
   if (FAILED(hr)) {
     return false;

--- a/tensorflow/core/common_runtime/dml/dml_device_state.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_state.cc
@@ -45,8 +45,7 @@ namespace tensorflow {
                                         : D3D_FEATURE_LEVEL_11_0;
 
   ComPtr<ID3D12Device> d3d_device =
-      TryCreateD3d12Device(adapter.Impl()->Get(), feature_level);
-  CHECK(d3d_device != nullptr);
+      CreateD3d12Device(adapter.Impl()->Get(), feature_level);
 
   DML_CREATE_DEVICE_FLAGS dml_flags = DML_CREATE_DEVICE_FLAG_NONE;
 

--- a/tensorflow/core/common_runtime/dml/dml_device_state.cc
+++ b/tensorflow/core/common_runtime/dml/dml_device_state.cc
@@ -44,9 +44,9 @@ namespace tensorflow {
                                         ? D3D_FEATURE_LEVEL_1_0_CORE
                                         : D3D_FEATURE_LEVEL_11_0;
 
-  ComPtr<ID3D12Device> d3d_device;
-  DML_CHECK_SUCCEEDED(D3D12CreateDevice(adapter.Impl()->Get(), feature_level,
-                                        IID_PPV_ARGS(&d3d_device)));
+  ComPtr<ID3D12Device> d3d_device =
+      TryCreateD3d12Device(adapter.Impl()->Get(), feature_level);
+  CHECK(d3d_device != nullptr);
 
   DML_CREATE_DEVICE_FLAGS dml_flags = DML_CREATE_DEVICE_FLAG_NONE;
 

--- a/tensorflow/core/common_runtime/dml/dml_kernel_manager_test.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_manager_test.cc
@@ -223,8 +223,7 @@ TEST_F(DmlKernelManagerTest, QueueReference) {
   ComPtr<ID3D12Device> device;
 
 #ifdef DML_BUILD_WINDOWS
-  DML_CHECK_SUCCEEDED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0,
-                                        IID_PPV_ARGS(&device)));
+  device = CreateD3d12Device(nullptr, D3D_FEATURE_LEVEL_11_0);
 #else
   auto adapters = EnumerateAdapters();
   EXPECT_FALSE(adapters.empty());
@@ -233,8 +232,7 @@ TEST_F(DmlKernelManagerTest, QueueReference) {
                                                ? D3D_FEATURE_LEVEL_1_0_CORE
                                                : D3D_FEATURE_LEVEL_11_0;
 
-  DML_CHECK_SUCCEEDED(D3D12CreateDevice(
-      adapters[0].Impl()->Get(), dxcore_feature_level, IID_PPV_ARGS(&device)));
+  device = CreateD3d12Device(adapters[0].Impl()->Get(), dxcore_feature_level);
 #endif
 
   ComPtr<ID3D12Fence> fence;

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -43,7 +43,6 @@ Microsoft::WRL::ComPtr<TDeviceOrFactory> DxExportHelper(
   }
 
   // Load the function.
-  using D3D12CreateDeviceFn = decltype(D3D12CreateDevice);
   F* create_function;
   auto get_symbol_status = Env::Default()->GetSymbolFromLibrary(
       module_handle.ValueOrDie(), function_name, (void**)&create_function);

--- a/tensorflow/core/common_runtime/dml/dml_util.cc
+++ b/tensorflow/core/common_runtime/dml/dml_util.cc
@@ -110,7 +110,7 @@ Microsoft::WRL::ComPtr<IDXGIFactory4> TryCreateDxgiFactory(
 #endif  // _WIN32
 
 #ifndef _WIN32
-Microsoft::WRL::ComPtr<IDXCoreAdapterFactory> CreateDxCoreAdapterFactory(
+Microsoft::WRL::ComPtr<IDXCoreAdapterFactory> TryCreateDxCoreAdapterFactory(
     DxCallErrorHandling call_error_handling,
     DxCallErrorHandling module_error_handling) {
   // DXCoreCreateAdapterFactory has a C++ overload so we must be explicit in the

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -230,11 +230,27 @@ port::StatusOr<void*> GetDirectMLDebugDsoHandle() {
   return GetDirectMLLibraryHandle("directml.debug");
 }
 
+port::StatusOr<void*> GetD3d12DsoHandle() { return GetDsoHandle("d3d12", ""); }
+
+port::StatusOr<void*> GetDxgiDsoHandle() {
+#if _WIN32
+  return GetDsoHandle("dxgi", "");
+#else
+  return port::Status(port::error::UNIMPLEMENTED,
+                      "DXGI is not supported in WSL");
+#endif
+}
+
+port::StatusOr<void*> GetDxCoreDsoHandle() {
+  return GetDsoHandle("dxcore", "");
+}
+
 port::StatusOr<void*> GetPixDsoHandle() {
 #if _WIN32
   return GetDsoHandle("WinPixEventRuntime", "", GetModuleDirectory());
 #else
-  return port::Status(port::error::UNIMPLEMENTED, "PIX events are not supported in WSL");
+  return port::Status(port::error::UNIMPLEMENTED,
+                      "PIX events are not supported in WSL");
 #endif
 }
 #endif  // TENSORFLOW_USE_DIRECTML
@@ -243,7 +259,8 @@ port::StatusOr<void*> GetKernel32DsoHandle() {
 #if _WIN32
   return GetDsoHandle("Kernel32", "");
 #else
-  return port::Status(port::error::UNIMPLEMENTED, "Kernel32.dll is only available on Windows");
+  return port::Status(port::error::UNIMPLEMENTED,
+                      "Kernel32.dll is only available on Windows");
 #endif
 }
 
@@ -328,6 +345,21 @@ port::StatusOr<void*> GetDirectMLDsoHandle() {
 
 port::StatusOr<void*> GetDirectMLDebugDsoHandle() {
   static auto result = new auto(DsoLoader::GetDirectMLDebugDsoHandle());
+  return *result;
+}
+
+port::StatusOr<void*> GetD3d12DsoHandle() {
+  static auto result = new auto(DsoLoader::GetD3d12DsoHandle());
+  return *result;
+}
+
+port::StatusOr<void*> GetDxgiDsoHandle() {
+  static auto result = new auto(DsoLoader::GetDxgiDsoHandle());
+  return *result;
+}
+
+port::StatusOr<void*> GetDxCoreDsoHandle() {
+  static auto result = new auto(DsoLoader::GetDxCoreDsoHandle());
   return *result;
 }
 

--- a/tensorflow/stream_executor/platform/default/dso_loader.h
+++ b/tensorflow/stream_executor/platform/default/dso_loader.h
@@ -53,6 +53,9 @@ port::StatusOr<void*> GetRocrandDsoHandle();
 port::StatusOr<void*> GetHipDsoHandle();
 port::StatusOr<void*> GetDirectMLDsoHandle();
 port::StatusOr<void*> GetDirectMLDebugDsoHandle();
+port::StatusOr<void*> GetD3d12DsoHandle();
+port::StatusOr<void*> GetDxgiDsoHandle();
+port::StatusOr<void*> GetDxCoreDsoHandle();
 port::StatusOr<void*> GetPixDsoHandle();
 port::StatusOr<void*> GetKernel32DsoHandle();
 
@@ -89,6 +92,9 @@ port::StatusOr<void*> GetRocrandDsoHandle();
 port::StatusOr<void*> GetHipDsoHandle();
 port::StatusOr<void*> GetDirectMLDsoHandle();
 port::StatusOr<void*> GetDirectMLDebugDsoHandle();
+port::StatusOr<void*> GetD3d12DsoHandle();
+port::StatusOr<void*> GetDxgiDsoHandle();
+port::StatusOr<void*> GetDxCoreDsoHandle();
 port::StatusOr<void*> GetPixDsoHandle();
 port::StatusOr<void*> GetKernel32DsoHandle();
 }  // namespace CachedDsoLoader

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -87,11 +87,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     # TODO: Remove def file filter when TensorFlow can export symbols properly on Windows.
     def_file_filter_configure(name = "local_config_def_file_filter")
 
+    # URL must point at the DirectML redistributable NuGet package.
     dml_repository(
         name = "dml_redist",
-        package = "Microsoft.AI.DirectML.Preview",
-        version = "1.7.0-dev20210806",
-        source = "https://api.nuget.org/v3/index.json",
+        url = "https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML.Preview/1.7.0-dev20210824",
+        sha256 = "43bfee662d1f0e51086f609b54baae727866ef6a838ffa62d2a4e478492da46e",
         build_file = "//third_party/dml/redist:BUILD.bazel",
     )
 

--- a/third_party/dml/redist/BUILD.bazel
+++ b/third_party/dml/redist/BUILD.bazel
@@ -7,15 +7,15 @@ licenses(["notice"]) # MIT license for headers
 
 cc_library(
     name = "headers",
-    hdrs = glob(["Microsoft.AI.DirectML.Preview/include/*.h"]),
-    includes = ["Microsoft.AI.DirectML.Preview/include"],
+    hdrs = glob(["directml/include/*.h"]),
+    includes = ["directml/include"],
 )
 
 filegroup(
     name = "pip_files",
     srcs = glob([
-        "Microsoft.AI.DirectML.Preview/bin/**", 
-        "Microsoft.AI.DirectML.Preview/include/DirectMLConfig.h", 
+        "directml/bin/**", 
+        "directml/include/DirectMLConfig.h", 
         "DirectML/*.txt"]),
     visibility = ["//visibility:public"],
 )

--- a/third_party/dml/redist/workspace.bzl
+++ b/third_party/dml/redist/workspace.bzl
@@ -1,55 +1,16 @@
 """Loads the DirectML redistributable library"""
 
 def _directml_nuget_repository_impl(repository_ctx):
-  # Download NuGet CLI executable. WSL builds can use interop to invoke this executable
-  # directly, so it "just works" on both Windows and Linux.
-  nuget_path = repository_ctx.path("nuget.exe")
+  # Download and extract .nupkg in separate steps because bazel does not
+  # recognize .nupkg as an archive format.
+  archive_path = repository_ctx.path("directml/directml.zip")
   repository_ctx.download(
-    url = "https://dist.nuget.org/win-x86-commandline/v5.7.0/nuget.exe", 
-    sha256 = "ae3bb02517b52a744833a4777e99d647cd80b29a62fd360e9aabaa34f09af59c",
-    output = nuget_path,
+    url = repository_ctx.attr.url, 
+    sha256 = repository_ctx.attr.sha256,
+    output = archive_path,
     executable = True,
   )
-
-  # On Linux, NuGet has trouble installing to a WSL path; instead, install to
-  # a Windows path and copy it.
-  output_directory = repository_ctx.path("")
-  if repository_ctx.os.name == "linux":
-    # Get path to %LOCALAPPDATA%\tfdml_redist in Windows
-    cmd = ["powershell.exe", "echo $env:LOCALAPPDATA"]
-    result = repository_ctx.execute(cmd)
-    if result.return_code != 0:
-      fail("Checking LOCALAPPDATA path failed: %s (%s)" % (result.stderr, " ".join(cmd)))
-    install_directory = "{}\\tfdml_redist".format(result.stdout.strip())
-    
-    # Convert path to Linux path
-    cmd = ["wslpath", "{}".format(install_directory)]
-    result = repository_ctx.execute(cmd)
-    if result.return_code != 0:
-      fail("Converting install_directory path failed: %s (%s)" % (result.stderr, " ".join(cmd)))
-    install_directory_wsl = result.stdout.strip()
-  else:
-    install_directory = output_directory
-
-  # Install the DirectML NuGet package.
-  cmd = [
-    nuget_path,
-    "install",
-    "-Source", repository_ctx.attr.source,
-    "-Version", repository_ctx.attr.version,
-    "-OutputDirectory", install_directory,
-    "-ExcludeVersion",
-    repository_ctx.attr.package,
-  ]
-  result = repository_ctx.execute(cmd)
-  if result.return_code != 0:
-    fail("Downloading DirectML failed: %s (%s)" % (result.stderr, " ".join(cmd)))
-
-  if repository_ctx.os.name == "linux":
-    cmd = ["cp", "-R", "{}/{}".format(install_directory_wsl, repository_ctx.attr.package), output_directory]
-    result = repository_ctx.execute(cmd)
-    if result.return_code != 0:
-      fail("Copying DirectML redist files failed: %s (%s)" % (result.stderr, " ".join(cmd)))
+  repository_ctx.extract(archive = archive_path, output = "directml/")
 
   # Overlay bazel BUILD file on top of the extracted DirectML NuGet.
   build_file_path = repository_ctx.path(repository_ctx.attr.build_file)
@@ -58,9 +19,8 @@ def _directml_nuget_repository_impl(repository_ctx):
 dml_repository = repository_rule(
     implementation = _directml_nuget_repository_impl,
     attrs = {
-      "source" : attr.string(mandatory=True),
-      "version" : attr.string(mandatory=True),
-      "package" : attr.string(mandatory=True),
+      "url" : attr.string(mandatory=True),
+      "sha256" : attr.string(mandatory=True),
       "build_file" : attr.label(),
     }
 )


### PR DESCRIPTION
This change removes the load-time dependencies on D3D12, DXGI (Windows), and DXCore (WSL); they are now loaded at runtime like all other dependencies including DirectML. The primary motivation for this change is to make it easy to build the Linux wheels without having access to libd3d12.so and libdxcore.so on the build machine.