### PR TITLE
Utilize DirectML APIs for BatchNorm and BatchNormGrad in training mode and enable fusion

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1033,7 +1033,7 @@ bool FindFusedBatchNormEx(const RemapperContext& ctx, int node_index,
     // In training mode we rely on cuDNN for computing FusedBatchNorm with side
     // inputs and activation, and it has its own limitations. In inference mode
     // we have a custom CUDA kernel that doesn't not have these constraints.
-    if (is_training) {
+    if (is_training && !NodeIsOnDml(node_def)) {
       // cuDNN only supports NHWC data layout.
       string data_format;
       if (!GetNodeAttr(*fused_batch_norm_node_def, kDataFormat, &data_format)

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -975,11 +975,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "directml",
         urls = [
-            "https://mirror.bazel.build/github.com/microsoft/DirectML/archive/3cc9a99d8846311d98a1add7adf79b8b0238ac09.tar.gz",
-            "https://github.com/microsoft/DirectML/archive/3cc9a99d8846311d98a1add7adf79b8b0238ac09.tar.gz",
+            "https://mirror.bazel.build/github.com/microsoft/DirectML/archive/36a8fcbac70fecb9f451a4e617d48ad3780de6cb.tar.gz",
+            "https://github.com/microsoft/DirectML/archive/36a8fcbac70fecb9f451a4e617d48ad3780de6cb.tar.gz",
         ],
-        sha256 = "f865f49c99c5b147231220469716c63f44980ddc13e8a22826973efa1b4b2898",
-        strip_prefix = "DirectML-3cc9a99d8846311d98a1add7adf79b8b0238ac09",
+        sha256 = "a14ba4a2cdd8ea9ebff4043e6141601261262e1d722eb3ea15e15e8bcb59ef24",
+        strip_prefix = "DirectML-36a8fcbac70fecb9f451a4e617d48ad3780de6cb",
         build_file = clean_dep("//third_party:directml.BUILD"),
     )
 


### PR DESCRIPTION
This makes the DirectML backend utilize DirectML APIs for BatchNorm and BatchNormGrad in training mode.  It also enables fusions for BatchNorm operators in this mode.