### PR TITLE
Add a small int64 workaround for elementwise ops that don't support it

### DIFF
--- a/tensorflow/core/common_runtime/dml/dml_common.h
+++ b/tensorflow/core/common_runtime/dml/dml_common.h
@@ -131,6 +131,9 @@ static constexpr uint32_t kNchwSpatialDimensionCount = 2;
 static constexpr uint32_t kNcdhwDimensionCount = 5;
 static constexpr uint32_t kNcdhwSpatialDimensionCount = 3;
 
+// 8 dimensions are supported for elementwise operators
+static constexpr uint32_t kBinaryCwiseOpMaxDimCount = 8;
+
 // The batch and channel dimensions of NCW, NCHW, NCDHW....
 static constexpr uint32_t kNonspatialDimensionCount = 2;
 


### PR DESCRIPTION
It turns out that DIVIDE, MODULUS_FLOOR, DIFFERENCE_SQUARE, MODULUS_TRUNCATE and POW don't yet support emulated int64 in DirectML, so we can't entirely get rid of int64 workarounds.