### PR TITLE
Remove remaning _assertRecent calls in writer_test.py

### DIFF
--- a/tensorflow/python/summary/writer/writer_test.py
+++ b/tensorflow/python/summary/writer/writer_test.py
@@ -68,9 +68,6 @@ class FileWriterTestCase(test.TestCase):
     self.assertTrue(event_paths)
     return summary_iterator.summary_iterator(event_paths[-1])
 
-  def _assertRecent(self, t):
-    self.assertTrue(abs(t - time.time()) < 5)
-
   def _assertEventsWithGraph(self, test_dir, g, has_shapes):
     meta_graph_def = meta_graph.create_meta_graph_def(
         graph_def=g.as_graph_def(add_shapes=has_shapes))
@@ -79,12 +76,10 @@ class FileWriterTestCase(test.TestCase):
 
     # The first event should list the file_version.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals("brain.Event:2", ev.file_version)
 
     # The next event should have the graph.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(0, ev.step)
     ev_graph = graph_pb2.GraphDef()
     ev_graph.ParseFromString(ev.graph_def)
@@ -92,7 +87,6 @@ class FileWriterTestCase(test.TestCase):
 
     # The next event should have the metagraph.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(0, ev.step)
     ev_meta_graph = meta_graph_pb2.MetaGraphDef()
     ev_meta_graph.ParseFromString(ev.meta_graph_def)
@@ -130,18 +124,15 @@ class FileWriterTestCase(test.TestCase):
 
     # The first event should list the file_version.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals("brain.Event:2", ev.file_version)
 
     # The next event should be the START message.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(1, ev.step)
     self.assertEquals(SessionLog.START, ev.session_log.status)
 
     # The next event should have the value 'mee=10.0'.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(10, ev.step)
     self.assertProtoEquals("""
       value { tag: 'mee' simple_value: 10.0 }
@@ -149,7 +140,6 @@ class FileWriterTestCase(test.TestCase):
 
     # The next event should have the value 'boo=20.0'.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(20, ev.step)
     self.assertProtoEquals("""
       value { tag: 'boo' simple_value: 20.0 }
@@ -157,7 +147,6 @@ class FileWriterTestCase(test.TestCase):
 
     # The next event should have the graph_def.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(30, ev.step)
     ev_graph = graph_pb2.GraphDef()
     ev_graph.ParseFromString(ev.graph_def)
@@ -165,7 +154,6 @@ class FileWriterTestCase(test.TestCase):
 
     # The next event should have metadata for the run.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(40, ev.step)
     self.assertEquals("test run", ev.tagged_run_metadata.tag)
     parsed_run_metadata = config_pb2.RunMetadata()
@@ -276,9 +264,7 @@ class FileWriterTestCase(test.TestCase):
     sw = self._FileWriter(test_dir)
     # Sleep 1.2 seconds to make sure event queue is empty.
     time.sleep(1.2)
-    time_before_close = time.time()
     sw.close()
-    self._assertRecent(time_before_close)
 
   @test_util.run_deprecated_v1
   def testUseAfterClose(self):
@@ -330,13 +316,11 @@ class FileWriterTestCase(test.TestCase):
     # File_version.
     ev = next(rr)
     self.assertTrue(ev)
-    self._assertRecent(ev.wall_time)
     self.assertEquals("brain.Event:2", ev.file_version)
 
     # Summary passed serialized.
     ev = next(rr)
     self.assertTrue(ev)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(1, ev.step)
     self.assertProtoEquals("""
       value { tag: 'i' simple_value: 1.0 }
@@ -345,7 +329,6 @@ class FileWriterTestCase(test.TestCase):
     # Summary passed as SummaryObject.
     ev = next(rr)
     self.assertTrue(ev)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(2, ev.step)
     self.assertProtoEquals("""
       value { tag: 'l' simple_value: 2.0 }
@@ -377,12 +360,10 @@ class FileWriterTestCase(test.TestCase):
 
     # The first event should list the file_version.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals("brain.Event:2", ev.file_version)
 
     # The next event should be the START message.
     ev = next(rr)
-    self._assertRecent(ev.wall_time)
     self.assertEquals(1, ev.step)
     self.assertEquals(SessionLog.START, ev.session_log.status)
 


### PR DESCRIPTION
Checking for the wall time in a multi threaded test environment running on a wide variety of hardware cannot work reliably.