### PR TITLE
Pin numpy when building

### DIFF
--- a/third_party/dml/ci/pipeline/setup_agent_linux.yml
+++ b/third_party/dml/ci/pipeline/setup_agent_linux.yml
@@ -22,7 +22,7 @@ steps:
 
 - script: |
     $(miniconda.activateCommand)
-    pip install six numpy wheel
+    pip install six numpy==1.18.5 wheel
     pip install keras_applications==1.0.6 --no-deps
     pip install keras_preprocessing==1.0.5 --no-deps
   displayName: Install Python Packages

--- a/third_party/dml/ci/pipeline/setup_agent_windows.yml
+++ b/third_party/dml/ci/pipeline/setup_agent_windows.yml
@@ -38,7 +38,7 @@ steps:
 
 - powershell: |
     Invoke-Expression '$(miniconda.activateCommand)'
-    pip install six numpy wheel
+    pip install six numpy==1.18.5 wheel
     pip install keras_applications==1.0.6 --no-deps
     pip install keras_preprocessing==1.0.5 --no-deps
   displayName: Install Python Packages


### PR DESCRIPTION
Fixes issue where python 3.7 builds were using a version of numpy (1.21) that isn't compatible with the version requirement specified by the python wheel (<1.19). We should have left this pinned at 1.18.5 for build purposes, consistent with upstream 1.15.