### PR TITLE
Optimize output allocation for inputs that can be forwarded

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.cc
@@ -105,7 +105,8 @@ DmlKernelContext::DmlKernelContext(
     const DmlDevice* device, OpKernelContext* op_ctx,
     const InitializationHelper* init_helper,
     absl::Span<const TensorShape> output_shapes,
-    absl::Span<const absl::optional<uint32_t>> output_refs_forwarding)
+    absl::Span<const absl::optional<uint32_t>> output_refs_forwarding,
+    bool supports_in_place_execution)
     : device_(device), op_ctx_(op_ctx), init_helper_(init_helper) {
   assert(output_shapes.size() == op_ctx_->num_outputs());
 
@@ -120,6 +121,15 @@ DmlKernelContext::DmlKernelContext(
       CHECK(output_refs_forwarding[i].has_value());
       op_ctx->forward_ref_input_to_ref_output(*output_refs_forwarding[i], i);
       output_tensor = op_ctx_->mutable_output(i);
+    } else if (supports_in_place_execution) {
+      absl::InlinedVector<int, 4> candidate_input_indices(
+          op_ctx_->num_inputs());
+      std::iota(candidate_input_indices.begin(), candidate_input_indices.end(),
+                0);
+
+      OP_REQUIRES_OK(op_ctx_, op_ctx_->forward_input_or_allocate_output(
+                                  candidate_input_indices, i, output_shapes[i],
+                                  &output_tensor));
     } else {
       OP_REQUIRES_OK(op_ctx_, op_ctx_->allocate_output(i, output_shapes[i],
                                                        &output_tensor));

--- a/tensorflow/core/common_runtime/dml/dml_kernel_context.h
+++ b/tensorflow/core/common_runtime/dml/dml_kernel_context.h
@@ -102,7 +102,8 @@ class DmlKernelContext {
       const DmlDevice* device, OpKernelContext* op_ctx,
       const InitializationHelper* init_helper,
       absl::Span<const TensorShape> output_shapes,
-      absl::Span<const absl::optional<uint32_t>> output_refs_forwarding = {});
+      absl::Span<const absl::optional<uint32_t>> output_refs_forwarding,
+      bool supports_in_place_execution);
 
   IDMLDevice* GetDmlDevice() const;
   ID3D12Device* GetD3D12Device() const;

--- a/tensorflow/core/kernels/dml_bias_add_op.cc
+++ b/tensorflow/core/kernels/dml_bias_add_op.cc
@@ -113,6 +113,7 @@ class DmlBiasAddKernel : public DmlKernel {
     }
 
     DmlKernelTensors tensors;
+    tensors.supports_in_place_execution = true;
     tensors.inputs.resize(2);
     tensors.outputs.resize(1);
 

--- a/tensorflow/core/kernels/dml_broadcast_to_op.cc
+++ b/tensorflow/core/kernels/dml_broadcast_to_op.cc
@@ -86,6 +86,7 @@ class DmlBroadcastToKernel : public DmlKernel {
     CHECK(ctx->GetOutputCount() == 1);
 
     DmlKernelTensors tensors;
+    tensors.supports_in_place_execution = true;
 
     const TensorShape input_shape = init_helper->GetCollapsedInputShape();
     const TensorShape output_shape = init_helper->GetCollapsedOutputShape();

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -309,10 +309,12 @@ class DmlCompositeUnaryKernel : public DmlKernel {
       DmlCompositeUnaryKernel<Dml##opName##Functor,                        \
                               supports_in_place_execution>;
 
-#define REGISTER_DML_COMPOSITE_UNARY_BOOL_KERNEL(opName, expression) \
-  namespace CONCAT_NAMESPACE_NAME(opName, __COUNTER__) {             \
-    REGISTER_DML_COMPOSITE_UNARY_STRUCT(opName, expression)          \
-    REGISTER_BOOL_OP_KERNEL(opName);                                 \
+#define REGISTER_DML_COMPOSITE_UNARY_BOOL_KERNEL(opName, expression,          \
+                                                 supports_in_place_execution) \
+  namespace CONCAT_NAMESPACE_NAME(opName, __COUNTER__) {                      \
+    REGISTER_DML_COMPOSITE_UNARY_STRUCT(opName, expression,                   \
+                                        supports_in_place_execution)          \
+    REGISTER_BOOL_OP_KERNEL(opName);                                          \
   }
 
 #define REGISTER_DML_COMPOSITE_BINARY_STRUCT(                          \
@@ -590,7 +592,10 @@ REGISTER_DML_COMPOSITE_UNARY_KERNEL_1(Sinh, dml::Sinh(x), true, float)
 REGISTER_DML_COMPOSITE_UNARY_KERNEL_1(Rint, dml::Round(x), true, float)
 // TFDML #24881131
 REGISTER_DML_COMPOSITE_UNARY_KERNEL_1(
-    Inv, dml::Recip(dml::Cast(x, DML_TENSOR_DATA_TYPE_FLOAT32)), int64)
+    Inv,
+    dml::Cast(dml::Recip(dml::Cast(x, DML_TENSOR_DATA_TYPE_FLOAT32)),
+              DML_TENSOR_DATA_TYPE_FLOAT32),
+    int64)
 // TFDML #24881131
 REGISTER_DML_COMPOSITE_UNARY_KERNEL_1(
     Reciprocal,
@@ -636,8 +641,10 @@ REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(Erf, dml::Erf(x), true, Eigen::half,
                                       float)
 REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(IsNan, dml::IsNaN(x), false, Eigen::half,
                                       float)
-REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(Round, dml::Round(x), Eigen::half, float)
-REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(Round, dml::Identity(x), int32, int64)
+REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(Round, dml::Round(x), true, Eigen::half,
+                                      float)
+REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(Round, dml::Identity(x), true, int32,
+                                      int64)
 REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(Softplus, dml::ActivationSoftplus(x),
                                       true, Eigen::half, float)
 REGISTER_DML_COMPOSITE_UNARY_KERNEL_2(Erfc, 1.0f - dml::Erf(x), true,

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -506,9 +506,8 @@ REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(RealDiv, x / y, 8, true, Eigen::half,
 // cwise_op_floor_div.cc).
 REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(FloorDiv, dml::Floor(x / y), 8, true,
                                        Eigen::half, float)
-REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(FloorMod, dml::ModulusFloor(x, y), 8,
-                                       true, Eigen::half, float, int8, int16,
-                                       int64, uint8, uint16, uint32)
+REGISTER_DML_COMPOSITE_BINARY_KERNEL_3(FloorMod, dml::ModulusFloor(x, y), 8,
+                                       true, Eigen::half, float, int64)
 REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(SigmoidGrad, (y * x * (1 - x)), 8, false,
                                        Eigen::half, float)
 REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(TanhGrad, (y * (1 - x * x)), 8, false,

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -595,7 +595,7 @@ REGISTER_DML_COMPOSITE_UNARY_KERNEL_1(
     Inv,
     dml::Cast(dml::Recip(dml::Cast(x, DML_TENSOR_DATA_TYPE_FLOAT32)),
               DML_TENSOR_DATA_TYPE_FLOAT32),
-    int64)
+    true, int64)
 // TFDML #24881131
 REGISTER_DML_COMPOSITE_UNARY_KERNEL_1(
     Reciprocal,

--- a/tensorflow/core/kernels/dml_cwise_ops.cc
+++ b/tensorflow/core/kernels/dml_cwise_ops.cc
@@ -504,7 +504,7 @@ REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(RealDiv, x / y, 8, true, Eigen::half,
 // cwise_op_floor_div.cc).
 REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(FloorDiv, dml::Floor(x / y), 8, true,
                                        Eigen::half, float)
-REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(FloorMod, dml::ModulusFloor(x / y), 8,
+REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(FloorMod, dml::ModulusFloor(x, y), 8,
                                        true, Eigen::half, float, int8, int16,
                                        int64, uint8, uint16, uint32)
 REGISTER_DML_COMPOSITE_BINARY_KERNEL_2(SigmoidGrad, (y * x * (1 - x)), 8, false,

--- a/tensorflow/core/kernels/dml_fill_op.cc
+++ b/tensorflow/core/kernels/dml_fill_op.cc
@@ -69,6 +69,7 @@ class DmlFillKernel : public DmlKernel {
     CHECK(ctx->GetOutputCount() == 1);
 
     DmlKernelParams params;
+    params.supports_in_place_execution = true;
 
     // Broadcast inputs to match output shape
     params.input_shape = ctx->GetOutputTensorShape(0);

--- a/tensorflow/core/kernels/dml_kernel_wrapper.cc
+++ b/tensorflow/core/kernels/dml_kernel_wrapper.cc
@@ -108,25 +108,24 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
     for (int i = 0; i < ctx->num_outputs(); ++i) {
       absl::optional<int> inputIndexToForward =
           shared_helper->GetForwardableInputIndex(ctx, output_shapes, i);
-      
+
       bool cancelForward = true;
 
       // If the input is considered forwardable for the op
       if (inputIndexToForward) {
         int inputIndex = inputIndexToForward.value();
         const Tensor& input = ctx->input_is_ref(inputIndex)
-                            ? ctx->mutable_input(inputIndex, false)
-                            : ctx->input(inputIndex);
+                                  ? ctx->mutable_input(inputIndex, false)
+                                  : ctx->input(inputIndex);
 
         // Element counts must also match
-        if (input.NumElements() == output_shapes[i].num_elements())
-        {
+        if (input.NumElements() == output_shapes[i].num_elements()) {
           forwardIndices.emplace_back(
-            std::make_pair(inputIndexToForward.value(), i));
-            cancelForward = false;   
+              std::make_pair(inputIndexToForward.value(), i));
+          cancelForward = false;
         }
       }
-      
+
       // If not all outputs are forwardable, we will forward nothing and
       // proceed with the kernel normally.
       if (cancelForward) {
@@ -176,7 +175,8 @@ void DmlKernelWrapperBase::Compute(OpKernelContext* ctx) {
 
   // Execute the kernel
   DmlKernelContext dml_ctx(dml_device, ctx, init_helper, output_shapes,
-                           kernel->GetOutputRefsForwarding());
+                           kernel->GetOutputRefsForwarding(),
+                           kernel->SupportsInPlaceExecution());
 
   // Check for errors triggered during the kernel context's constructor (e.g.
   // OOM when allocating the output buffers)

--- a/tensorflow/core/kernels/dml_ops_common.cc
+++ b/tensorflow/core/kernels/dml_ops_common.cc
@@ -109,6 +109,7 @@ static uint32_t GetDmlOutputTensorCount(DmlKernelConstruction* ctx,
     DmlKernelConstruction* ctx, const DmlKernelParams& params) {
   DmlKernelTensors tensor_descs;
   tensor_descs.output_refs_forwarding = params.output_refs_forwarding;
+  tensor_descs.supports_in_place_execution = params.supports_in_place_execution;
 
   // The number of inputs/outputs the DML operator takes
   uint32_t dml_input_count = GetDmlInputTensorCount(ctx, params);
@@ -175,8 +176,8 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   ComPtr<IDMLOperator> op;
   DML_CHECK_SUCCEEDED(dml_device->CreateOperator(&op_desc, IID_PPV_ARGS(&op)));
 
-  // For now, we don't set any flags
-  DML_EXECUTION_FLAGS execution_flags = DML_EXECUTION_FLAG_NONE;
+  DML_EXECUTION_FLAGS execution_flags =
+      DML_EXECUTION_FLAG_ALLOW_HALF_PRECISION_COMPUTATION;
 
   // Compile the operator
   ComPtr<IDMLCompiledOperator> compiled_op;
@@ -209,6 +210,7 @@ void DmlKernel::Initialize(DmlKernelConstruction* ctx,
   input_descs_ = std::move(tensor_descs.inputs);
   output_descs_ = std::move(tensor_descs.outputs);
   output_refs_forwarding_ = std::move(tensor_descs.output_refs_forwarding);
+  supports_in_place_execution_ = tensor_descs.supports_in_place_execution;
   init_helper_ = ctx->GetInitializationHelper();
 
   DML_BINDING_PROPERTIES exec_binding_props =

--- a/tensorflow/core/kernels/dml_ops_common.h
+++ b/tensorflow/core/kernels/dml_ops_common.h
@@ -67,6 +67,8 @@ struct DmlKernelParams {
 
   // OutputIndex -> InputIndex ref forwarding mapping
   absl::InlinedVector<absl::optional<uint32_t>, 8> output_refs_forwarding;
+
+  bool supports_in_place_execution = false;
 };
 
 struct DmlTensorInfo {
@@ -81,6 +83,7 @@ struct DmlKernelTensors {
   absl::InlinedVector<absl::optional<DmlTensorInfo>, 8> inputs;
   absl::InlinedVector<absl::optional<DmlTensorInfo>, 4> outputs;
   absl::InlinedVector<absl::optional<uint32_t>, 8> output_refs_forwarding;
+  bool supports_in_place_execution = false;
 };
 
 // Abstract base class of all DirectML kernel implementations. Note that this
@@ -97,6 +100,8 @@ class DmlKernel {
   absl::Span<const absl::optional<uint32_t>> GetOutputRefsForwarding() const {
     return output_refs_forwarding_;
   }
+
+  bool SupportsInPlaceExecution() const { return supports_in_place_execution_; }
 
   const InitializationHelper* GetInitializationHelper() const {
     return init_helper_.get();
@@ -183,7 +188,7 @@ class DmlKernel {
 
   Microsoft::WRL::ComPtr<ID3D12Resource> persistent_resource_;
   absl::optional<DML_BUFFER_BINDING> persistent_resource_binding_;
-  
+
   std::shared_ptr<const InitializationHelper> init_helper_;
 
   // The order and count of these descs match the DML operator, which might be
@@ -209,6 +214,8 @@ class DmlKernel {
   // needs the second input to be forwarded to it, we would have the following
   // vector: {nullopt, 1}
   absl::InlinedVector<absl::optional<uint32_t>, 8> output_refs_forwarding_;
+
+  bool supports_in_place_execution_;
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/dml_relu_op.cc
+++ b/tensorflow/core/kernels/dml_relu_op.cc
@@ -78,6 +78,7 @@ class DmlReluKernel : public DmlKernel {
     tensor_info.desc = DmlTensorDesc{data_type, tensor_sizes};
 
     DmlKernelTensors tensors = {};
+    tensors.supports_in_place_execution = true;
     tensors.inputs = {tensor_info};
     tensors.outputs = {tensor_info};
 
@@ -132,6 +133,7 @@ class DmlLUGradKernel : public DmlKernel {
                                                output_shape, output_shape);
 
     DmlKernelTensors tensors = {};
+    tensors.supports_in_place_execution = true;
     tensors.inputs = {feature_tensor, input_gradient_tensor};
     tensors.outputs = {output_tensor};
 

--- a/tensorflow/core/kernels/dml_scan_ops.cc
+++ b/tensorflow/core/kernels/dml_scan_ops.cc
@@ -106,6 +106,7 @@ class DmlScanKernel : public DmlKernel {
                                         tensor_shape);
 
     DmlKernelTensors tensors;
+    tensors.supports_in_place_execution = true;
     tensors.inputs = {input};
     tensors.outputs = {output};
 


### PR DESCRIPTION
When in-place execution is possible (mostly for element-wise operators), forward one of the inputs if all following conditions exist:

1. The input isn't used for another operator that hasn't yet been executed
2. The input has the same datatype, shape and size as the output
3. For composite operators, the input isn't used more than once. This is important since we're writing to the input/output in a non-deterministic fashion, so elements can't be relied upon more than once