### PR TITLE
Set BFC allocator garbage collection to default false

### DIFF
--- a/tensorflow/core/common_runtime/bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/bfc_allocator.cc
@@ -163,7 +163,8 @@ bool BFCAllocator::Extend(size_t alignment, size_t rounded_bytes) {
 
   VLOG(1) << "Allocated memory at " << mem_addr << " to "
           << static_cast<void*>(static_cast<char*>(mem_addr) + bytes);
-  region_manager_.AddAllocationRegion(mem_addr, bytes, min_alloc_size_exponent_);
+  region_manager_.AddAllocationRegion(mem_addr, bytes,
+                                      min_alloc_size_exponent_);
 
   // Create one large chunk for the whole memory space that will
   // be chunked later.

--- a/tensorflow/core/common_runtime/dml/dml_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/dml/dml_bfc_allocator.cc
@@ -35,7 +35,7 @@ DmlAllocator::DmlAllocator(D3D12HeapAllocator* heap_allocator,
                            const GPUOptions& gpu_options, const string& name)
     : GPUBFCAllocator(new SubAllocatorWrapper(heap_allocator),
                       memory_limit_in_bytes, gpu_options, name,
-                      GetMaxAllocationSize()),
+                      GetMaxAllocationSize(), false),
       heap_allocator_(heap_allocator) {}
 
 D3D12BufferRegion DmlAllocator::CreateBufferRegion(const void* ptr,

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
@@ -57,8 +57,13 @@ bool GPUBFCAllocator::GetGarbageCollectionValue() {
   const char* enable_gpu_garbage_collection =
       std::getenv("TF_ENABLE_GPU_GARBAGE_COLLECTION");
   if (enable_gpu_garbage_collection == nullptr) {
-    // By default, turn on the memory garbage collection.
-    return true;
+    // By default, turn off the memory garbage collection.
+    //
+    // The mainline TF branch sets this to true. This modification
+    // for the DirectML fork is so the garbage collector doesn't
+    // attempt to free chunks in the middle of GPU processing, which
+    // would result in a DXGI device removed error and process death.
+    return false;
   }
   if (strcmp("false", enable_gpu_garbage_collection) == 0) {
     return false;

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
@@ -90,7 +90,8 @@ GPUBFCAllocator::GPUBFCAllocator(SubAllocator* sub_allocator,
                                  bool default_garbage_collection_value)
     : BFCAllocator(sub_allocator, total_memory,
                    GPUBFCAllocator::GetAllowGrowthValue(gpu_options), name,
-                   GPUBFCAllocator::GetGarbageCollectionValue(default_garbage_collection_value), 8,
-                   max_allocation_size) {}
+                   GPUBFCAllocator::GetGarbageCollectionValue(
+                       default_garbage_collection_value),
+                   8, max_allocation_size) {}
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
@@ -59,10 +59,10 @@ bool GPUBFCAllocator::GetGarbageCollectionValue() {
   if (enable_gpu_garbage_collection == nullptr) {
     // By default, turn off the memory garbage collection.
     //
-    // The mainline TF branch sets this to true. This modification
-    // for the DirectML fork is so the garbage collector doesn't
-    // attempt to free chunks in the middle of GPU processing, which
-    // would result in a DXGI device removed error and process death.
+    // The mainline TF branch sets this to true. This modification for the
+    // DirectML fork is false so the garbage collector doesn't attempt to
+    // free allocations in the middle of GPU processing, which would result
+    // in a DXGI device removed error and process death.
     return false;
   }
   if (strcmp("false", enable_gpu_garbage_collection) == 0) {

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.h
@@ -44,7 +44,8 @@ class GPUBFCAllocator : public BFCAllocator {
 
  private:
   static bool GetAllowGrowthValue(const GPUOptions& gpu_options);
-  static bool GetGarbageCollectionValue(bool default_garbage_collection_value = true);
+  static bool GetGarbageCollectionValue(
+      bool default_garbage_collection_value = true);
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.h
@@ -36,14 +36,15 @@ class GPUBFCAllocator : public BFCAllocator {
                   const string& name, size_t max_allocation_size = -1);
   GPUBFCAllocator(SubAllocator* sub_allocator, size_t total_memory,
                   const GPUOptions& gpu_options, const string& name,
-                  size_t max_allocation_size = -1);
+                  size_t max_allocation_size = -1,
+                  bool default_garbage_collection_value = true);
   ~GPUBFCAllocator() override {}
 
   TF_DISALLOW_COPY_AND_ASSIGN(GPUBFCAllocator);
 
  private:
   static bool GetAllowGrowthValue(const GPUOptions& gpu_options);
-  static bool GetGarbageCollectionValue();
+  static bool GetGarbageCollectionValue(bool default_garbage_collection_value = true);
 };
 
 }  // namespace tensorflow


### PR DESCRIPTION
Avoid garbage collection in the BFC allocator upon running out of memory since chunks/allocations can still be in use on the GPU, which causes a DGXI device removed error and process death.