### PR TITLE
Prevent unbounded growth of command allocator memory

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_command_list.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_list.cc
@@ -23,12 +23,13 @@ limitations under the License.
 namespace tensorflow {
 
 DmlCommandList::DmlCommandList(ID3D12Device* d3d_device, IDMLDevice* dml_device,
-                               D3D12_COMMAND_LIST_TYPE command_list_type)
+                               std::shared_ptr<DmlCommandQueue> queue)
     : d3d_device_(d3d_device),
       dml_device_(dml_device),
-      command_list_type_(command_list_type),
+      queue_(std::move(queue)),
       descriptor_pool_(d3d_device, 2048),
-      command_allocator_ring_(d3d_device, command_list_type) {
+      command_allocator_ring_(d3d_device, queue_->GetType(),
+                              queue_->GetCurrentCompletionEvent()) {
   DML_CHECK_SUCCEEDED(
       dml_device->CreateCommandRecorder(IID_PPV_ARGS(&recorder_)));
 }
@@ -199,25 +200,20 @@ void DmlCommandList::SetDescriptorHeap(ID3D12DescriptorHeap* descriptor_heap) {
   }
 }
 
-void DmlCommandList::Open(DmlGpuEvent completion_event) {
+void DmlCommandList::Open() {
   assert(current_descriptor_heap_ == nullptr);
-  current_completion_event_ = completion_event;
 
-  ID3D12CommandAllocator* allocator =
-      command_allocator_ring_.GetCurrentAllocator();
+  ID3D12CommandAllocator* allocator = command_allocator_ring_.GetNextAllocator(
+      queue_->GetNextCompletionEvent());
 
   if (!d3d_command_list_) {
     // Lazily create underlying D3D command list.
     DML_CHECK_SUCCEEDED(d3d_device_->CreateCommandList(
-        0, command_list_type_, allocator, nullptr,
+        0, queue_->GetType(), , allocator, nullptr,
         IID_PPV_ARGS(&d3d_command_list_)));
   } else {
     DML_CHECK_SUCCEEDED(d3d_command_list_->Reset(allocator, nullptr));
   }
-
-  // The current command allocator will become eligible for reset once this
-  // command list completes execution
-  command_allocator_ring_.AdvanceAllocator(completion_event);
 }
 
 Status DmlCommandList::Close() {

--- a/tensorflow/core/common_runtime/dml/dml_command_list.cc
+++ b/tensorflow/core/common_runtime/dml/dml_command_list.cc
@@ -208,9 +208,9 @@ void DmlCommandList::Open() {
 
   if (!d3d_command_list_) {
     // Lazily create underlying D3D command list.
-    DML_CHECK_SUCCEEDED(d3d_device_->CreateCommandList(
-        0, queue_->GetType(), , allocator, nullptr,
-        IID_PPV_ARGS(&d3d_command_list_)));
+    DML_CHECK_SUCCEEDED(
+        d3d_device_->CreateCommandList(0, queue_->GetType(), allocator, nullptr,
+                                       IID_PPV_ARGS(&d3d_command_list_)));
   } else {
     DML_CHECK_SUCCEEDED(d3d_command_list_->Reset(allocator, nullptr));
   }

--- a/tensorflow/core/common_runtime/dml/dml_command_list.h
+++ b/tensorflow/core/common_runtime/dml/dml_command_list.h
@@ -30,7 +30,7 @@ class DmlCommandList {
  public:
   // Constructs a command list.
   DmlCommandList(ID3D12Device* d3d12_device, IDMLDevice* dml_device,
-                 D3D12_COMMAND_LIST_TYPE command_list_type);
+                 std::shared_ptr<DmlCommandQueue> queue);
 
   // Records a CopyBufferRegion (see
   // ID3D12GraphicsCommandList::CopyBufferRegion) for execution. Transition
@@ -66,10 +66,8 @@ class DmlCommandList {
   void UavBarrier();
 
   // Opens the command list for recording, which is required before any of the
-  // above methods can be called. The supplied completion event indicates the
-  // fence value that will be signaled when the commands recorded to this
-  // command list have finished executing on the hardware.
-  void Open(DmlGpuEvent completion_event);
+  // above methods can be called.
+  void Open();
 
   // Closes the command list for recording, which is required before the command
   // list can be executed on a command queue. If any errors occur while
@@ -84,8 +82,7 @@ class DmlCommandList {
   Microsoft::WRL::ComPtr<IDMLDevice> dml_device_;
   Microsoft::WRL::ComPtr<IDMLCommandRecorder> recorder_;
   Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> d3d_command_list_;
-
-  D3D12_COMMAND_LIST_TYPE command_list_type_;
+  std::shared_ptr<DmlCommandQueue> queue_;
 
   // Descriptors are allocated from a pool. The current heap pointer is only
   // used to avoid redundantly setting the same heap; it does not have ownership


### PR DESCRIPTION
This is a port of the fix made in the plugin repo: https://github.com/microsoft/tensorflow-directml-plugin/pull/223